### PR TITLE
chore: point bootstrap-sha at a commit main actually has

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bootstrap-sha": "09ed3da9c2a000162b4f76468c1517e8005671a0",
+  "bootstrap-sha": "7ede4aed978699c090801cb183664726c2539123",
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
It named 09ed3da, which was a commit on an unpushed local main and is still only reachable through the review-fixes branch. Release Please walks the history back looking for that sha, and not finding it would have taken the whole repository into the first changelog — including a breaking feat, which would have made the first release 0.2.0 rather than the 0.1.1 the commits since actually call for.

7ede4ae is the tip main carried before the release setup landed, so the first changelog starts where it was meant to.