### PR TITLE
chore: set the release base with last-release-sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bootstrap-sha": "7ede4aed978699c090801cb183664726c2539123",
+  "last-release-sha": "7ede4aed978699c090801cb183664726c2539123",
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
bootstrap-sha stops being read once a release pull request has been opened, and one had been by the time the sha it named was corrected — so the open pull request still proposes 0.2.0 off the whole history. last-release-sha is the key meant for correcting a release already in flight, and it keeps being read.