### PR TITLE
docs: lay the readme header out as one block

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,11 @@
-<h1 align="center">
-  <img
-  src="assets/banner.png"
-  alt="Herdr Auto Title: smarter tab titles, zero effort"
-  width="800"
-  />
-</h1>
-
 <div align="center">
-  <a href="https://github.com/kryptamine/herdr-auto-title/actions/workflows/ci.yml">
-    <img
-    src="https://img.shields.io/github/actions/workflow/status/kryptamine/herdr-auto-title/ci.yml?branch=main&style=for-the-badge&logo=githubactions&logoColor=white&label=CI"
-    alt="CI Badge"
-    />
-  </a>
-  <a href="https://github.com/kryptamine/herdr-auto-title/releases">
-    <img
-    src="https://img.shields.io/github/v/release/kryptamine/herdr-auto-title?style=for-the-badge&logo=github&color=0797ff&labelColor=000000"
-    alt="Release Badge"
-    />
-  </a>
-  <a href="https://go.dev">
-    <img
-    src="https://img.shields.io/github/go-mod/go-version/kryptamine/herdr-auto-title?style=for-the-badge&logo=go&logoColor=white&labelColor=000000"
-    alt="Go Version Badge"
-    />
-  </a>
-  <a href="LICENSE">
-    <img
-    src="https://img.shields.io/badge/license-MIT-0797ff?style=for-the-badge&labelColor=000000"
-    alt="License Badge"
-    />
-  </a>
+  <img src="assets/banner.png" alt="Herdr Auto Title: smarter tab titles, zero effort" width="800">
+  <p>
+    <a href="https://github.com/kryptamine/herdr-auto-title/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/kryptamine/herdr-auto-title/ci.yml?branch=main&style=for-the-badge&logo=githubactions&logoColor=white&label=CI&labelColor=000000" alt="CI status"></a>
+    <a href="https://github.com/kryptamine/herdr-auto-title/releases"><img src="https://img.shields.io/github/v/release/kryptamine/herdr-auto-title?style=for-the-badge&logo=github&logoColor=white&color=0797ff&labelColor=000000" alt="Latest release"></a>
+    <a href="https://go.dev"><img src="https://img.shields.io/github/go-mod/go-version/kryptamine/herdr-auto-title?style=for-the-badge&logo=go&logoColor=white&color=0797ff&labelColor=000000" alt="Go version"></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-0797ff?style=for-the-badge&labelColor=000000" alt="MIT licence"></a>
+  </p>
 </div>
 
 A [Herdr](https://herdr.dev) plugin that reads your session twice a second and


### PR DESCRIPTION
Two rendering details drove this change, both verified against GitHub's own markdown renderer (`POST /markdown`) rather than guessed at.

**The banner no longer sits inside an `h1`.** GitHub draws a horizontal rule under every first-level heading, so the line fell between the banner and the badge row and cut the header in half. A readme cannot reach that CSS, so the heading is gone and the banner's `alt` carries the project name. The cost: the file no longer has an `h1`.

**No blank lines inside the centring `div`.** With one, markdown parsing resumes inside the block and every newline between the badges becomes a `<br>`, stacking them vertically. Rendering the file through the API showed four such breaks before the change and none after.

Also in this change:

- `labelColor` added to the CI badge, which was the only one with a grey left half.
- `color` added to the Go badge, so release, Go and licence share one accent. The CI badge keeps its status colour, which is the point of it.
- `alt` texts say what each badge reports (`CI status`, `Latest release`, `Go version`, `MIT licence`) instead of ending in "Badge".

All four badges were checked live: `CI: PASSING`, `RELEASE: V0.1.1`, `GO: V1.24`, `LICENSE: MIT`.