### PR TITLE
docs: space the readme banner off the badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
-  <img src="assets/banner.png" alt="Herdr Auto Title: smarter tab titles, zero effort" width="800">
+  <p>
+    <img src="assets/banner.png" alt="Herdr Auto Title: smarter tab titles, zero effort" width="800">
+  </p>
   <p>
     <a href="https://github.com/kryptamine/herdr-auto-title/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/kryptamine/herdr-auto-title/ci.yml?branch=main&style=for-the-badge&logo=githubactions&logoColor=white&label=CI&labelColor=000000" alt="CI status"></a>
     <a href="https://github.com/kryptamine/herdr-auto-title/releases"><img src="https://img.shields.io/github/v/release/kryptamine/herdr-auto-title?style=for-the-badge&logo=github&logoColor=white&color=0797ff&labelColor=000000" alt="Latest release"></a>


### PR DESCRIPTION
The banner and the badge row sat in the same centred block with nothing between them.

A blank line is the obvious fix and the one thing this markup cannot have: inside a `div`, a blank line resumes markdown parsing, and every newline between the badges then renders as a `<br>`, stacking them into a column. That is what #8 had just removed.

The banner now sits in its own `<p>`, so the gap comes from the paragraph margin instead. Checked through GitHub's markdown renderer: the badges still render on one line, zero `<br>` in the block.