### PR TITLE
docs: say how the plugin is registered with herdr

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ herdr plugin install kryptamine/herdr-auto-title
 That is the whole setup. Herdr clones the repository, builds the binary and
 starts it; `herdr plugin list` shows it, `herdr plugin disable` turns it off.
 
+Working on the plugin rather than using it? [Development](docs/development.md)
+covers linking a local checkout, which Herdr makes you unlink before `install`
+will run.
+
 ## What your tabs will be called
 
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,13 +22,13 @@ need the outer two.
 make test        # go test -race ./...
 make test-v      # the same, verbose
 make check       # fmt + vet + lint + test, run this before every commit
+```
 
 The same four run in CI on every push and pull request
 (`.github/workflows/ci.yml`), plus the Go version floor the manifest promises,
 which a laptop on the newest toolchain does not cover. Windows was tried once
 and dropped: the fixtures assume Unix paths, so `filepath.IsAbs` rejects every
 directory in them and every tab falls back to `Shell`.
-```
 
 The suite drives the whole loop through `herdr.StubClient`: the first poll, a
 tab appearing later, deduplication, rename failures, a poll that fails outright.
@@ -93,6 +93,31 @@ per active pane before anything live.
 The current list of verified facts lives in the README under *Notes on the Herdr
 socket API*, and the measurements behind the polling decision are in CLAUDE.md.
 When a probe teaches you something new, add it there.
+
+## Registering it with Herdr
+
+`make run` starts the binary from your working tree and registers nothing.
+Herdr itself knows two ways to hold a plugin, and it refuses to hold both at
+once for the same id (`herdr.auto-title`).
+
+While developing, link the checkout:
+
+```sh
+make build                                    # link runs no build command
+herdr plugin link /path/to/herdr-auto-title
+```
+
+To use the published plugin the way anyone else does:
+
+```sh
+herdr plugin unlink herdr.auto-title          # installing over a link is refused
+herdr plugin install kryptamine/herdr-auto-title
+```
+
+`unlink` only unregisters; your checkout is left alone. `install` takes GitHub
+shorthand and nothing else (`owner/repo`, or `owner/repo/subdir`), clones the
+repository, runs the build command from `herdr-plugin.toml` and registers what
+it built. `herdr plugin list` shows which of the two you are running.
 
 ## Working through a ticket
 


### PR DESCRIPTION
Adds a `## Registering it with Herdr` section to `docs/development.md`, covering the two ways Herdr can hold this plugin and the constraints on each.

Written from what Herdr 0.8.2 actually does, not from the shape of the instructions this was modelled on:

- `plugin unlink` takes a **plugin id** (`herdr.auto-title`), not `owner/repo`.
- Installing over a linked plugin is not merely discouraged, it is refused: *"Installing over a locally linked plugin is refused; unlink or uninstall the local plugin first."*
- `plugin link` runs no build command, so `make build` has to come first. A linked checkout that was never built does nothing at all.
- `plugin unlink` only unregisters and leaves the checkout alone, which is worth stating before someone assumes it deletes their work.

The README gets a one-line pointer rather than the commands themselves: `unlink` only concerns someone who linked a checkout first, which is not the person following the install instructions.

Also fixes an unclosed code fence in the same file. It began at the test commands and swallowed the paragraph that follows, rendering prose about CI and the dropped Windows support as shell.

Two stale claims in `docs/development.md` are left alone, to be decided separately: the "Things that will bite you" section still says manual rename protection has not landed, and the protocol-probe section still points at a README section that no longer exists.