### PR TITLE
test(app): stop the process-read test racing the poll it waits for

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -586,8 +586,11 @@ func TestAPaneThatCannotBeReadIsAskedAgain(t *testing.T) {
 
 	// The tab is already named from the snapshot alone; the second rename is
 	// the one that could only come from a process read that happened again.
-	client.SetProcessError(nil)
+	// The processes go in before the error is cleared: between the two calls a
+	// poll can read an empty pane successfully, and that answer is reused for
+	// processRefresh, which outlasts what this test is willing to wait.
 	client.SetProcesses("wE:p1", herdr.PaneProcessInfoProcess{Name: "nvim"})
+	client.SetProcessError(nil)
 
 	if got := h.awaitRenames(2)[1].Label; got != "dashboard › nvim" {
 		t.Errorf("rename = %q, want %q", got, "dashboard › nvim")


### PR DESCRIPTION
Fixes the CI failure on `main` ([run 32905040223](https://github.com/kryptamine/herdr-auto-title/actions/runs/32905040223)):

```
--- FAIL: TestAPaneThatCannotBeReadIsAskedAgain (2.02s)
    app_test.go:592: timed out waiting for 2 renames, saw [{wE:t1 dashboard}]
```

The test was racing the loop it was watching, and the plugin itself is not involved.

`SetProcessError(nil)` came before `SetProcesses(...)`, leaving a window in which a poll finds no error and no process either. That read **succeeds** and returns an empty list, so it is stored by `Changes.Ran` and reused for `processRefresh` — two seconds (`internal/state/changes.go:13`). Two seconds is also the longest `awaitRenames` waits (`app_test.go:83`), so the test came down to whether a poll landed in a window a few microseconds wide. On a loaded runner it does.

Confirmed rather than assumed: widening that window with a 30 ms sleep took a single run from 0.08 s to ~2.5 s, i.e. the test stopped re-reading and started waiting out the cache.

The processes now go in while reads are still failing, so nothing gets cached and the first successful read is the one carrying `nvim`.

Verified with 50 runs under `-race` (3.0 s total, no run waiting on the cache), and again with a deliberate 50 ms pause in the old window to prove it is closed. `make check` is green.

No production change: reusing a successful read for two seconds is the documented behaviour of the poll loop, and an empty process list is a normal answer for a pane with nothing in the foreground.