### PR TITLE
docs: say that installing does not start the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ https://github.com/user-attachments/assets/94d9f4f3-b986-4664-a9bc-d078ece4f05e
 herdr plugin install kryptamine/herdr-auto-title
 ```
 
-That is the whole setup. Herdr clones the repository, builds the binary and
-starts it; `herdr plugin list` shows it, `herdr plugin disable` turns it off.
+Herdr clones the repository, builds the binary and registers it, but it starts
+a plugin only when a session starts. **Restart Herdr once after installing**;
+until you do, nothing is renamed. `herdr plugin list` shows it, `herdr plugin
+disable` turns it off.
 
 Working on the plugin rather than using it? [Development](docs/development.md)
 covers linking a local checkout, which Herdr makes you unlink before `install`

--- a/README.md
+++ b/README.md
@@ -28,10 +28,18 @@ https://github.com/user-attachments/assets/94d9f4f3-b986-4664-a9bc-d078ece4f05e
 herdr plugin install kryptamine/herdr-auto-title
 ```
 
-Herdr clones the repository, builds the binary and registers it, but it starts
-a plugin only when a session starts. **Restart Herdr once after installing**;
-until you do, nothing is renamed. `herdr plugin list` shows it, `herdr plugin
-disable` turns it off.
+Herdr clones the repository, builds the binary and registers it, but a plugin
+is started by the Herdr server, and only when it restores a session. So the
+install is followed by one more step, once:
+
+```sh
+herdr server stop   # closes the session; `herdr` brings it back
+```
+
+Reopening your terminal is not enough — that starts a new client and leaves the
+server, and your plugin, exactly as they were. Until the server restarts,
+nothing is renamed. `herdr plugin list` shows the plugin, `herdr plugin disable`
+turns it off.
 
 Working on the plugin rather than using it? [Development](docs/development.md)
 covers linking a local checkout, which Herdr makes you unlink before `install`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://github.com/user-attachments/assets/94d9f4f3-b986-4664-a9bc-d078ece4f05e
 
 ## Quick start
 
-> [!IMPORTANT]
+> [!NOTE]
 > Requires Herdr 0.8.2+ and Go 1.24+ on macOS or Linux. Herdr compiles the
 > plugin from source on your machine when it installs it.
 
@@ -28,18 +28,20 @@ https://github.com/user-attachments/assets/94d9f4f3-b986-4664-a9bc-d078ece4f05e
 herdr plugin install kryptamine/herdr-auto-title
 ```
 
-Herdr clones the repository, builds the binary and registers it, but a plugin
-is started by the Herdr server, and only when it restores a session. So the
-install is followed by one more step, once:
+> [!IMPORTANT]
+> Installing does not start the plugin. Plugins are started by the Herdr
+> **server**, and only when it restores a session, so run this once:
+>
+> ```sh
+> herdr server stop   # closes the session; `herdr` brings it back
+> ```
+>
+> Reopening your terminal will not do: that attaches a new client and leaves
+> the server, and your plugin, exactly as they were.
 
-```sh
-herdr server stop   # closes the session; `herdr` brings it back
-```
-
-Reopening your terminal is not enough — that starts a new client and leaves the
-server, and your plugin, exactly as they were. Until the server restarts,
-nothing is renamed. `herdr plugin list` shows the plugin, `herdr plugin disable`
-turns it off.
+Herdr clones the repository, builds the binary and registers it. Until the
+server has restarted, nothing is renamed. `herdr plugin list` shows the plugin,
+`herdr plugin disable` turns it off.
 
 Working on the plugin rather than using it? [Development](docs/development.md)
 covers linking a local checkout, which Herdr makes you unlink before `install`

--- a/docs/development.md
+++ b/docs/development.md
@@ -119,10 +119,14 @@ shorthand and nothing else (`owner/repo`, or `owner/repo/subdir`), clones the
 repository, runs the build command from `herdr-plugin.toml` and registers what
 it built. `herdr plugin list` shows which of the two you are running.
 
-Neither one starts anything. Herdr runs `[[startup]]` when a session starts and
-has no hook for install or enable, so a freshly installed or linked plugin sits
-idle until Herdr restarts. That is why `make run` exists: it is the only way to
-see your working tree do something without restarting the session.
+Neither one starts anything. Herdr runs `[[startup]]` when the **server**
+restores a session, and has no hook for install or enable, so a freshly
+installed or linked plugin sits idle until `herdr server stop` and a fresh
+`herdr`. Opening a new terminal only attaches another client and starts
+nothing — `herdr status server` reports the uptime that gives it away.
+
+That is why `make run` exists: it is the only way to see your working tree do
+something without taking the session down.
 
 ## Working through a ticket
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -119,6 +119,11 @@ shorthand and nothing else (`owner/repo`, or `owner/repo/subdir`), clones the
 repository, runs the build command from `herdr-plugin.toml` and registers what
 it built. `herdr plugin list` shows which of the two you are running.
 
+Neither one starts anything. Herdr runs `[[startup]]` when a session starts and
+has no hook for install or enable, so a freshly installed or linked plugin sits
+idle until Herdr restarts. That is why `make run` exists: it is the only way to
+see your working tree do something without restarting the session.
+
 ## Working through a ticket
 
 Before changing how a title is decided, read


### PR DESCRIPTION
The quick start said Herdr "clones the repository, builds the binary and **starts it**". The last part is wrong, and it is the part a new user depends on.

Herdr runs `[[startup]]` "once for each enabled plugin after Herdr restores the session and its API socket is ready", and it has **no hook that runs at install or enable time**. So `herdr plugin install` leaves the plugin registered, enabled, and doing nothing until Herdr is restarted. Nothing in the output says so: the install preview and `herdr plugin list` both look exactly as they would if it were running.

Found by installing the plugin from the marketplace on this machine and watching new tabs keep their default labels.

The readme now says to restart Herdr once after installing, and `docs/development.md` gains the same caveat next to `link`/`install`, along with why `make run` exists at all.

Not done, deliberately: an `[[actions]]` entry that starts the plugin on demand. Herdr actions are short-lived commands whose exit code it waits for and logs, so an action that never returns would hang. Making it work needs the binary to detach, keep a pid file and refuse a second instance — otherwise the next session start adds a second process renaming the same tabs. That is a new class of bug traded for one avoided restart.