### PR TITLE
feat: name a tab after the branch it is on

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ will run.
 
 ```
 ~/work/dashboard                       →  dashboard
+~/work/dashboard on feature/MC-13200   →  dashboard › MC-13200
 nvim editing auth.provider.ts          →  nvim › auth.provider.ts
 an agent working on OAuth scopes       →  dashboard › claude › Implement OAuth scopes
 ssh into prod-01                       →  ssh › prod-01
@@ -60,12 +61,17 @@ $HOME                                  →  Shell
 Titles read `<context> › <activity>`, capped at 64 columns of the tab bar. The
 activity is the first of these that has something to say: what an agent reports
 it is working on, then the terminal title, then a lone program in the pane. The
-context is the directory you are in, or the machine you reached over `ssh`.
+context is the directory you are in, or the machine you reached over `ssh`, and
+the branch you have checked out qualifies it.
 
 Four rules explain most surprises:
 
 - Auto Title never repeats your workspace name, because Herdr already shows it
   above the tabs.
+- **A branch shows when it distinguishes.** Your repository's own default
+  branch says nothing, so it is left out; anything else is shown, shortened to
+  what identifies it (`bugfix-asa-cpanel-uapi-mc-13675` → `MC-13675`) when it is
+  too long for the tab bar.
 - It drops paths, shell prompts and bare program names, which only say again
   where you are.
 - A tab with several panes takes its name from one of them: the focused pane, a

--- a/cmd/herdr-auto-title/main.go
+++ b/cmd/herdr-auto-title/main.go
@@ -46,7 +46,7 @@ func run() error {
 		return err
 	}
 
-	titles := resolver.Default(cfg.MaxLength)
+	titles := resolver.Default(cfg.MaxLength, resolver.DefaultBranchMaxLength)
 
 	app.New(cfg, log, titles).Run(ctx, client)
 	return nil

--- a/cmd/herdr-auto-title/main.go
+++ b/cmd/herdr-auto-title/main.go
@@ -46,7 +46,7 @@ func run() error {
 		return err
 	}
 
-	titles := resolver.Default(cfg.MaxLength, resolver.DefaultBranchMaxLength)
+	titles := resolver.Default(cfg.MaxLength, cfg.BranchMax)
 
 	app.New(cfg, log, titles).Run(ctx, client)
 	return nil

--- a/docs/architecture/poll-loop.md
+++ b/docs/architecture/poll-loop.md
@@ -95,7 +95,10 @@ changes name at most once per poll however fast its pane is churning, so
 3. `tabsIn` — assemble tabs with their panes, asking `pane.process_info` about
    the panes that moved since they were last read and reusing the last answer
    for the rest. A pane whose processes cannot be read simply has none, and a
-   failed read is not remembered as an answer.
+   failed read is not remembered as an answer. Each pane's directory is read for
+   the branch it has checked out, every poll and without a cache: two small file
+   reads at 0.038 ms are cheaper than the bookkeeping that would keep a stale
+   answer — see [title resolution](./title-resolution.md#the-git-branch).
 4. `Manual.Retain` — drop bookkeeping for tabs the session no longer holds.
 5. Per tab: skip it if locked, otherwise resolve a title, check whether the
    label moved under us, and rename when the result differs from the label the

--- a/docs/architecture/title-resolution.md
+++ b/docs/architecture/title-resolution.md
@@ -21,9 +21,10 @@ separator can convey, and a second one would only ask the reader to learn a
 distinction they cannot see. So there is exactly one, `Separator`
 (`internal/resolver/sanitize.go`).
 
-Structurally a title is two fields, `Parts{Context, Activity}`
+Structurally a title is three fields, `Parts{Context, Branch, Activity}`
 (`internal/resolver/resolver.go`): *where* the user is and *what* they are
-doing.
+doing. The branch belongs to the first of those — it qualifies the directory
+rather than standing beside it as a separate kind of thing.
 
 ## One pane speaks for the tab
 
@@ -52,6 +53,7 @@ rather than by the order the sources happen to be listed in
 | 80 | Terminal title | `terminal.go` | Activity |
 | 70 | Foreground process | `process.go` | Activity |
 | 60 | SSH session | `ssh.go` | Context |
+| 40 | Git branch | `git.go` | Branch |
 | 30 | Working directory | `cwd.go` | Context |
 | 10 | Generic fallback | `resolver.go` | the whole name (`Shell`) |
 
@@ -130,33 +132,50 @@ opposite — with no host to bind to, the mark went into the activity slot — a
 that put it back in the contested half, where the remote shell's own title
 outranked it and a remote tab read exactly like a local one.
 
-### The git branch, and why it is gone
+### The git branch
 
-A source at confidence 40 read the branch checked out in the pane's directory
-and put it in the activity slot, so a tab read `dashboard › MC-13675`.
+The branch checked out in the pane's directory, read from the files under
+`.git` and never by running git: `git rev-parse` measured 12.37 ms against
+0.019 ms for reading `HEAD`, on a poll whose whole snapshot costs 0.47 ms. The
+reading is not cached — at 0.038 ms including the walk up to the repository, a
+fresh answer costs less than remembering a stale one, and a checkout shows up in
+the tab within one poll.
 
-It was removed. Sitting below the terminal title it only ever spoke for a plain
-shell in a repository, and in that spot the choice was between a tab called
-`dashboard` and one called `dashboard › <something from a branch name>`.
-Measured against a realistic corpus, that something was worth having only when
-the branch carried a tracker key:
+A branch says which slice of a project a tab is on, so it qualifies the
+**context**: `dashboard › feat/oauth › nvim › auth.ts`. Three rules keep it from
+saying anything it has not earned:
 
-```
-bugfix-asatretdinov-…-mc-13675  ->  MC-13675      identifies the work
-fix/filter-sentry-errors-…      ->  filter        a fragment, worse than nothing
-feature/add-dark-mode           ->  add-dark      a fragment
-hotfix-login-500                ->  LOGIN-500     reads as a ticket, is not one
-sprint-42-cleanup               ->  SPRINT-42     reads as a ticket, is not one
-develop                         ->  develop       says nothing, on every tab
-```
+- **The trunk contributes nothing.** Which branch that is comes from the
+  repository itself, `refs/remotes/origin/HEAD`, rather than from a list of
+  names: a team whose trunk is `develop` gets the same silence, and a branch
+  actually called `main` off a `develop` trunk still shows. A repository that
+  records no default shows its branch always.
+- **A name that fits is left whole.** `feat/oauth` keeps the namespace that
+  tells it from `fix/oauth`. Only a name too wide for `BranchMax` is reduced,
+  and then an issue key wins outright (`bugfix-asa-cpanel-uapi-mc-13675` →
+  `MC-13675`) because it identifies the work whatever convention wraps it;
+  failing that the namespace goes and the rest is cut at a whole word.
+- **A detached HEAD says so**, with the short hash — it is where commits get
+  lost, and silence there is indistinguishable from sitting on the trunk. A
+  rebase is the exception: it detaches HEAD but records the branch it set aside,
+  and that branch is still where the user is, so the tab keeps its name instead
+  of taking a new hash on every step.
 
-Every other source in the resolver declines when nothing useful survives. This
-one guessed instead, and the guesses were noise on tabs that would otherwise
-have been quietly correct. Keeping only the tracker-key rule was considered and
-turned down as well: it would have meant a source that fires for teams with one
-naming convention and never for anyone else.
+A worktree and a submodule are followed through the `gitdir:` file to their own
+HEAD, and to the shared refs their default branch lives in. Agents run in
+worktrees, and a worktree's directory is exactly the kind that names nothing.
 
-The whole thing lives in the git history if the trade ever looks different.
+**This source was here before, and was removed** (2d90d74). It sat at the same
+confidence but filled the *activity* slot, where the terminal title outranked it
+— so it spoke only for a plain shell in a repository, and there it guessed:
+`fix/filter-sentry-errors-…` became `filter`, and `develop` became a word every
+tab carried alike. Moving it into the context is what makes it visible beside an
+agent or an editor; reading the trunk from the repository is what retires the
+guess that produced the noise.
+
+It stays out of an ssh pane. The branch is read from the directory ssh was
+launched in, which says nothing about the machine on the other end, and a branch
+printed beside `prod-01` reads as that machine's.
 
 ### Working directory and the fallback
 
@@ -176,3 +195,6 @@ than `dashboard › nvim › auth.ts`.
 It is dropped only when something else remains — a tab reduced to nothing has
 lost more than it saved — and only on an exact match, so a tab whose directory
 has left its workspace behind is exactly the one that keeps saying where it is.
+A branch counts as something remaining, and the match is against the directory
+alone, so a tab in the workspace of the repository it is in reads `feat/oauth ›
+nvim`: the half that repeats goes, the half that distinguishes stays.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -205,7 +205,13 @@ func (a *App) processesIn(ctx context.Context, client herdr.Client, paneID strin
 // checkoutIn reports what the repository holding the pane has checked out.
 // Unlike a process read it is not cached, and why not is in
 // docs/architecture/title-resolution.md.
-func checkoutIn(pane herdr.PaneInfo) git.Checkout {
+func (a *App) checkoutIn(pane herdr.PaneInfo) git.Checkout {
+	// A branch width of zero is how branches are turned off, and a read whose
+	// answer is thrown away is still a read on every pane twice a second.
+	if a.cfg.BranchMax <= 0 {
+		return git.Checkout{}
+	}
+
 	// The shell's own directory, for the same reason the CWD source prefers it:
 	// it names the project more stably than whatever is running right now.
 	dir := pane.CWD
@@ -229,7 +235,7 @@ func (a *App) tabsIn(ctx context.Context, client herdr.Client, snapshot herdr.Sn
 	for _, pane := range snapshot.Panes {
 		byTab[pane.TabID] = append(byTab[pane.TabID],
 			state.PaneFrom(pane, a.processesIn(ctx, client, pane.PaneID),
-				checkoutIn(pane), a.changes.ChangedAt(pane.PaneID)))
+				a.checkoutIn(pane), a.changes.ChangedAt(pane.PaneID)))
 	}
 
 	// An unnamed tab carries its place in the workspace, and the snapshot lists

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -203,9 +203,8 @@ func (a *App) processesIn(ctx context.Context, client herdr.Client, paneID strin
 }
 
 // checkoutIn reports what the repository holding the pane has checked out.
-// Unlike a process read this is not cached: it is two small file reads at
-// 0.038 ms against a snapshot's 0.47 ms, so a fresh answer costs less than
-// remembering a stale one — see docs/architecture/title-resolution.md.
+// Unlike a process read it is not cached, and why not is in
+// docs/architecture/title-resolution.md.
 func checkoutIn(pane herdr.PaneInfo) git.Checkout {
 	// The shell's own directory, for the same reason the CWD source prefers it:
 	// it names the project more stably than whatever is running right now.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/kryptamine/herdr-auto-title/internal/git"
 	"github.com/kryptamine/herdr-auto-title/internal/herdr"
 	"github.com/kryptamine/herdr-auto-title/internal/resolver"
 	"github.com/kryptamine/herdr-auto-title/internal/state"
@@ -201,6 +202,21 @@ func (a *App) processesIn(ctx context.Context, client herdr.Client, paneID strin
 	return processes
 }
 
+// checkoutIn reports what the repository holding the pane has checked out.
+// Unlike a process read this is not cached: it is two small file reads at
+// 0.038 ms against a snapshot's 0.47 ms, so a fresh answer costs less than
+// remembering a stale one — see docs/architecture/title-resolution.md.
+func checkoutIn(pane herdr.PaneInfo) git.Checkout {
+	// The shell's own directory, for the same reason the CWD source prefers it:
+	// it names the project more stably than whatever is running right now.
+	dir := pane.CWD
+	if dir == "" {
+		dir = pane.ForegroundCWD
+	}
+	checkout, _ := git.Read(dir)
+	return checkout
+}
+
 // tabsIn assembles the snapshot's tabs with their panes. What is running in a
 // pane needs a request of its own, which processesIn makes only when the last
 // answer will no longer do.
@@ -214,7 +230,7 @@ func (a *App) tabsIn(ctx context.Context, client herdr.Client, snapshot herdr.Sn
 	for _, pane := range snapshot.Panes {
 		byTab[pane.TabID] = append(byTab[pane.TabID],
 			state.PaneFrom(pane, a.processesIn(ctx, client, pane.PaneID),
-				a.changes.ChangedAt(pane.PaneID)))
+				checkoutIn(pane), a.changes.ChangedAt(pane.PaneID)))
 	}
 
 	// An unnamed tab carries its place in the workspace, and the snapshot lists

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -212,13 +212,7 @@ func (a *App) checkoutIn(pane herdr.PaneInfo) git.Checkout {
 		return git.Checkout{}
 	}
 
-	// The shell's own directory, for the same reason the CWD source prefers it:
-	// it names the project more stably than whatever is running right now.
-	dir := pane.CWD
-	if dir == "" {
-		dir = pane.ForegroundCWD
-	}
-	checkout, _ := git.Read(dir)
+	checkout, _ := git.Read(pane.Dir())
 	return checkout
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func discardLogger() *slog.Logger {
 func testResolver(t *testing.T) resolver.TitleResolver {
 	t.Helper()
 	t.Setenv("HOME", filepath.Join(t.TempDir(), "home"))
-	return resolver.Default(resolver.DefaultMaxLength)
+	return resolver.Default(resolver.DefaultMaxLength, resolver.DefaultBranchMaxLength)
 }
 
 // harness runs an App against a stubbed Herdr session.
@@ -594,5 +595,61 @@ func TestAPaneThatCannotBeReadIsAskedAgain(t *testing.T) {
 
 	if got := h.awaitRenames(2)[1].Label; got != "dashboard › nvim" {
 		t.Errorf("rename = %q, want %q", got, "dashboard › nvim")
+	}
+}
+
+// repoAt builds a repository on disk, since the branch is the one thing a poll
+// reads from the filesystem rather than from the session.
+func repoAt(t *testing.T, branch, defaultBranch string) string {
+	t.Helper()
+	root := t.TempDir()
+	gitDir := filepath.Join(root, ".git")
+	remote := filepath.Join(gitDir, "refs", "remotes", "origin")
+	if err := os.MkdirAll(remote, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(path, content string) {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(gitDir, "HEAD"), "ref: refs/heads/"+branch+"\n")
+	write(filepath.Join(remote, "HEAD"), "ref: refs/remotes/origin/"+defaultBranch+"\n")
+	return root
+}
+
+func TestAPollNamesATabAfterItsBranch(t *testing.T) {
+	repo := repoAt(t, "feat/oauth", "main")
+
+	h := start(t,
+		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		[]herdr.PaneInfo{{PaneID: "wE:p1", TabID: "wE:t1", CWD: repo, Focused: true}},
+	)
+
+	renames := h.awaitRenames(1)
+	if want := filepath.Base(repo) + " › feat/oauth"; renames[0].Label != want {
+		t.Errorf("rename = %q, want %q", renames[0].Label, want)
+	}
+}
+
+func TestCheckingOutABranchRetitlesTheTab(t *testing.T) {
+	// Nothing in the session announces a checkout, and the pane's revision does
+	// not have to move for one — the next poll simply reads HEAD again.
+	repo := repoAt(t, "main", "main")
+
+	h := start(t,
+		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		[]herdr.PaneInfo{{PaneID: "wE:p1", TabID: "wE:t1", CWD: repo, Focused: true}},
+	)
+	h.awaitRenames(1)
+
+	head := filepath.Join(repo, ".git", "HEAD")
+	if err := os.WriteFile(head, []byte("ref: refs/heads/feat/oauth\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	renames := h.awaitRenames(2)
+	if want := filepath.Base(repo) + " › feat/oauth"; renames[1].Label != want {
+		t.Errorf("rename = %q, want %q", renames[1].Label, want)
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kryptamine/herdr-auto-title/internal/git"
 	"github.com/kryptamine/herdr-auto-title/internal/herdr"
 	"github.com/kryptamine/herdr-auto-title/internal/resolver"
 )
@@ -16,7 +17,11 @@ import (
 const testPoll = 10 * time.Millisecond
 
 func testConfig() Config {
-	return Config{Poll: testPoll, MaxLength: resolver.DefaultMaxLength}
+	return Config{
+		Poll:      testPoll,
+		MaxLength: resolver.DefaultMaxLength,
+		BranchMax: resolver.DefaultBranchMaxLength,
+	}
 }
 
 func discardLogger() *slog.Logger {
@@ -651,5 +656,19 @@ func TestCheckingOutABranchRetitlesTheTab(t *testing.T) {
 	renames := h.awaitRenames(2)
 	if want := filepath.Base(repo) + " › feat/oauth"; renames[1].Label != want {
 		t.Errorf("rename = %q, want %q", renames[1].Label, want)
+	}
+}
+
+func TestBranchesSwitchedOffAreNotRead(t *testing.T) {
+	// Zero is how a user turns branches off, and a read whose answer is
+	// discarded still costs a walk up the tree on every pane, every poll.
+	repo := repoAt(t, "feat/oauth", "main")
+
+	cfg := testConfig()
+	cfg.BranchMax = 0
+	app := New(cfg, discardLogger(), testResolver(t))
+
+	if checkout := app.checkoutIn(herdr.PaneInfo{PaneID: "wE:p1", CWD: repo}); checkout != (git.Checkout{}) {
+		t.Errorf("checkout = %+v, want nothing read", checkout)
 	}
 }

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -16,6 +16,7 @@ const (
 	EnvDebug     = "HERDR_AUTO_TITLE_DEBUG"
 	EnvPoll      = "HERDR_AUTO_TITLE_POLL_MS"
 	EnvMaxLength = "HERDR_AUTO_TITLE_MAX_LENGTH"
+	EnvBranchMax = "HERDR_AUTO_TITLE_BRANCH_MAX"
 	EnvManual    = "HERDR_AUTO_TITLE_MANUAL_FILE"
 )
 
@@ -28,9 +29,12 @@ const DefaultPoll = 500 * time.Millisecond
 type Config struct {
 	Debug bool
 	Poll  time.Duration
-	// MaxLength is measured in columns of the tab bar rather than in
-	// characters: a CJK character or an emoji takes two.
+	// MaxLength and BranchMax are measured in columns of the tab bar rather
+	// than in characters: a CJK character or an emoji takes two.
 	MaxLength int
+	// BranchMax bounds what a git branch may add to a title. Zero leaves
+	// branches out of titles entirely.
+	BranchMax int
 	// ManualPath is where tabs the user renamed by hand are remembered across
 	// restarts. Empty keeps them in memory only.
 	ManualPath string
@@ -43,6 +47,7 @@ func LoadConfig() (Config, []string) {
 	cfg := Config{
 		Poll:       DefaultPoll,
 		MaxLength:  resolver.DefaultMaxLength,
+		BranchMax:  resolver.DefaultBranchMaxLength,
 		ManualPath: state.DefaultManualPath(),
 	}
 	var warnings []string
@@ -50,6 +55,8 @@ func LoadConfig() (Config, []string) {
 	cfg.Debug = fromEnv(&warnings, EnvDebug, cfg.Debug, boolean)
 	cfg.Poll = fromEnv(&warnings, EnvPoll, cfg.Poll, milliseconds)
 	cfg.MaxLength = fromEnv(&warnings, EnvMaxLength, cfg.MaxLength, count)
+	// Zero is meaningful here, and only here: it leaves branches out of titles.
+	cfg.BranchMax = fromEnv(&warnings, EnvBranchMax, cfg.BranchMax, countOrNone)
 	// A path needs neither parsing nor checking, so it does not go through
 	// fromEnv: any string the user set is the path they meant.
 	if raw := os.Getenv(EnvManual); raw != "" {
@@ -85,6 +92,7 @@ var (
 	errNotBoolean  = errors.New("is not a boolean")
 	errNotNumber   = errors.New("is not a number")
 	errNotPositive = errors.New("must be positive")
+	errNegative    = errors.New("cannot be negative")
 )
 
 func boolean(raw string) (bool, error) {
@@ -104,6 +112,19 @@ func count(raw string) (int, error) {
 	}
 	if value <= 0 {
 		return 0, errNotPositive
+	}
+	return value, nil
+}
+
+// countOrNone reads a number that may be zero, for a setting where zero means
+// "none of this" rather than a value that would stop the plugin working.
+func countOrNone(raw string) (int, error) {
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, errNotNumber
+	}
+	if value < 0 {
+		return 0, errNegative
 	}
 	return value, nil
 }

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -12,7 +12,7 @@ import (
 // sets and the environment the tests run in cannot change the outcome.
 func isolate(t *testing.T) {
 	t.Helper()
-	for _, name := range []string{EnvDebug, EnvPoll, EnvMaxLength, EnvManual} {
+	for _, name := range []string{EnvDebug, EnvPoll, EnvMaxLength, EnvBranchMax, EnvManual} {
 		t.Setenv(name, "")
 	}
 }
@@ -33,6 +33,9 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if cfg.MaxLength != resolver.DefaultMaxLength {
 		t.Errorf("max length = %d, want %d", cfg.MaxLength, resolver.DefaultMaxLength)
 	}
+	if cfg.BranchMax != resolver.DefaultBranchMaxLength {
+		t.Errorf("branch max = %d, want %d", cfg.BranchMax, resolver.DefaultBranchMaxLength)
+	}
 }
 
 func TestLoadConfigFromEnvironment(t *testing.T) {
@@ -40,6 +43,7 @@ func TestLoadConfigFromEnvironment(t *testing.T) {
 	t.Setenv(EnvDebug, "true")
 	t.Setenv(EnvPoll, "250")
 	t.Setenv(EnvMaxLength, "32")
+	t.Setenv(EnvBranchMax, "20")
 
 	cfg, warnings := LoadConfig()
 	if len(warnings) != 0 {
@@ -54,7 +58,40 @@ func TestLoadConfigFromEnvironment(t *testing.T) {
 	if cfg.MaxLength != 32 {
 		t.Errorf("max length = %d, want 32", cfg.MaxLength)
 	}
-	// Raising the window must raise the cap with it.
+	if cfg.BranchMax != 20 {
+		t.Errorf("branch max = %d, want 20", cfg.BranchMax)
+	}
+}
+
+func TestABranchWidthOfZeroIsAValue(t *testing.T) {
+	// Zero is how branches are turned off, so it must pass where zero is
+	// rejected everywhere else — and without a warning.
+	isolate(t)
+	t.Setenv(EnvBranchMax, "0")
+
+	cfg, warnings := LoadConfig()
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want none", warnings)
+	}
+	if cfg.BranchMax != 0 {
+		t.Errorf("branch max = %d, want 0", cfg.BranchMax)
+	}
+}
+
+func TestANegativeBranchWidthIsRejected(t *testing.T) {
+	isolate(t)
+	t.Setenv(EnvBranchMax, "-1")
+
+	cfg, warnings := LoadConfig()
+	if cfg.BranchMax != resolver.DefaultBranchMaxLength {
+		t.Errorf("branch max = %d, want the default", cfg.BranchMax)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want one", warnings)
+	}
+	if !strings.Contains(warnings[0], "cannot be negative") {
+		t.Errorf("warning %q does not say what is wrong", warnings[0])
+	}
 }
 
 func TestLoadConfigKeepsDefaultsOnBadValues(t *testing.T) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,212 @@
+// Package git reads what a repository has checked out by reading the files
+// under .git directly. It never runs the git executable: reading HEAD costs
+// 0.038 ms where `git rev-parse` costs 12 ms, and a pane's directory is a
+// terminal-derived value that is better not handed to a subprocess at all.
+package git
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// shortCommitLength is how much of a detached HEAD's hash names it. Seven is
+// what git itself abbreviates to.
+const shortCommitLength = 7
+
+// commitLengths are the lengths a whole hash has: sha1, and sha256 for a
+// repository built with it. Checking the length is what keeps a HEAD holding
+// something else from being read as a commit.
+var commitLengths = map[int]struct{}{40: {}, 64: {}}
+
+// maxRefFileSize bounds what is read from a ref file. These hold one short
+// line; anything larger is not one, and the paths reaching here come from a
+// pane's working directory.
+const maxRefFileSize = 4 << 10
+
+// branchPrefix is what HEAD carries when a branch is checked out.
+const branchPrefix = "ref: refs/heads/"
+
+// remoteHeadPrefix is what the default-branch marker carries.
+const remoteHeadPrefix = "ref: refs/remotes/origin/"
+
+// Checkout is what the repository holding a directory has checked out.
+type Checkout struct {
+	// Branch is the checked-out branch, or the branch a rebase set aside.
+	Branch string
+	// Commit is the abbreviated hash HEAD points at, set only when no branch
+	// does — a checked-out tag, a bisect, a detached HEAD.
+	Commit string
+	// Default is the repository's default branch, empty when it records none.
+	Default string
+}
+
+// Read reports what the repository holding dir has checked out. It reports
+// false for a directory outside a repository, and for one whose .git cannot be
+// read: neither is an error worth a log line twice a second.
+func Read(dir string) (Checkout, bool) {
+	gitDir, commonDir, found := discover(dir)
+	if !found {
+		return Checkout{}, false
+	}
+
+	head, ok := readRef(filepath.Join(gitDir, "HEAD"))
+	if !ok {
+		return Checkout{}, false
+	}
+
+	checkout := Checkout{Default: defaultBranch(commonDir)}
+	switch {
+	case strings.HasPrefix(head, branchPrefix):
+		checkout.Branch = strings.TrimPrefix(head, branchPrefix)
+	default:
+		// A rebase detaches HEAD and records the branch it came from, which is
+		// still where the user is working.
+		if branch, rebasing := rebasingBranch(gitDir); rebasing {
+			checkout.Branch = branch
+			break
+		}
+		checkout.Commit = abbreviate(head)
+	}
+
+	if checkout.Branch == "" && checkout.Commit == "" {
+		return Checkout{}, false
+	}
+	return checkout, true
+}
+
+// discover walks up from dir to the repository holding it, returning the
+// directory holding HEAD and the one holding the shared refs. The two differ in
+// a worktree and in a submodule, where .git is a file pointing elsewhere.
+func discover(dir string) (gitDir, commonDir string, found bool) {
+	if dir == "" || !filepath.IsAbs(dir) {
+		return "", "", false
+	}
+
+	for dir = filepath.Clean(dir); ; {
+		candidate := filepath.Join(dir, ".git")
+		info, err := os.Stat(candidate)
+		switch {
+		case err != nil:
+		case info.IsDir():
+			return candidate, candidate, true
+		default:
+			gitDir, ok := linkedGitDir(candidate)
+			if !ok {
+				return "", "", false
+			}
+			return gitDir, commonDirOf(gitDir), true
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", "", false
+		}
+		dir = parent
+	}
+}
+
+// linkedGitDir follows the `gitdir:` line a worktree or submodule leaves in
+// place of a .git directory. A relative path in it is relative to the directory
+// the file is in.
+func linkedGitDir(gitFile string) (string, bool) {
+	line, ok := readRef(gitFile)
+	if !ok {
+		return "", false
+	}
+	target := strings.TrimSpace(strings.TrimPrefix(line, "gitdir:"))
+	if target == line || target == "" {
+		return "", false
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(gitFile), target)
+	}
+	return filepath.Clean(target), true
+}
+
+// commonDirOf returns where a linked git directory keeps the refs it shares
+// with the repository it belongs to. A worktree's own directory holds its HEAD
+// but not the remote refs the default branch is read from.
+func commonDirOf(gitDir string) string {
+	common, ok := readRef(filepath.Join(gitDir, "commondir"))
+	if !ok {
+		return gitDir
+	}
+	if !filepath.IsAbs(common) {
+		common = filepath.Join(gitDir, common)
+	}
+	return filepath.Clean(common)
+}
+
+// defaultBranch reads the branch the repository treats as its trunk. It is a
+// symbolic ref, which `git pack-refs` leaves as a file, so there is no packed
+// form to parse. A repository that was never cloned records none.
+func defaultBranch(commonDir string) string {
+	line, ok := readRef(filepath.Join(commonDir, "refs", "remotes", "origin", "HEAD"))
+	if !ok || !strings.HasPrefix(line, remoteHeadPrefix) {
+		return ""
+	}
+	return strings.TrimPrefix(line, remoteHeadPrefix)
+}
+
+// rebasingBranch reports the branch a rebase in progress set aside. Both
+// backends record it: the merge backend is the default, the apply backend is
+// what `--apply` and `git am` use.
+func rebasingBranch(gitDir string) (string, bool) {
+	for _, state := range []string{"rebase-merge", "rebase-apply"} {
+		line, ok := readRef(filepath.Join(gitDir, state, "head-name"))
+		if !ok || !strings.HasPrefix(line, "refs/heads/") {
+			continue
+		}
+		if branch := strings.TrimPrefix(line, "refs/heads/"); branch != "" {
+			return branch, true
+		}
+	}
+	return "", false
+}
+
+// readRef returns the first line of a ref file, or false when there is nothing
+// to read. Reading is bounded: these files hold one line.
+func readRef(path string) (string, bool) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer file.Close() //nolint:errcheck // a read-only file has nothing to report on close
+
+	content, err := io.ReadAll(io.LimitReader(file, maxRefFileSize))
+	if err != nil {
+		return "", false
+	}
+
+	line, _, _ := strings.Cut(string(content), "\n")
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return "", false
+	}
+	return line, true
+}
+
+// abbreviate shortens a detached HEAD's hash to the length git prints. A HEAD
+// holding anything else yields nothing, so a file that is not a ref cannot
+// become a tab label.
+func abbreviate(head string) string {
+	if _, whole := commitLengths[len(head)]; !whole || !isHex(head) {
+		return ""
+	}
+	return head[:shortCommitLength]
+}
+
+func isHex(value string) bool {
+	for _, r := range value {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,7 +1,6 @@
-// Package git reads what a repository has checked out by reading the files
-// under .git directly. It never runs the git executable: reading HEAD costs
-// 0.038 ms where `git rev-parse` costs 12 ms, and a pane's directory is a
-// terminal-derived value that is better not handed to a subprocess at all.
+// Package git reads what a repository has checked out from the files under
+// .git, never by running git. The measurements that settled that are in
+// docs/architecture/title-resolution.md.
 package git
 
 import (

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,222 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// repo builds a repository out of files rather than by running git, so the
+// tests describe the format they parse and do not depend on what is installed.
+type repo struct {
+	root   string
+	gitDir string
+}
+
+func newRepo(t *testing.T) repo {
+	t.Helper()
+	root := t.TempDir()
+	r := repo{root: root, gitDir: filepath.Join(root, ".git")}
+	r.write(t, filepath.Join(r.gitDir, "HEAD"), "ref: refs/heads/main\n")
+	return r
+}
+
+func (r repo) write(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (r repo) head(t *testing.T, content string) repo {
+	t.Helper()
+	r.write(t, filepath.Join(r.gitDir, "HEAD"), content)
+	return r
+}
+
+func (r repo) originHead(t *testing.T, branch string) repo {
+	t.Helper()
+	r.write(t, filepath.Join(r.gitDir, "refs", "remotes", "origin", "HEAD"),
+		"ref: refs/remotes/origin/"+branch+"\n")
+	return r
+}
+
+func (r repo) subdir(t *testing.T, path string) string {
+	t.Helper()
+	dir := filepath.Join(r.root, path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func mustRead(t *testing.T, dir string) Checkout {
+	t.Helper()
+	checkout, ok := Read(dir)
+	if !ok {
+		t.Fatalf("Read(%q) found no repository", dir)
+	}
+	return checkout
+}
+
+func TestTheCheckedOutBranchIsRead(t *testing.T) {
+	r := newRepo(t).head(t, "ref: refs/heads/feature/MC-13675\n")
+
+	if got := mustRead(t, r.root).Branch; got != "feature/MC-13675" {
+		t.Errorf("branch %q, want %q", got, "feature/MC-13675")
+	}
+}
+
+func TestTheRepositoryIsFoundFromASubdirectory(t *testing.T) {
+	r := newRepo(t).head(t, "ref: refs/heads/side\n")
+
+	if got := mustRead(t, r.subdir(t, "internal/app")).Branch; got != "side" {
+		t.Errorf("branch %q, want %q", got, "side")
+	}
+}
+
+func TestADirectoryOutsideARepositoryIsNotOne(t *testing.T) {
+	if _, ok := Read(t.TempDir()); ok {
+		t.Error("a directory with no .git reported a checkout")
+	}
+}
+
+func TestOnlyAnAbsolutePathIsRead(t *testing.T) {
+	// A relative path would be resolved against the plugin's own directory,
+	// naming a tab after a repository nobody is looking at.
+	if _, ok := Read("relative/path"); ok {
+		t.Error("a relative path reported a checkout")
+	}
+}
+
+func TestTheDefaultBranchIsReadFromTheRepository(t *testing.T) {
+	r := newRepo(t).head(t, "ref: refs/heads/side\n").originHead(t, "develop")
+
+	if got := mustRead(t, r.root).Default; got != "develop" {
+		t.Errorf("default %q, want %q", got, "develop")
+	}
+}
+
+func TestARepositoryWithoutARemoteRecordsNoDefault(t *testing.T) {
+	if got := mustRead(t, newRepo(t).root).Default; got != "" {
+		t.Errorf("default %q, want none", got)
+	}
+}
+
+func TestADetachedHeadIsAbbreviated(t *testing.T) {
+	r := newRepo(t).head(t, "aaf1fd85f68047764760489dbfc3ecb5ab9d0cb8\n")
+
+	checkout := mustRead(t, r.root)
+	if checkout.Commit != "aaf1fd8" {
+		t.Errorf("commit %q, want %q", checkout.Commit, "aaf1fd8")
+	}
+	if checkout.Branch != "" {
+		t.Errorf("branch %q, want none", checkout.Branch)
+	}
+}
+
+func TestASha256HeadIsAbbreviatedToo(t *testing.T) {
+	r := newRepo(t).head(t, "9c8f2b1a0123456789abcdef0123456789abcdef0123456789abcdef08b1cd2e\n")
+
+	if got := mustRead(t, r.root).Commit; got != "9c8f2b1" {
+		t.Errorf("commit %q, want %q", got, "9c8f2b1")
+	}
+}
+
+func TestAHeadHoldingSomethingElseIsNoCheckout(t *testing.T) {
+	// A HEAD that is neither a ref nor a hash must not reach a tab label. A
+	// hash of the wrong length is not one: that is what bounds the read.
+	for _, content := range []string{"", "\n", "ref: refs/tags/v1.0.0\n", "not a hash\n",
+		"aaf1fd85f68047764760489dbfc3ecb5ab9d0c\n"} {
+		r := newRepo(t).head(t, content)
+		if _, ok := Read(r.root); ok {
+			t.Errorf("HEAD %q reported a checkout", content)
+		}
+	}
+}
+
+func TestARebaseNamesTheBranchItSetAside(t *testing.T) {
+	// Both backends: the merge backend is the default, the apply backend is
+	// what `--apply` and `git am` use.
+	for _, state := range []string{"rebase-merge", "rebase-apply"} {
+		r := newRepo(t).head(t, "e87a64205f30ad32f455ff99a335cb89669f3321\n")
+		r.write(t, filepath.Join(r.gitDir, state, "head-name"), "refs/heads/topic\n")
+
+		checkout := mustRead(t, r.root)
+		if checkout.Branch != "topic" {
+			t.Errorf("%s: branch %q, want %q", state, checkout.Branch, "topic")
+		}
+		if checkout.Commit != "" {
+			t.Errorf("%s: commit %q, want none", state, checkout.Commit)
+		}
+	}
+}
+
+func TestAWorktreeIsFollowedToItsOwnHead(t *testing.T) {
+	main := newRepo(t).originHead(t, "main")
+	worktreeGitDir := filepath.Join(main.gitDir, "worktrees", "wt")
+	main.write(t, filepath.Join(worktreeGitDir, "HEAD"), "ref: refs/heads/side\n")
+	main.write(t, filepath.Join(worktreeGitDir, "commondir"), "../..\n")
+
+	tree := t.TempDir()
+	main.write(t, filepath.Join(tree, ".git"), "gitdir: "+worktreeGitDir+"\n")
+
+	checkout := mustRead(t, tree)
+	if checkout.Branch != "side" {
+		t.Errorf("branch %q, want %q", checkout.Branch, "side")
+	}
+	// The default branch lives with the shared refs, not in the worktree.
+	if checkout.Default != "main" {
+		t.Errorf("default %q, want %q", checkout.Default, "main")
+	}
+}
+
+func TestARelativeGitdirIsResolvedAgainstTheFileHoldingIt(t *testing.T) {
+	// A submodule records its git directory relative to its own working tree.
+	parent := newRepo(t)
+	moduleGitDir := filepath.Join(parent.gitDir, "modules", "vendor")
+	parent.write(t, filepath.Join(moduleGitDir, "HEAD"), "ref: refs/heads/pinned\n")
+
+	module := parent.subdir(t, "vendor")
+	parent.write(t, filepath.Join(module, ".git"), "gitdir: ../.git/modules/vendor\n")
+
+	if got := mustRead(t, module).Branch; got != "pinned" {
+		t.Errorf("branch %q, want %q", got, "pinned")
+	}
+}
+
+func TestAnUnreadableGitFileIsNoRepository(t *testing.T) {
+	root := t.TempDir()
+	r := repo{root: root, gitDir: filepath.Join(root, ".git")}
+	r.write(t, filepath.Join(root, ".git"), "not a gitdir line\n")
+
+	if _, ok := Read(root); ok {
+		t.Error("a .git file with no gitdir reported a checkout")
+	}
+}
+
+func TestOnlyTheFirstLineOfARefIsRead(t *testing.T) {
+	// Nothing writes a second line, but a tab label is one line either way.
+	r := newRepo(t).head(t, "ref: refs/heads/side\nrubbish\n")
+
+	if got := mustRead(t, r.root).Branch; got != "side" {
+		t.Errorf("branch %q, want %q", got, "side")
+	}
+}
+
+func TestAHugeHeadIsNotReadWhole(t *testing.T) {
+	r := newRepo(t)
+	huge := make([]byte, 2*maxRefFileSize)
+	for i := range huge {
+		huge[i] = 'a'
+	}
+	r.write(t, filepath.Join(r.gitDir, "HEAD"), string(huge))
+
+	// The bounded read leaves a truncated hash, which is not a checkout.
+	if _, ok := Read(r.root); ok {
+		t.Error("an oversized HEAD reported a checkout")
+	}
+}

--- a/internal/herdr/session.go
+++ b/internal/herdr/session.go
@@ -49,6 +49,15 @@ type PaneInfo struct {
 	AgentStatus  string `json:"agent_status"`
 }
 
+// Dir is the directory a pane speaks for. The shell's own is preferred over
+// the foreground process's, which follows whatever is running right now.
+func (p PaneInfo) Dir() string {
+	if p.CWD != "" {
+		return p.CWD
+	}
+	return p.ForegroundCWD
+}
+
 // PaneProcessInfoProcess is one process running in a pane. Herdr reports more
 // about each — its pid, its working directory, the joined command line — but a
 // title is derived from the name and the arguments alone.

--- a/internal/resolver/agent_test.go
+++ b/internal/resolver/agent_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAgentTitleBeatsEverySourceBelowIt(t *testing.T) {
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
-		CWD:           "/Users/dev/work/dashboard",
+		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Claude Code",
 		Agent:         "claude",
 		AgentStatus:   herdr.AgentStatusWorking,
@@ -29,7 +29,7 @@ func TestAgentTitleBeatsEverySourceBelowIt(t *testing.T) {
 
 func TestAgentTitleOutranksAMeaningfulTerminalTitle(t *testing.T) {
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
-		CWD:           "/Users/dev/work/dashboard",
+		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Fix OAuth redirect",
 		Agent:         "claude",
 		AgentStatus:   herdr.AgentStatusWorking,
@@ -47,7 +47,7 @@ func TestGenericAgentNameFallsThrough(t *testing.T) {
 	for _, title := range []string{"Claude", "Claude Code", "Agent", "Coding Agent", ""} {
 		t.Run(title, func(t *testing.T) {
 			got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
-				CWD:           "/Users/dev/work/dashboard",
+				Dir:           "/Users/dev/work/dashboard",
 				TerminalTitle: "Fix OAuth redirect",
 				Agent:         "claude",
 				AgentStatus:   herdr.AgentStatusWorking,
@@ -69,7 +69,7 @@ func TestAgentEchoingItsOwnNameIsNotAgentContext(t *testing.T) {
 	// off as a report of their work. The name still reaches the tab, but as the
 	// kind of program running there rather than as what it is doing.
 	pane := &state.PaneState{
-		CWD:          "/Users/dev/work/dashboard",
+		Dir:          "/Users/dev/work/dashboard",
 		Agent:        "acme-bot",
 		DisplayAgent: "Acme Bot",
 		AgentStatus:  herdr.AgentStatusWorking,
@@ -93,7 +93,7 @@ func TestAgentTitleWithoutAnAgentIsIgnored(t *testing.T) {
 	// Herdr leaves the title on a pane whose agent it no longer recognizes;
 	// without an agent it is not agent context.
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
-		CWD:        "/Users/dev/work/dashboard",
+		Dir:        "/Users/dev/work/dashboard",
 		AgentTitle: "Implement OAuth scopes",
 	}))
 
@@ -128,12 +128,12 @@ func TestContextAndActivityComeFromTheSamePane(t *testing.T) {
 		Panes: map[string]*state.PaneState{
 			"wE:p1": {
 				ID:            "wE:p1",
-				CWD:           "/Users/dev/work/api",
+				Dir:           "/Users/dev/work/api",
 				TerminalTitle: "Run migrations",
 			},
 			"wE:p2": {
 				ID:          "wE:p2",
-				CWD:         "/Users/dev/work/dashboard",
+				Dir:         "/Users/dev/work/dashboard",
 				Agent:       "claude",
 				AgentStatus: herdr.AgentStatusWorking,
 				AgentTitle:  "Implement OAuth scopes",

--- a/internal/resolver/agent_test.go
+++ b/internal/resolver/agent_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAgentTitleBeatsEverySourceBelowIt(t *testing.T) {
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		CWD:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Claude Code",
 		Agent:         "claude",
@@ -28,7 +28,7 @@ func TestAgentTitleBeatsEverySourceBelowIt(t *testing.T) {
 }
 
 func TestAgentTitleOutranksAMeaningfulTerminalTitle(t *testing.T) {
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		CWD:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Fix OAuth redirect",
 		Agent:         "claude",
@@ -46,7 +46,7 @@ func TestGenericAgentNameFallsThrough(t *testing.T) {
 	// topic then arrives through the terminal title instead.
 	for _, title := range []string{"Claude", "Claude Code", "Agent", "Coding Agent", ""} {
 		t.Run(title, func(t *testing.T) {
-			got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+			got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 				CWD:           "/Users/dev/work/dashboard",
 				TerminalTitle: "Fix OAuth redirect",
 				Agent:         "claude",
@@ -80,7 +80,7 @@ func TestAgentEchoingItsOwnNameIsNotAgentContext(t *testing.T) {
 		t.Error("the agent source claimed an agent naming itself")
 	}
 
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 	if want := "dashboard › acme-bot"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -92,7 +92,7 @@ func TestAgentEchoingItsOwnNameIsNotAgentContext(t *testing.T) {
 func TestAgentTitleWithoutAnAgentIsIgnored(t *testing.T) {
 	// Herdr leaves the title on a pane whose agent it no longer recognizes;
 	// without an agent it is not agent context.
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		CWD:        "/Users/dev/work/dashboard",
 		AgentTitle: "Implement OAuth scopes",
 	}))
@@ -109,7 +109,7 @@ func TestAgentSourceOnANilPane(t *testing.T) {
 }
 
 func TestAgentTitleWithNoDirectoryStandsAlone(t *testing.T) {
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		Agent:       "claude",
 		AgentStatus: herdr.AgentStatusWorking,
 		AgentTitle:  "Implement OAuth scopes",
@@ -141,7 +141,7 @@ func TestContextAndActivityComeFromTheSamePane(t *testing.T) {
 		},
 	}
 
-	got := Default(DefaultMaxLength).Resolve(tab)
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
 	if want := "dashboard › claude › Implement OAuth scopes"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}

--- a/internal/resolver/cwd.go
+++ b/internal/resolver/cwd.go
@@ -33,14 +33,7 @@ func (c CWD) Resolve(pane *state.PaneState) (Parts, bool) {
 		return Parts{}, false
 	}
 
-	// The shell's own directory names the project more stably than the
-	// foreground process's, which follows whatever is currently running.
-	dir := pane.CWD
-	if dir == "" {
-		dir = pane.ForegroundCWD
-	}
-
-	name := c.base(dir)
+	name := c.base(pane.Dir)
 	if name == "" {
 		return Parts{}, false
 	}

--- a/internal/resolver/git.go
+++ b/internal/resolver/git.go
@@ -82,14 +82,14 @@ func shortenBranch(branch string, maxLength int) string {
 		return ""
 	}
 
+	if _, over := splitAtWidth(branch, maxLength); over == "" {
+		return branch
+	}
+
 	// A key is atomic: cutting it leaves something that identifies nothing, so
 	// it is the one value allowed past maxLength.
 	if key := trackerKey.FindString(branch); key != "" {
 		return strings.ToUpper(key)
-	}
-
-	if _, over := splitAtWidth(branch, maxLength); over == "" {
-		return branch
 	}
 
 	if cut := strings.LastIndex(branch, "/"); cut >= 0 && cut+1 < len(branch) {

--- a/internal/resolver/git.go
+++ b/internal/resolver/git.go
@@ -50,16 +50,16 @@ func (g Git) Resolve(pane *state.PaneState) (Parts, bool) {
 		return Parts{}, false
 	}
 
-	branch := branchLabel(pane.Git, g.maxLength)
+	branch := g.label(pane.Git)
 	if branch == "" {
 		return Parts{}, false
 	}
 	return Parts{Branch: branch}, true
 }
 
-// branchLabel reduces a checkout to what a tab says about it, or "" when it
-// says nothing worth the width.
-func branchLabel(checkout git.Checkout, maxLength int) string {
+// label reduces a checkout to what a tab says about it, or "" when it says
+// nothing worth the width.
+func (g Git) label(checkout git.Checkout) string {
 	if checkout.Branch == "" {
 		// A detached HEAD is the one place a bare hash belongs in a title: it
 		// is where commits get lost, and no name is being left behind.
@@ -70,7 +70,7 @@ func branchLabel(checkout git.Checkout, maxLength int) string {
 	if checkout.Branch == checkout.Default {
 		return ""
 	}
-	return shortenBranch(Sanitize(checkout.Branch, 0), maxLength)
+	return shortenBranch(Sanitize(checkout.Branch, 0), g.maxLength)
 }
 
 // shortenBranch reduces an over-long branch name to the part worth a tab's

--- a/internal/resolver/git.go
+++ b/internal/resolver/git.go
@@ -65,9 +65,9 @@ func branchLabel(checkout git.Checkout, maxLength int) string {
 		// is where commits get lost, and no name is being left behind.
 		return Sanitize(checkout.Commit, 0)
 	}
-	// A tab in a repository it is already named after learns nothing from
-	// being told it is on that repository's default branch.
-	if strings.EqualFold(checkout.Branch, checkout.Default) {
+	// Compared exactly, because git refs are: a branch named `Main` beside a
+	// `main` trunk is a different branch and has something to say.
+	if checkout.Branch == checkout.Default {
 		return ""
 	}
 	return shortenBranch(Sanitize(checkout.Branch, 0), maxLength)

--- a/internal/resolver/git.go
+++ b/internal/resolver/git.go
@@ -1,0 +1,142 @@
+package resolver
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/kryptamine/herdr-auto-title/internal/git"
+	"github.com/kryptamine/herdr-auto-title/internal/state"
+)
+
+// DefaultBranchMaxLength bounds what a branch may contribute to a title, in
+// columns of the tab bar.
+//
+// Twelve columns hold a tracker key, or a short word and part of the next, and
+// leave a tab readable beside a dozen others. Real branch names run far past
+// it: the ones this was calibrated against averaged fifty characters and
+// reached sixty-two.
+const DefaultBranchMaxLength = 12
+
+// trackerKey matches an issue key such as MC-13675 or ABC-42.
+//
+// It is the one part of a branch name that identifies the work, and it survives
+// every naming convention: whether a team writes `feature/MC-13675`,
+// `bugfix-alex-the-thing-mc-13675` or `MC-13675`, the key is in there
+// somewhere. Two to six letters followed by at least two digits keeps it clear
+// of ordinary hyphenated words and of version-like fragments such as `utf-8`.
+var trackerKey = regexp.MustCompile(`(?i)\b[a-z]{2,6}-\d{2,6}\b`)
+
+// branchSeparators are the characters branch names are built out of. Cutting a
+// long branch at one of them ends it on a whole word.
+const branchSeparators = "-_./ "
+
+// Git names the branch the pane's repository has checked out.
+//
+// It contributes to the **context**, beside the directory, rather than to the
+// activity: a branch says which slice of a project a tab is on, which is part
+// of where the user is and not of what they are doing. That is also what makes
+// it useful — the activity is contested by the terminal title, and a branch
+// filed there spoke only for a plain shell. See docs/architecture/
+// title-resolution.md.
+type Git struct {
+	maxLength int
+}
+
+var _ Source = Git{}
+
+// NewGit builds the source. A maxLength of zero or less leaves branches out of
+// titles entirely.
+func NewGit(maxLength int) Git { return Git{maxLength: maxLength} }
+
+func (Git) Name() string    { return "git" }
+func (Git) Confidence() int { return ConfidenceGit }
+
+func (g Git) Resolve(pane *state.PaneState) (Parts, bool) {
+	if pane == nil || g.maxLength <= 0 {
+		return Parts{}, false
+	}
+
+	// The branch is read from the directory ssh was launched in, which says
+	// nothing about the machine the tab is showing.
+	if _, remote := sshArgs(pane); remote {
+		return Parts{}, false
+	}
+
+	branch := branchLabel(pane.Git, g.maxLength)
+	if branch == "" {
+		return Parts{}, false
+	}
+	return Parts{Branch: branch}, true
+}
+
+// branchLabel reduces a checkout to what a tab says about it, or "" when it
+// says nothing worth the width.
+func branchLabel(checkout git.Checkout, maxLength int) string {
+	if checkout.Branch == "" {
+		// A detached HEAD is the one place a bare hash belongs in a title: it
+		// is where commits get lost, and no name is being left behind.
+		return Sanitize(checkout.Commit, 0)
+	}
+	// A tab in a repository it is already named after learns nothing from
+	// being told it is on that repository's default branch.
+	if strings.EqualFold(checkout.Branch, checkout.Default) {
+		return ""
+	}
+	return shortenBranch(Sanitize(checkout.Branch, 0), maxLength)
+}
+
+// shortenBranch reduces a branch name to the part worth putting in a tab title.
+//
+// Branch conventions vary too much to enumerate, so nothing here is a list of
+// known prefixes — a list only ever fits the team it was written for. Two rules
+// cover every convention seen:
+//
+//   - An issue key wins outright. It identifies the work, it is short, and it
+//     survives whatever the convention wraps around it. A team whose branches
+//     all begin `bugfix-<author>-` gets eight characters that distinguish
+//     instead of eight that do not.
+//   - A name that already fits is left alone: dropping `feat/` from a branch
+//     with room to spare would throw away what distinguishes it from `fix/`.
+//   - Otherwise drop the namespace, which every branch in the repository
+//     carries alike, and cut at a separator so the result ends on a whole word.
+func shortenBranch(branch string, maxLength int) string {
+	branch = strings.Trim(branch, branchSeparators)
+	if branch == "" || maxLength <= 0 {
+		return ""
+	}
+
+	// A key is atomic: cutting it leaves something that identifies nothing, so
+	// it is the one value allowed past maxLength.
+	if key := trackerKey.FindString(branch); key != "" {
+		return strings.ToUpper(key)
+	}
+
+	if _, over := splitAtWidth(branch, maxLength); over == "" {
+		return branch
+	}
+
+	if cut := strings.LastIndex(branch, "/"); cut >= 0 && cut+1 < len(branch) {
+		branch = branch[cut+1:]
+	}
+	return cutAtSeparator(branch, maxLength)
+}
+
+// cutAtSeparator shortens a value to maxWidth columns, ending on the last
+// separator that fits so the result is a whole word rather than a fragment.
+func cutAtSeparator(value string, maxWidth int) string {
+	head, rest := splitAtWidth(value, maxWidth)
+	if rest == "" {
+		return strings.Trim(value, branchSeparators)
+	}
+
+	// When the character that did not fit is itself a separator, the head
+	// already ends on a whole word and cutting again would throw one away.
+	next, _ := utf8.DecodeRuneInString(rest)
+	if !strings.ContainsRune(branchSeparators, next) {
+		if cut := strings.LastIndexAny(head, branchSeparators); cut > 0 {
+			head = head[:cut]
+		}
+	}
+	return strings.Trim(head, branchSeparators)
+}

--- a/internal/resolver/git.go
+++ b/internal/resolver/git.go
@@ -9,36 +9,23 @@ import (
 	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
 
-// DefaultBranchMaxLength bounds what a branch may contribute to a title, in
-// columns of the tab bar.
-//
-// Twelve columns hold a tracker key, or a short word and part of the next, and
-// leave a tab readable beside a dozen others. Real branch names run far past
-// it: the ones this was calibrated against averaged fifty characters and
-// reached sixty-two.
+// DefaultBranchMaxLength bounds what a branch adds to a title, in columns of
+// the tab bar. Twelve holds a tracker key, or a word and part of the next —
+// see docs/architecture/title-resolution.md.
 const DefaultBranchMaxLength = 12
 
-// trackerKey matches an issue key such as MC-13675 or ABC-42.
-//
-// It is the one part of a branch name that identifies the work, and it survives
-// every naming convention: whether a team writes `feature/MC-13675`,
-// `bugfix-alex-the-thing-mc-13675` or `MC-13675`, the key is in there
-// somewhere. Two to six letters followed by at least two digits keeps it clear
-// of ordinary hyphenated words and of version-like fragments such as `utf-8`.
+// trackerKey matches an issue key such as MC-13675. Two to six letters and at
+// least two digits keeps it clear of hyphenated words and of fragments like
+// `utf-8`.
 var trackerKey = regexp.MustCompile(`(?i)\b[a-z]{2,6}-\d{2,6}\b`)
 
 // branchSeparators are the characters branch names are built out of. Cutting a
 // long branch at one of them ends it on a whole word.
 const branchSeparators = "-_./ "
 
-// Git names the branch the pane's repository has checked out.
-//
-// It contributes to the **context**, beside the directory, rather than to the
-// activity: a branch says which slice of a project a tab is on, which is part
-// of where the user is and not of what they are doing. That is also what makes
-// it useful — the activity is contested by the terminal title, and a branch
-// filed there spoke only for a plain shell. See docs/architecture/
-// title-resolution.md.
+// Git names the branch the pane's repository has checked out. It qualifies the
+// context rather than the activity, and why that matters is in
+// docs/architecture/title-resolution.md.
 type Git struct {
 	maxLength int
 }
@@ -86,20 +73,9 @@ func branchLabel(checkout git.Checkout, maxLength int) string {
 	return shortenBranch(Sanitize(checkout.Branch, 0), maxLength)
 }
 
-// shortenBranch reduces a branch name to the part worth putting in a tab title.
-//
-// Branch conventions vary too much to enumerate, so nothing here is a list of
-// known prefixes — a list only ever fits the team it was written for. Two rules
-// cover every convention seen:
-//
-//   - An issue key wins outright. It identifies the work, it is short, and it
-//     survives whatever the convention wraps around it. A team whose branches
-//     all begin `bugfix-<author>-` gets eight characters that distinguish
-//     instead of eight that do not.
-//   - A name that already fits is left alone: dropping `feat/` from a branch
-//     with room to spare would throw away what distinguishes it from `fix/`.
-//   - Otherwise drop the namespace, which every branch in the repository
-//     carries alike, and cut at a separator so the result ends on a whole word.
+// shortenBranch reduces an over-long branch name to the part worth a tab's
+// width. The rules, and why none of them is a list of known prefixes, are in
+// docs/architecture/title-resolution.md.
 func shortenBranch(branch string, maxLength int) string {
 	branch = strings.Trim(branch, branchSeparators)
 	if branch == "" || maxLength <= 0 {

--- a/internal/resolver/git_test.go
+++ b/internal/resolver/git_test.go
@@ -79,9 +79,10 @@ func TestABranchIsReducedToWhatIdentifiesIt(t *testing.T) {
 		"test/process-read-flake":      "process-read",
 		"feature/add-dark-mode":        "add-dark",
 
-		// A name that fits keeps its namespace: `feat/` is what tells it from
-		// `fix/`, and there is room for both halves.
+		// A name that fits is left whole, key or no key: `feat/` is what tells
+		// it from `fix/`, and a key that already fits needs no rescuing.
 		"feat/oauth": "feat/oauth",
+		"feat/ab-12": "feat/ab-12",
 		"short":      "short",
 	}
 

--- a/internal/resolver/git_test.go
+++ b/internal/resolver/git_test.go
@@ -1,0 +1,161 @@
+package resolver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kryptamine/herdr-auto-title/internal/git"
+	"github.com/kryptamine/herdr-auto-title/internal/state"
+)
+
+// repoPane builds a pane sitting in a repository with branch checked out and
+// origin/HEAD naming defaultBranch.
+func repoPane(branch, defaultBranch string) *state.PaneState {
+	return &state.PaneState{
+		CWD: "/Users/dev/work/dashboard",
+		Git: git.Checkout{Branch: branch, Default: defaultBranch},
+	}
+}
+
+func resolveRepoPane(pane *state.PaneState) string {
+	return Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane)).Name
+}
+
+func TestTheBranchQualifiesTheDirectory(t *testing.T) {
+	pane := repoPane("feat/oauth", "main")
+	pane.TerminalTitle = "auth.ts - Nvim"
+	pane.Processes = []state.Process{{Name: "nvim"}}
+
+	if got := resolveRepoPane(pane); got != "dashboard › feat/oauth › nvim › auth.ts" {
+		t.Errorf("title %q, want the branch between the directory and the work", got)
+	}
+}
+
+func TestTheDefaultBranchSaysNothing(t *testing.T) {
+	// A tab in a repository it is already named after learns nothing from
+	// being told it is on that repository's trunk.
+	if got := resolveRepoPane(repoPane("main", "main")); got != "dashboard" {
+		t.Errorf("title %q, want just the directory", got)
+	}
+}
+
+func TestTheDefaultBranchIsTheRepositorysOwn(t *testing.T) {
+	// A team whose trunk is `develop` gets the same silence, and one that works
+	// on a branch named `main` off a `develop` trunk still sees it.
+	if got := resolveRepoPane(repoPane("develop", "develop")); got != "dashboard" {
+		t.Errorf("develop as trunk → %q, want just the directory", got)
+	}
+	if got := resolveRepoPane(repoPane("main", "develop")); got != "dashboard › main" {
+		t.Errorf("main off a develop trunk → %q, want the branch", got)
+	}
+}
+
+func TestARepositoryWithNoRecordedTrunkAlwaysShowsItsBranch(t *testing.T) {
+	if got := resolveRepoPane(repoPane("main", "")); got != "dashboard › main" {
+		t.Errorf("title %q, want the branch", got)
+	}
+}
+
+func TestADetachedHeadShowsTheCommit(t *testing.T) {
+	pane := &state.PaneState{
+		CWD: "/Users/dev/work/dashboard",
+		Git: git.Checkout{Commit: "a1b2c3d", Default: "main"},
+	}
+
+	if got := resolveRepoPane(pane); got != "dashboard › a1b2c3d" {
+		t.Errorf("title %q, want the commit", got)
+	}
+}
+
+func TestABranchIsReducedToWhatIdentifiesIt(t *testing.T) {
+	cases := map[string]string{
+		// An issue key identifies the work whatever wraps it.
+		"bugfix-asatretdinov-cpanel-uapi-mc-13675": "MC-13675",
+		"feature/MC-13675":                         "MC-13675",
+		"MC-13675":                                 "MC-13675",
+
+		// Without one, the namespace goes and the rest is cut at a whole word.
+		"docs/install-needs-a-restart": "install",
+		"test/process-read-flake":      "process-read",
+		"feature/add-dark-mode":        "add-dark",
+
+		// A name that fits keeps its namespace: `feat/` is what tells it from
+		// `fix/`, and there is room for both halves.
+		"feat/oauth": "feat/oauth",
+		"short":      "short",
+	}
+
+	for branch, want := range cases {
+		if got := shortenBranch(branch, DefaultBranchMaxLength); got != want {
+			t.Errorf("%s → %q, want %q", branch, got, want)
+		}
+	}
+}
+
+func TestABranchIsNotShownForARemoteMachine(t *testing.T) {
+	// The branch is read from the directory ssh was launched in, which says
+	// nothing about the machine on the other end.
+	pane := repoPane("feat/oauth", "main")
+	pane.Processes = []state.Process{
+		{Name: "fish", Args: []string{"-fish"}},
+		{Name: "ssh", Args: strings.Fields("ssh root@prod-01")},
+	}
+
+	if got := resolveRepoPane(pane); got != "ssh › prod-01" {
+		t.Errorf("title %q, want no branch beside the host", got)
+	}
+}
+
+func TestTheBranchSurvivesTheWorkspaceItRepeats(t *testing.T) {
+	// Herdr shows the workspace above the tabs, so the directory goes — but
+	// the branch is exactly what tells two tabs of that workspace apart.
+	tab := tabWithPane(repoPane("feat/oauth", "main"))
+	tab.WorkspaceName = "dashboard"
+
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab).Name
+	if got != "feat/oauth" {
+		t.Errorf("title %q, want the branch alone", got)
+	}
+}
+
+func TestABranchWidthOfZeroLeavesBranchesOut(t *testing.T) {
+	got := Default(DefaultMaxLength, 0).Resolve(tabWithPane(repoPane("feat/oauth", "main"))).Name
+	if got != "dashboard" {
+		t.Errorf("title %q, want no branch at all", got)
+	}
+}
+
+func TestAPromptCarryingTheBranchDoesNotSayItTwice(t *testing.T) {
+	pane := repoPane("feat/oauth", "main")
+	pane.TerminalTitle = "feat/oauth"
+
+	if got := resolveRepoPane(pane); got != "dashboard › feat/oauth" {
+		t.Errorf("title %q, want the branch once", got)
+	}
+}
+
+func TestABranchStandsWhereTheDirectorySaysNothing(t *testing.T) {
+	// A home directory contributes no context, but a repository checked out in
+	// it — dotfiles — still says where the user is.
+	pane := &state.PaneState{Git: git.Checkout{Branch: "feat/oauth", Default: "main"}}
+
+	if got := resolveRepoPane(pane); got != "feat/oauth" {
+		t.Errorf("title %q, want the branch", got)
+	}
+}
+
+func TestTheBranchIsCreditedLikeAContext(t *testing.T) {
+	// The reason a tab carries a name is the source that named the work, and a
+	// branch is not work: it answers for the title only when nothing else does.
+	resolver := Default(DefaultMaxLength, DefaultBranchMaxLength)
+
+	pane := repoPane("feat/oauth", "main")
+	pane.TerminalTitle = "auth.ts - Nvim"
+	if got := resolver.Resolve(tabWithPane(pane)).Reason; got != "terminal_title" {
+		t.Errorf("reason %q, want the source of the activity", got)
+	}
+
+	if got := resolver.Resolve(tabWithPane(repoPane("feat/oauth", "main"))).Reason; got != "git" {
+		t.Errorf("reason %q, want git", got)
+	}
+}

--- a/internal/resolver/git_test.go
+++ b/internal/resolver/git_test.go
@@ -12,7 +12,7 @@ import (
 // origin/HEAD naming defaultBranch.
 func repoPane(branch, defaultBranch string) *state.PaneState {
 	return &state.PaneState{
-		CWD: "/Users/dev/work/dashboard",
+		Dir: "/Users/dev/work/dashboard",
 		Git: git.Checkout{Branch: branch, Default: defaultBranch},
 	}
 }
@@ -66,7 +66,7 @@ func TestARepositoryWithNoRecordedTrunkAlwaysShowsItsBranch(t *testing.T) {
 
 func TestADetachedHeadShowsTheCommit(t *testing.T) {
 	pane := &state.PaneState{
-		CWD: "/Users/dev/work/dashboard",
+		Dir: "/Users/dev/work/dashboard",
 		Git: git.Checkout{Commit: "a1b2c3d", Default: "main"},
 	}
 

--- a/internal/resolver/git_test.go
+++ b/internal/resolver/git_test.go
@@ -50,6 +50,14 @@ func TestTheDefaultBranchIsTheRepositorysOwn(t *testing.T) {
 	}
 }
 
+func TestTheTrunkIsMatchedAsGitStoresIt(t *testing.T) {
+	// Git refs are case-sensitive, so `Main` beside a `main` trunk is another
+	// branch and has something to say.
+	if got := resolveRepoPane(repoPane("Main", "main")); got != "dashboard › Main" {
+		t.Errorf("title %q, want the branch", got)
+	}
+}
+
 func TestARepositoryWithNoRecordedTrunkAlwaysShowsItsBranch(t *testing.T) {
 	if got := resolveRepoPane(repoPane("main", "")); got != "dashboard › main" {
 		t.Errorf("title %q, want the branch", got)

--- a/internal/resolver/process_test.go
+++ b/internal/resolver/process_test.go
@@ -23,7 +23,7 @@ func TestTheKindQualifiesTheTitle(t *testing.T) {
 		Processes:     running("nvim"),
 	}
 
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 	if want := "dashboard › nvim › auth.provider.ts"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -37,7 +37,7 @@ func TestAKindWithNothingToAddStandsAlone(t *testing.T) {
 		Processes:     running("nvim"),
 	}
 
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 	if want := "dashboard › nvim"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -46,7 +46,7 @@ func TestAKindWithNothingToAddStandsAlone(t *testing.T) {
 func TestAKindWithNoTitleAtAllStillNamesThePane(t *testing.T) {
 	pane := &state.PaneState{CWD: "/Users/dev/work/dashboard", Processes: running("htop")}
 
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 	if want := "dashboard › htop"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -95,7 +95,7 @@ func TestARemoteSessionIsNotNamedTwice(t *testing.T) {
 	if got := paneKind(pane); got != "" {
 		t.Errorf("paneKind = %q, want empty", got)
 	}
-	if got := Default(DefaultMaxLength).Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
+	if got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
 		t.Errorf("name = %q, want ssh › prod-01", got.Name)
 	}
 }
@@ -126,7 +126,7 @@ func TestAProjectNeverTakesAColon(t *testing.T) {
 		Processes:     running("esbuild", "node", "node"),
 	}
 
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 	if want := "self-care-portal › yarn dev"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -152,7 +152,7 @@ func TestAnAgentIsItsOwnKind(t *testing.T) {
 	if got := paneKind(pane); got != "claude" {
 		t.Errorf("paneKind = %q, want claude", got)
 	}
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 	if want := "dashboard › claude › Git email configuration"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -167,7 +167,7 @@ func TestAStartingAgentIsNamedByItsKindAlone(t *testing.T) {
 		Agent:         "claude",
 	}
 
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 	if want := "dashboard › claude"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -176,7 +176,7 @@ func TestAStartingAgentIsNamedByItsKindAlone(t *testing.T) {
 func TestAPaneWithoutAnAgentIsNotNamedAfterOne(t *testing.T) {
 	pane := &state.PaneState{CWD: "/Users/dev/work/dashboard", TerminalTitle: "Claude Code"}
 
-	if got := Default(DefaultMaxLength).Resolve(tabWithPane(pane)); got.Name != "dashboard" {
+	if got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane)); got.Name != "dashboard" {
 		t.Errorf("name = %q, want dashboard", got.Name)
 	}
 }

--- a/internal/resolver/process_test.go
+++ b/internal/resolver/process_test.go
@@ -18,7 +18,7 @@ func running(names ...string) []state.Process {
 func TestTheKindQualifiesTheTitle(t *testing.T) {
 	// The editor names itself in its own title; under the kind that is noise.
 	pane := &state.PaneState{
-		CWD:           "/Users/dev/work/dashboard",
+		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "auth.provider.ts - Nvim",
 		Processes:     running("nvim"),
 	}
@@ -32,7 +32,7 @@ func TestTheKindQualifiesTheTitle(t *testing.T) {
 func TestAKindWithNothingToAddStandsAlone(t *testing.T) {
 	// Neovim showing a file manager titles the window after itself alone.
 	pane := &state.PaneState{
-		CWD:           "/Users/dev/work/dashboard",
+		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Nvim",
 		Processes:     running("nvim"),
 	}
@@ -44,7 +44,7 @@ func TestAKindWithNothingToAddStandsAlone(t *testing.T) {
 }
 
 func TestAKindWithNoTitleAtAllStillNamesThePane(t *testing.T) {
-	pane := &state.PaneState{CWD: "/Users/dev/work/dashboard", Processes: running("htop")}
+	pane := &state.PaneState{Dir: "/Users/dev/work/dashboard", Processes: running("htop")}
 
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 	if want := "dashboard › htop"; got.Name != want {
@@ -88,7 +88,7 @@ func TestARemoteSessionIsNotNamedTwice(t *testing.T) {
 	// ssh is marked on the host, where the mark cannot be outranked. Repeating
 	// it in the activity would read `ssh › prod-01 › ssh`.
 	pane := &state.PaneState{
-		CWD:       "/Users/dev/work/dashboard",
+		Dir:       "/Users/dev/work/dashboard",
 		Processes: []state.Process{{Name: "ssh", Args: []string{"ssh", "prod-01"}}},
 	}
 
@@ -121,7 +121,7 @@ func TestAProjectNeverTakesAColon(t *testing.T) {
 	// The rule the format rests on: a colon binds a kind to its detail, and a
 	// project is a place rather than a kind.
 	pane := &state.PaneState{
-		CWD:           "/Users/dev/work/self-care-portal",
+		Dir:           "/Users/dev/work/self-care-portal",
 		TerminalTitle: "yarn dev",
 		Processes:     running("esbuild", "node", "node"),
 	}
@@ -143,7 +143,7 @@ func TestAnAgentIsItsOwnKind(t *testing.T) {
 	// agent shows up as a caffeinate, several nodes and an MCP helper, with its
 	// own name nowhere among them.
 	pane := &state.PaneState{
-		CWD:           "/Users/dev/work/dashboard",
+		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Git email configuration",
 		Agent:         "claude",
 		Processes:     running("caffeinate", "node", "node", "fff-mcp"),
@@ -162,7 +162,7 @@ func TestAStartingAgentIsNamedByItsKindAlone(t *testing.T) {
 	// Claude Code titles its window after itself until the conversation has a
 	// subject. That is generic as an activity, and exactly right as a kind.
 	pane := &state.PaneState{
-		CWD:           "/Users/dev/work/dashboard",
+		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Claude Code",
 		Agent:         "claude",
 	}
@@ -174,7 +174,7 @@ func TestAStartingAgentIsNamedByItsKindAlone(t *testing.T) {
 }
 
 func TestAPaneWithoutAnAgentIsNotNamedAfterOne(t *testing.T) {
-	pane := &state.PaneState{CWD: "/Users/dev/work/dashboard", TerminalTitle: "Claude Code"}
+	pane := &state.PaneState{Dir: "/Users/dev/work/dashboard", TerminalTitle: "Claude Code"}
 
 	if got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane)); got.Name != "dashboard" {
 		t.Errorf("name = %q, want dashboard", got.Name)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -23,6 +23,7 @@ const GenericFallback = "Shell"
 const (
 	ConfidenceFallback      = 10
 	ConfidenceCWD           = 30
+	ConfidenceGit           = 40
 	ConfidenceSSH           = 60
 	ConfidenceProcess       = 70
 	ConfidenceTerminalTitle = 80
@@ -30,9 +31,12 @@ const (
 )
 
 // Parts are the components a source contributes to a title, formatted as
-// "<context> › <activity>". A source may supply either or both.
+// "<context> › <branch> › <activity>". A source may supply any of them.
 type Parts struct {
-	Context  string
+	Context string
+	// Branch qualifies the context rather than standing on its own: a branch
+	// is part of where the user is, not of what they are doing.
+	Branch   string
 	Activity string
 }
 
@@ -85,12 +89,13 @@ func New(maxLength int, sources ...Source) *Deterministic {
 
 // Default builds the resolver Auto Title ships with, so the binary and the
 // tests cannot drift apart on what the chain contains.
-func Default(maxLength int) *Deterministic {
+func Default(maxLength, branchMax int) *Deterministic {
 	return New(maxLength,
 		NewAgent(),
 		NewTerminalTitle(),
 		NewProcess(),
 		NewSSH(),
+		NewGit(branchMax),
 		NewCWD(),
 	)
 }
@@ -138,10 +143,17 @@ func (d *Deterministic) collect(pane *state.PaneState) collected {
 func (c *collected) take(source Source, parts Parts) {
 	// The activity is what a title is about, so its source answers for the
 	// title whenever one turns up. A context is credited only while no activity
-	// has been found.
+	// has been found, and a branch is credited on the same terms: it says where
+	// the user is, not what they are doing.
 	if c.parts.Activity == "" && parts.Activity != "" {
 		c.parts.Activity = parts.Activity
 		c.credit(source)
+	}
+	if c.parts.Branch == "" && parts.Branch != "" {
+		c.parts.Branch = parts.Branch
+		if c.reason == "" {
+			c.credit(source)
+		}
 	}
 	if c.parts.Context == "" && parts.Context != "" {
 		c.parts.Context = parts.Context
@@ -156,6 +168,9 @@ func (c *collected) credit(source Source) {
 	c.confidence = source.Confidence()
 }
 
+// complete stops the walk once both halves of a title are answered. The branch
+// is not required: a tab outside a repository has none, and waiting for one
+// would only walk sources that have already been outranked.
 func (c *collected) complete() bool {
 	return c.parts.Context != "" && c.parts.Activity != ""
 }
@@ -169,9 +184,16 @@ func withoutRepetition(parts Parts, workspace string) Parts {
 		parts.Activity = ""
 	}
 
+	// A prompt that carries the branch in the window title would otherwise
+	// produce `feat/oauth › feat/oauth`.
+	if parts.Branch != "" && strings.EqualFold(parts.Activity, parts.Branch) {
+		parts.Activity = ""
+	}
+
 	// Herdr shows the workspace above its tabs, so repeating it wastes half the
-	// width. Dropped only when something else remains.
-	if parts.Activity != "" && strings.EqualFold(parts.Context, workspace) {
+	// width. Dropped only when something else remains — the branch counts,
+	// which is what keeps `feat/oauth › nvim` from losing where it is.
+	if (parts.Activity != "" || parts.Branch != "") && strings.EqualFold(parts.Context, workspace) {
 		parts.Context = ""
 	}
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -142,9 +142,8 @@ func (d *Deterministic) collect(pane *state.PaneState) collected {
 // take fills whatever this source supplies and nothing already has.
 func (c *collected) take(source Source, parts Parts) {
 	// The activity is what a title is about, so its source answers for the
-	// title whenever one turns up. A context is credited only while no activity
-	// has been found, and a branch is credited on the same terms: it says where
-	// the user is, not what they are doing.
+	// title whenever one turns up. A context and a branch are credited only
+	// while no activity has been found.
 	if c.parts.Activity == "" && parts.Activity != "" {
 		c.parts.Activity = parts.Activity
 		c.credit(source)

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -165,7 +165,7 @@ func TestATabDoesNotRepeatItsWorkspace(t *testing.T) {
 	})
 	tab.WorkspaceName = "dashboard"
 
-	got := Default(DefaultMaxLength).Resolve(tab)
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
 	if got.Name != "Fix OAuth redirect" {
 		t.Errorf("name = %q, want %q", got.Name, "Fix OAuth redirect")
 	}
@@ -177,7 +177,7 @@ func TestATabWithNothingElseKeepsItsContext(t *testing.T) {
 	tab := tabWithPane(&state.PaneState{CWD: "/Users/dev/work/dashboard"})
 	tab.WorkspaceName = "dashboard"
 
-	got := Default(DefaultMaxLength).Resolve(tab)
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
 	if got.Name != "dashboard" {
 		t.Errorf("name = %q, want dashboard", got.Name)
 	}
@@ -192,7 +192,7 @@ func TestADifferentWorkspaceIsNotDropped(t *testing.T) {
 	})
 	tab.WorkspaceName = "api"
 
-	got := Default(DefaultMaxLength).Resolve(tab)
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
 	if want := "dashboard › Fix OAuth redirect"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -205,7 +205,7 @@ func TestAWorkspaceWithoutAName(t *testing.T) {
 		TerminalTitle: "Fix OAuth redirect",
 	})
 
-	got := Default(DefaultMaxLength).Resolve(tab)
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
 	if want := "dashboard › Fix OAuth redirect"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -215,7 +215,7 @@ func TestTheShippedChainIsAWellFormedLadder(t *testing.T) {
 	// Confidences used to be repeated in every result a source returned, and
 	// the chain's order was a second, unchecked statement of the same ladder.
 	// Now the numbers are the only statement, so they have to hold up.
-	chain := Default(DefaultMaxLength)
+	chain := Default(DefaultMaxLength, DefaultBranchMaxLength)
 
 	seen := make(map[int]string, len(chain.sources))
 	previous := 0
@@ -266,7 +266,7 @@ func TestCWDSourceOnANilPane(t *testing.T) {
 }
 
 func TestTheShippedChainResolvesATabWithNoPanes(t *testing.T) {
-	got := Default(DefaultMaxLength).Resolve(state.TabState{ID: "wE:t1"})
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(state.TabState{ID: "wE:t1"})
 	if got.Name != GenericFallback {
 		t.Errorf("name = %q, want %q", got.Name, GenericFallback)
 	}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -13,7 +13,7 @@ func tabWithCWD(dir string) state.TabState {
 	return state.TabState{
 		ID: "wE:t1",
 		Panes: map[string]*state.PaneState{
-			"wE:p1": {ID: "wE:p1", CWD: dir, Focused: true},
+			"wE:p1": {ID: "wE:p1", Dir: dir, Focused: true},
 		},
 	}
 }
@@ -51,12 +51,12 @@ func TestResolveFromCWD(t *testing.T) {
 	}
 }
 
-func TestResolveFallsBackToForegroundCWD(t *testing.T) {
+func TestResolveNamesATabAfterItsDirectory(t *testing.T) {
 	r := New(DefaultMaxLength, NewCWD())
 	tab := state.TabState{
 		ID: "wE:t1",
 		Panes: map[string]*state.PaneState{
-			"wE:p1": {ID: "wE:p1", ForegroundCWD: "/Users/dev/work/api", Focused: true},
+			"wE:p1": {ID: "wE:p1", Dir: "/Users/dev/work/api", Focused: true},
 		},
 	}
 
@@ -89,9 +89,9 @@ func TestResolveIsDeterministic(t *testing.T) {
 	tab := state.TabState{
 		ID: "wE:t1",
 		Panes: map[string]*state.PaneState{
-			"wE:p1": {ID: "wE:p1", CWD: "/Users/dev/work/dashboard"},
-			"wE:p2": {ID: "wE:p2", CWD: "/Users/dev/work/api"},
-			"wE:p3": {ID: "wE:p3", CWD: "/Users/dev/work/infra"},
+			"wE:p1": {ID: "wE:p1", Dir: "/Users/dev/work/dashboard"},
+			"wE:p2": {ID: "wE:p2", Dir: "/Users/dev/work/api"},
+			"wE:p3": {ID: "wE:p3", Dir: "/Users/dev/work/infra"},
 		},
 	}
 
@@ -160,7 +160,7 @@ func TestATabDoesNotRepeatItsWorkspace(t *testing.T) {
 	// Herdr shows the workspace above its tabs, so a tab in the workspace it is
 	// named after spends half its width saying what is already on screen.
 	tab := tabWithPane(&state.PaneState{
-		CWD:           "/Users/dev/work/dashboard",
+		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Fix OAuth redirect",
 	})
 	tab.WorkspaceName = "dashboard"
@@ -174,7 +174,7 @@ func TestATabDoesNotRepeatItsWorkspace(t *testing.T) {
 func TestATabWithNothingElseKeepsItsContext(t *testing.T) {
 	// Dropping it here would leave the tab with no name at all, which loses
 	// more than it saves.
-	tab := tabWithPane(&state.PaneState{CWD: "/Users/dev/work/dashboard"})
+	tab := tabWithPane(&state.PaneState{Dir: "/Users/dev/work/dashboard"})
 	tab.WorkspaceName = "dashboard"
 
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
@@ -187,7 +187,7 @@ func TestADifferentWorkspaceIsNotDropped(t *testing.T) {
 	// A tab whose directory left its workspace behind is exactly the tab that
 	// needs to say where it is.
 	tab := tabWithPane(&state.PaneState{
-		CWD:           "/Users/dev/work/dashboard",
+		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Fix OAuth redirect",
 	})
 	tab.WorkspaceName = "api"
@@ -201,7 +201,7 @@ func TestADifferentWorkspaceIsNotDropped(t *testing.T) {
 func TestAWorkspaceWithoutAName(t *testing.T) {
 	// An unnamed workspace must not make every context look like a repeat.
 	tab := tabWithPane(&state.PaneState{
-		CWD:           "/Users/dev/work/dashboard",
+		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Fix OAuth redirect",
 	})
 

--- a/internal/resolver/sanitize.go
+++ b/internal/resolver/sanitize.go
@@ -98,16 +98,17 @@ func splitAtWidth(s string, maxWidth int) (head, rest string) {
 }
 
 // Format assembles a title from its parts and sanitizes the result as a whole.
+// The order is the one a title reads in: from the general to the particular.
 func Format(parts Parts, maxLen int) string {
 	var b strings.Builder
-	if parts.Context != "" {
-		b.WriteString(parts.Context)
-	}
-	if parts.Activity != "" {
+	for _, part := range []string{parts.Context, parts.Branch, parts.Activity} {
+		if part == "" {
+			continue
+		}
 		if b.Len() > 0 {
 			b.WriteString(Separator)
 		}
-		b.WriteString(parts.Activity)
+		b.WriteString(part)
 	}
 	return Sanitize(b.String(), maxLen)
 }

--- a/internal/resolver/ssh_test.go
+++ b/internal/resolver/ssh_test.go
@@ -64,7 +64,7 @@ func TestTheHostBecomesTheContext(t *testing.T) {
 func TestTheTabIsNamedAfterTheMarkedHost(t *testing.T) {
 	pane := sshPane("ssh", "root@prod-01")
 
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 	if want := "ssh › prod-01"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -80,7 +80,7 @@ func TestTheHostOutranksTheWorkingDirectory(t *testing.T) {
 	// The local directory of a pane running ssh describes the wrong machine.
 	pane := sshPane("ssh", "prod-01")
 
-	if got := Default(DefaultMaxLength).Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
+	if got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
 		t.Errorf("name = %q, want %q", got.Name, "ssh › prod-01")
 	}
 }
@@ -92,7 +92,7 @@ func TestAnUnreadableDestinationStillMarksTheTabRemote(t *testing.T) {
 	for _, argv := range [][]string{nil, {"ssh"}, {"ssh", "-p", "2222"}, {"ssh", "-"}} {
 		pane := sshPane(argv...)
 
-		got := Default(DefaultMaxLength).Resolve(tabWithPane(pane))
+		got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 		if want := "ssh"; got.Name != want {
 			t.Errorf("argv %v → %q, want %q", argv, got.Name, want)
 		}
@@ -106,7 +106,7 @@ func TestAnUnreadableDestinationKeepsTheMarkUnderARemoteTitle(t *testing.T) {
 	pane := sshPane()
 	pane.TerminalTitle = "Restart the queue workers"
 
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 	if want := "ssh › Restart the queue workers"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -121,7 +121,7 @@ func TestAPaneWithoutSSHIsUnaffected(t *testing.T) {
 		},
 	}
 
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 	if strings.Contains(strings.ToLower(got.Name), "ssh") {
 		t.Errorf("name = %q, want nothing about ssh", got.Name)
 	}
@@ -139,7 +139,7 @@ func TestSSHIsFoundAmongOtherProcesses(t *testing.T) {
 		},
 	}
 
-	if got := Default(DefaultMaxLength).Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
+	if got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
 		t.Errorf("name = %q, want %q", got.Name, "ssh › prod-01")
 	}
 }
@@ -151,7 +151,7 @@ func TestTheMarkSurvivesARemoteTitle(t *testing.T) {
 	pane := sshPane("ssh", "prod-01")
 	pane.TerminalTitle = "Restart the queue workers"
 
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 	if want := "ssh › prod-01 › Restart the queue workers"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -167,7 +167,7 @@ func TestHostsFromArgvAreSanitized(t *testing.T) {
 	// argv is terminal-derived input like any other.
 	pane := sshPane("ssh", "root@prod\x1b[31m-01")
 
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
 	if strings.ContainsRune(got.Name, '\x1b') {
 		t.Errorf("name = %q, still carries an escape", got.Name)
 	}

--- a/internal/resolver/ssh_test.go
+++ b/internal/resolver/ssh_test.go
@@ -14,7 +14,7 @@ const paneCWD = "/Users/dev/work/dashboard"
 
 func sshPane(argv ...string) *state.PaneState {
 	return &state.PaneState{
-		CWD: paneCWD,
+		Dir: paneCWD,
 		Processes: []state.Process{
 			{Name: "fish", Args: []string{"-fish"}},
 			{Name: "ssh", Args: argv},
@@ -114,7 +114,7 @@ func TestAnUnreadableDestinationKeepsTheMarkUnderARemoteTitle(t *testing.T) {
 
 func TestAPaneWithoutSSHIsUnaffected(t *testing.T) {
 	pane := &state.PaneState{
-		CWD: "/Users/dev/work/dashboard",
+		Dir: "/Users/dev/work/dashboard",
 		Processes: []state.Process{
 			{Name: "fish", Args: []string{"-fish"}},
 			{Name: "nvim", Args: []string{"nvim"}},
@@ -131,7 +131,7 @@ func TestSSHIsFoundAmongOtherProcesses(t *testing.T) {
 	// Herdr lists the foreground process and its descendants, so ssh can be
 	// anywhere in the list.
 	pane := &state.PaneState{
-		CWD: "/Users/dev/work/dashboard",
+		Dir: "/Users/dev/work/dashboard",
 		Processes: []state.Process{
 			{Name: "fish", Args: []string{"-fish"}},
 			{Name: "ssh", Args: []string{"ssh", "prod-01"}},

--- a/internal/resolver/terminal_test.go
+++ b/internal/resolver/terminal_test.go
@@ -19,7 +19,7 @@ func tabWithPane(pane *state.PaneState) state.TabState {
 }
 
 func TestTerminalTitleBeatsTheWorkingDirectory(t *testing.T) {
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		CWD:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Fix OAuth redirect",
 	}))
@@ -39,7 +39,7 @@ func TestGenericTerminalTitleFallsThrough(t *testing.T) {
 	// Every one of these was observed on a live Herdr session.
 	for _, title := range []string{"zsh", "Claude Code", "node", "~", "~/W/dashboard", ""} {
 		t.Run(title, func(t *testing.T) {
-			got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+			got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 				CWD:           "/Users/dev/work/dashboard",
 				TerminalTitle: title,
 			}))
@@ -55,7 +55,7 @@ func TestGenericTerminalTitleFallsThrough(t *testing.T) {
 }
 
 func TestTerminalTitleFallsBackToTheRawField(t *testing.T) {
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		CWD:              "/Users/dev/work/dashboard",
 		TerminalTitleRaw: "\x1b[32m✳ Fix OAuth redirect\x1b[0m",
 	}))
@@ -67,7 +67,7 @@ func TestTerminalTitleFallsBackToTheRawField(t *testing.T) {
 }
 
 func TestStrippedTerminalTitleWinsOverTheRawOne(t *testing.T) {
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		CWD:              "/Users/dev/work/dashboard",
 		TerminalTitle:    "Fix OAuth redirect",
 		TerminalTitleRaw: "◐ Fix OAuth redirect",
@@ -79,7 +79,7 @@ func TestStrippedTerminalTitleWinsOverTheRawOne(t *testing.T) {
 }
 
 func TestTerminalTitleIsSanitized(t *testing.T) {
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		CWD:           "/Users/dev/work/dashboard",
 		TerminalTitle: "\x1b[31mFix OAuth\nredirect\x1b[0m\t",
 	}))
@@ -90,7 +90,7 @@ func TestTerminalTitleIsSanitized(t *testing.T) {
 }
 
 func TestLongTerminalTitleIsTruncatedAsAWhole(t *testing.T) {
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		CWD:           "/Users/dev/work/dashboard",
 		TerminalTitle: strings.Repeat("long ", 40),
 	}))
@@ -104,7 +104,7 @@ func TestLongTerminalTitleIsTruncatedAsAWhole(t *testing.T) {
 }
 
 func TestTerminalTitleWithoutAWorkingDirectory(t *testing.T) {
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		TerminalTitle: "Fix OAuth redirect",
 	}))
 
@@ -115,7 +115,7 @@ func TestTerminalTitleWithoutAWorkingDirectory(t *testing.T) {
 }
 
 func TestTerminalTitleRepeatingTheContextIsDropped(t *testing.T) {
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		CWD:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Dashboard",
 	}))
@@ -126,7 +126,7 @@ func TestTerminalTitleRepeatingTheContextIsDropped(t *testing.T) {
 }
 
 func TestTerminalTitleWithNothingElse(t *testing.T) {
-	got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		TerminalTitle: "zsh",
 	}))
 
@@ -158,7 +158,7 @@ func TestEditorTitleKeepsTheFileAndDropsThePath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.title, func(t *testing.T) {
-			got := Default(DefaultMaxLength).Resolve(tabWithPane(&state.PaneState{
+			got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 				CWD:           "/Users/dev/Work/herdr-auto-title",
 				TerminalTitle: tc.title,
 			}))

--- a/internal/resolver/terminal_test.go
+++ b/internal/resolver/terminal_test.go
@@ -20,7 +20,7 @@ func tabWithPane(pane *state.PaneState) state.TabState {
 
 func TestTerminalTitleBeatsTheWorkingDirectory(t *testing.T) {
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
-		CWD:           "/Users/dev/work/dashboard",
+		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Fix OAuth redirect",
 	}))
 
@@ -40,7 +40,7 @@ func TestGenericTerminalTitleFallsThrough(t *testing.T) {
 	for _, title := range []string{"zsh", "Claude Code", "node", "~", "~/W/dashboard", ""} {
 		t.Run(title, func(t *testing.T) {
 			got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
-				CWD:           "/Users/dev/work/dashboard",
+				Dir:           "/Users/dev/work/dashboard",
 				TerminalTitle: title,
 			}))
 
@@ -56,7 +56,7 @@ func TestGenericTerminalTitleFallsThrough(t *testing.T) {
 
 func TestTerminalTitleFallsBackToTheRawField(t *testing.T) {
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
-		CWD:              "/Users/dev/work/dashboard",
+		Dir:              "/Users/dev/work/dashboard",
 		TerminalTitleRaw: "\x1b[32m✳ Fix OAuth redirect\x1b[0m",
 	}))
 
@@ -68,7 +68,7 @@ func TestTerminalTitleFallsBackToTheRawField(t *testing.T) {
 
 func TestStrippedTerminalTitleWinsOverTheRawOne(t *testing.T) {
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
-		CWD:              "/Users/dev/work/dashboard",
+		Dir:              "/Users/dev/work/dashboard",
 		TerminalTitle:    "Fix OAuth redirect",
 		TerminalTitleRaw: "◐ Fix OAuth redirect",
 	}))
@@ -80,7 +80,7 @@ func TestStrippedTerminalTitleWinsOverTheRawOne(t *testing.T) {
 
 func TestTerminalTitleIsSanitized(t *testing.T) {
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
-		CWD:           "/Users/dev/work/dashboard",
+		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "\x1b[31mFix OAuth\nredirect\x1b[0m\t",
 	}))
 
@@ -91,7 +91,7 @@ func TestTerminalTitleIsSanitized(t *testing.T) {
 
 func TestLongTerminalTitleIsTruncatedAsAWhole(t *testing.T) {
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
-		CWD:           "/Users/dev/work/dashboard",
+		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: strings.Repeat("long ", 40),
 	}))
 
@@ -116,7 +116,7 @@ func TestTerminalTitleWithoutAWorkingDirectory(t *testing.T) {
 
 func TestTerminalTitleRepeatingTheContextIsDropped(t *testing.T) {
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
-		CWD:           "/Users/dev/work/dashboard",
+		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Dashboard",
 	}))
 
@@ -159,7 +159,7 @@ func TestEditorTitleKeepsTheFileAndDropsThePath(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.title, func(t *testing.T) {
 			got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
-				CWD:           "/Users/dev/Work/herdr-auto-title",
+				Dir:           "/Users/dev/Work/herdr-auto-title",
 				TerminalTitle: tc.title,
 			}))
 

--- a/internal/state/tab.go
+++ b/internal/state/tab.go
@@ -16,8 +16,9 @@ import (
 type PaneState struct {
 	ID string
 
-	CWD           string
-	ForegroundCWD string
+	// Dir is the directory this pane speaks for, already chosen between the
+	// shell's and the foreground process's.
+	Dir string
 	// TerminalTitle is Herdr's cleaned title; TerminalTitleRaw still carries
 	// escapes and decorative prefixes and is only a fallback.
 	TerminalTitle    string
@@ -57,8 +58,7 @@ func PaneFrom(info herdr.PaneInfo, processes []herdr.PaneProcessInfoProcess,
 ) *PaneState {
 	return &PaneState{
 		ID:               info.PaneID,
-		CWD:              info.CWD,
-		ForegroundCWD:    info.ForegroundCWD,
+		Dir:              info.Dir(),
 		TerminalTitle:    info.TerminalTitleStripped,
 		TerminalTitleRaw: info.TerminalTitle,
 		Agent:            info.Agent,

--- a/internal/state/tab.go
+++ b/internal/state/tab.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kryptamine/herdr-auto-title/internal/git"
 	"github.com/kryptamine/herdr-auto-title/internal/herdr"
 )
 
@@ -33,6 +34,10 @@ type PaneState struct {
 	// Processes are the pane's foreground process and its descendants.
 	Processes []Process
 
+	// Git is what the repository holding the pane's directory has checked out,
+	// zero outside a repository.
+	Git git.Checkout
+
 	Focused bool
 	// ChangedAt is when a poll last saw this pane's revision advance.
 	// Snapshots carry no timestamp, so it is the only ordering available.
@@ -47,7 +52,9 @@ type Process struct {
 }
 
 // PaneFrom builds pane context from what a read returned.
-func PaneFrom(info herdr.PaneInfo, processes []herdr.PaneProcessInfoProcess, changedAt time.Time) *PaneState {
+func PaneFrom(info herdr.PaneInfo, processes []herdr.PaneProcessInfoProcess,
+	checkout git.Checkout, changedAt time.Time,
+) *PaneState {
 	return &PaneState{
 		ID:               info.PaneID,
 		CWD:              info.CWD,
@@ -59,6 +66,7 @@ func PaneFrom(info herdr.PaneInfo, processes []herdr.PaneProcessInfoProcess, cha
 		AgentTitle:       info.Title,
 		AgentStatus:      info.AgentStatus,
 		Processes:        processesFrom(processes),
+		Git:              checkout,
 		Focused:          info.Focused,
 		ChangedAt:        changedAt,
 	}

--- a/internal/state/tab_test.go
+++ b/internal/state/tab_test.go
@@ -45,7 +45,7 @@ func TestTabFromKeepsItsLabel(t *testing.T) {
 		herdr.TabInfo{TabID: "wE:t1", Label: "dashboard"},
 		"dashboard",
 		1,
-		[]*PaneState{{ID: "wE:p1", CWD: "/work/dashboard"}},
+		[]*PaneState{{ID: "wE:p1", Dir: "/work/dashboard"}},
 	)
 
 	if tab.CurrentName != "dashboard" {
@@ -57,8 +57,8 @@ func TestTabFromKeepsItsLabel(t *testing.T) {
 	if tab.DefaultName != "1" {
 		t.Errorf("default name = %q, want the tab's position 1", tab.DefaultName)
 	}
-	if pane := tab.Panes["wE:p1"]; pane == nil || pane.CWD != "/work/dashboard" {
-		t.Errorf("pane wE:p1 = %+v, want cwd /work/dashboard", pane)
+	if pane := tab.Panes["wE:p1"]; pane == nil || pane.Dir != "/work/dashboard" {
+		t.Errorf("pane wE:p1 = %+v, want dir /work/dashboard", pane)
 	}
 }
 
@@ -193,5 +193,23 @@ func TestAgentIsActiveOnANilPane(t *testing.T) {
 	var pane *PaneState
 	if pane.HasAgent() || pane.AgentIsActive() {
 		t.Fatal("a nil pane reported an agent")
+	}
+}
+
+func TestPaneFromPrefersTheShellsDirectory(t *testing.T) {
+	// foreground_cwd follows whatever is running right now, so it only speaks
+	// when the shell's own directory is missing.
+	both := PaneFrom(herdr.PaneInfo{
+		PaneID: "wE:p1", CWD: "/work/dashboard", ForegroundCWD: "/tmp",
+	}, nil, git.Checkout{}, time.Now())
+	if both.Dir != "/work/dashboard" {
+		t.Errorf("dir = %q, want the shell's own", both.Dir)
+	}
+
+	foreground := PaneFrom(herdr.PaneInfo{
+		PaneID: "wE:p1", ForegroundCWD: "/work/api",
+	}, nil, git.Checkout{}, time.Now())
+	if foreground.Dir != "/work/api" {
+		t.Errorf("dir = %q, want the foreground process's", foreground.Dir)
 	}
 }

--- a/internal/state/tab_test.go
+++ b/internal/state/tab_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kryptamine/herdr-auto-title/internal/git"
 	"github.com/kryptamine/herdr-auto-title/internal/herdr"
 )
 
@@ -72,7 +73,7 @@ func TestPaneFromReadsAgentContext(t *testing.T) {
 		Agent:                 "claude",
 		DisplayAgent:          "Claude Code",
 		AgentStatus:           herdr.AgentStatusWorking,
-	}, nil, stamp)
+	}, nil, git.Checkout{}, stamp)
 
 	switch {
 	case pane.TerminalTitle != "Claude Code":
@@ -89,7 +90,7 @@ func TestPaneFromReadsAgentContext(t *testing.T) {
 }
 
 func TestPaneWithoutAnAgent(t *testing.T) {
-	pane := PaneFrom(herdr.PaneInfo{PaneID: "wE:p1", AgentStatus: herdr.AgentStatusUnknown}, nil, time.Now())
+	pane := PaneFrom(herdr.PaneInfo{PaneID: "wE:p1", AgentStatus: herdr.AgentStatusUnknown}, nil, git.Checkout{}, time.Now())
 	if pane.HasAgent() || pane.AgentIsActive() {
 		t.Errorf("pane %+v reported an agent", pane)
 	}


### PR DESCRIPTION
A tab in a repository now carries the branch it has checked out, between
the directory and the work: `global-sso › feat/oauth › nvim › auth.ts`.

## Why this is not the source that was removed

A branch source existed and was dropped in 2d90d74, for two reasons. This
one answers both.

**It sat in the activity slot**, below the terminal title, so it spoke
only for a plain shell in a repository — invisible in exactly the panes
worth naming. The branch belongs to the *context*: it says which slice of
a project a tab is on, which is part of where you are, not of what you
are doing. From the context it survives an agent pane and a titled editor.

**It guessed.** `develop` was a word every tab carried alike, and
`fix/filter-sentry-errors-…` was cut down to `filter`. Now the trunk is
whatever the repository itself records in `origin/HEAD` — a team whose
trunk is `develop` gets the same silence — and a branch name that fits is
left whole, so `feat/oauth` keeps the namespace that tells it from
`fix/oauth`. Only an over-long name is reduced, and there a tracker key
wins (`bugfix-asa-cpanel-uapi-mc-13675` → `MC-13675`).

## Behaviour

| Case | Title |
|---|---|
| the repository's default branch | no branch shown |
| no `origin/HEAD` recorded | branch always shown |
| detached HEAD | short hash (`a1b2c3d`) |
| rebase in progress | the branch it set aside, not a hash that moves each step |
| worktree, submodule | followed through `gitdir:` and `commondir` |
| pane running ssh | no branch — it is the local one, and would read as the remote machine's |
| directory equals the workspace name | directory dropped, branch kept |

`HERDR_AUTO_TITLE_BRANCH_MAX` is back: 12 columns by default, `0` turns
branches off — and turns off the read, not just its result.

## How it reads the branch

By reading `.git` directly, never by running git. Measured on this
machine: `git rev-parse` 12.37 ms median, reading `HEAD` 0.019 ms, against
a session snapshot at 0.47 ms. The read is not cached — 0.038 ms per pane
including the walk up the tree is cheaper than the bookkeeping a stale
answer would need — and it lives in the poll loop, so the resolver stays a
pure function of state.

The reasoning is recorded in `docs/architecture/title-resolution.md`,
beside the argument it overturns.

## Not in scope

Two tabs in the same directory on the same branch still get identical
names. Deduplicating tab titles is its own change.

## Testing

`make check` on every commit. Fixtures build `.git` from files rather
than by running git, so the tests do not depend on what is installed;
worktrees, both rebase backends, `pack-refs --all` and detached HEAD were
also verified against real repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)