### PR TITLE
feat: put each tab's position in front of its title

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,22 +50,26 @@ will run.
 ## What your tabs will be called
 
 ```
-~/work/dashboard                       →  dashboard
-~/work/dashboard on feature/MC-13200   →  dashboard › MC-13200
-nvim editing auth.provider.ts          →  nvim › auth.provider.ts
-an agent working on OAuth scopes       →  dashboard › claude › Implement OAuth scopes
-ssh into prod-01                       →  ssh › prod-01
-$HOME                                  →  Shell
+~/work/dashboard                       →  1 · dashboard
+~/work/dashboard on feature/MC-13200   →  2 · dashboard › MC-13200
+nvim editing auth.provider.ts          →  3 · nvim › auth.provider.ts
+an agent working on OAuth scopes       →  4 · dashboard › claude › Implement OAuth scopes
+ssh into prod-01                       →  5 · ssh › prod-01
+$HOME                                  →  6 · Shell
 ```
 
-Titles read `<context> › <activity>`, capped at 64 columns of the tab bar. The
-activity is the first of these that has something to say: what an agent reports
-it is working on, then the terminal title, then a lone program in the pane. The
-context is the directory you are in, or the machine you reached over `ssh`, and
-the branch you have checked out qualifies it.
+Titles read `<position> · <context> › <activity>`, capped at 64 columns of the
+tab bar. The activity is the first of these that has something to say: what an
+agent reports it is working on, then the terminal title, then a lone program in
+the pane. The context is the directory you are in, or the machine you reached
+over `ssh`, and the branch you have checked out qualifies it.
 
-Four rules explain most surprises:
+These rules explain most surprises:
 
+- **The number in front is the tab's place in the workspace**, which is the key
+  that switches to it. It leads the title because the tab bar cuts the tail of
+  a title too wide for it, and it moves with the tab when one to its left
+  closes. `HERDR_AUTO_TITLE_POSITION=false` leaves it out.
 - Auto Title never repeats your workspace name, because Herdr already shows it
   above the tabs.
 - **A branch shows when it distinguishes.** Your repository's own default

--- a/cmd/herdr-auto-title/main.go
+++ b/cmd/herdr-auto-title/main.go
@@ -46,7 +46,11 @@ func run() error {
 		return err
 	}
 
-	titles := resolver.Default(cfg.MaxLength, cfg.BranchMax)
+	chain := resolver.Default(cfg.MaxLength, cfg.BranchMax)
+	var titles resolver.TitleResolver = chain
+	if cfg.ShowPosition {
+		titles = resolver.NewNumbered(chain)
+	}
 
 	app.New(cfg, log, titles).Run(ctx, client)
 	return nil

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -18,7 +18,7 @@ that settled it.
 | Note | What it covers |
 |------|----------------|
 | [The poll loop](./poll-loop.md) | Why polling beats the event stream, what one poll does, what survives between polls, and how the loop behaves when Herdr is unreachable |
-| [Title resolution](./title-resolution.md) | Which pane speaks for a tab, the confidence ladder, what each source contributes, and why the workspace name is not repeated |
+| [Title resolution](./title-resolution.md) | Which pane speaks for a tab, the confidence ladder, what each source contributes, why the workspace name is not repeated, and why the tab position leads the title |
 | [Sanitizing untrusted values](./sanitization.md) | What is stripped from terminal-derived values, what is rejected as saying nothing, and why the length limit is counted in columns |
 | [Manual rename protection](./manual-rename-protection.md) | Telling your rename from the plugin's own using nothing but successive polls, and what that costs |
 | [Herdr socket API](./herdr-socket-api.md) | The wire protocol and the measured facts about Herdr 0.8.2 that everything else rests on |

--- a/docs/architecture/title-resolution.md
+++ b/docs/architecture/title-resolution.md
@@ -1,7 +1,7 @@
 ---
 type: doc
 title: 'Title Resolution'
-description: 'How a tab becomes a name: which pane speaks for the tab, the confidence ladder the sources order themselves by, what each source contributes, and the rules that keep a title from repeating itself.'
+description: 'How a tab becomes a name: which pane speaks for the tab, the confidence ladder the sources order themselves by, what each source contributes, the rules that keep a title from repeating itself, and why the tab position rides in front of it.'
 tags: [architecture]
 created: 2026-08-25
 generated: { by: claude-code/opus-5, at: 2026-08-25T12:46:22+03:00 }
@@ -10,16 +10,17 @@ generated: { by: claude-code/opus-5, at: 2026-08-25T12:46:22+03:00 }
 # Title Resolution
 
 A title reads as a path from the general to the particular, with one separator
-throughout:
+throughout, behind the number of the tab it names:
 
 ```
-self-care-portal › nvim › auth.provider.ts
+3 · self-care-portal › nvim › auth.provider.ts
 ```
 
 Where a part came from — a directory, a program, a file — is not something a
 separator can convey, and a second one would only ask the reader to learn a
-distinction they cannot see. So there is exactly one, `Separator`
-(`internal/resolver/sanitize.go`).
+distinction they cannot see. So every part shares one, `Separator`
+(`internal/resolver/sanitize.go`). The number in front is not a part of the
+title, and [carries a mark of its own](#the-position-is-not-a-part-of-the-title).
 
 Structurally a title is three fields, `Parts{Context, Branch, Activity}`
 (`internal/resolver/resolver.go`): *where* the user is and *what* they are
@@ -56,6 +57,8 @@ rather than by the order the sources happen to be listed in
 | 40 | Git branch | `git.go` | Branch |
 | 30 | Working directory | `cwd.go` | Context |
 | 10 | Generic fallback | `resolver.go` | the whole name (`Shell`) |
+
+The tab's position is not on this ladder, and [why is below](#the-position-is-not-a-part-of-the-title).
 
 **A source never overrides a field a higher-priority source already supplied**,
 but a lower one can still complete the other half. That is why the working
@@ -198,3 +201,35 @@ has left its workspace behind is exactly the one that keeps saying where it is.
 A branch counts as something remaining, and the match is against the directory
 alone, so a tab in the workspace of the repository it is in reads `feat/oauth ›
 nvim`: the half that repeats goes, the half that distinguishes stays.
+
+## The position is not a part of the title
+
+Every title carries the tab's place in its workspace in front of it, which is
+the key that switches to that tab: `3 · dashboard › nvim`. Herdr labels an
+unnamed tab with that same position, so naming a tab is what takes the number
+away — and a tab bar of names is a tab bar the user has to count along to reach
+the fourth one.
+
+**It is a decorator, `Numbered` (`internal/resolver/position.go`), not a
+source.** A source answers what a tab is about from what a pane holds; the
+position says nothing about that and comes from the workspace instead. Wrapping
+the resolver keeps the ladder about content, and keeps `Resolve` returning the
+label that will actually be set — which is what the manual-rename bookkeeping
+compares against.
+
+Three things follow from what the tab bar does with a title:
+
+- **The position leads.** Truncation cuts the tail (see
+  [Sanitization](sanitization.md)), so a position at the end is the first thing
+  a long title loses — exactly the titles a user is scanning when they reach
+  for a key. In front it also puts every number in one column.
+- **The mark is `·`, not `›`.** The parts separator would read as if the
+  position were one more thing the title says about the tab.
+- **It is counted against `MaxLength`, not added to it.** The decorator reads
+  that bound off the resolver it wraps rather than being handed one of its own,
+  so there are not two numbers to keep in step. The body is re-sanitized to
+  what the prefix leaves, and truncating an already-truncated title again is
+  the same cut, one column further in. Where nothing would be left — a tab bar
+  narrower than the number itself — the number goes and the name stays.
+
+`HERDR_AUTO_TITLE_POSITION=false` drops the decorator.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,6 +5,7 @@ package app
 import (
 	"context"
 	"log/slog"
+	"strconv"
 	"time"
 
 	"github.com/kryptamine/herdr-auto-title/internal/git"
@@ -135,7 +136,7 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 			TabID:   tab.ID,
 			Current: tab.CurrentName,
 			Desired: decision.Name,
-			Default: tab.DefaultName,
+			Default: strconv.Itoa(tab.Position),
 		}) {
 			a.log.Info("leaving a tab the user renamed", "tab_id", tab.ID, "name", tab.CurrentName)
 			continue

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -17,6 +17,7 @@ const (
 	EnvPoll      = "HERDR_AUTO_TITLE_POLL_MS"
 	EnvMaxLength = "HERDR_AUTO_TITLE_MAX_LENGTH"
 	EnvBranchMax = "HERDR_AUTO_TITLE_BRANCH_MAX"
+	EnvPosition  = "HERDR_AUTO_TITLE_POSITION"
 	EnvManual    = "HERDR_AUTO_TITLE_MANUAL_FILE"
 )
 
@@ -35,6 +36,9 @@ type Config struct {
 	// BranchMax bounds what a git branch may add to a title. Zero leaves
 	// branches out of titles entirely.
 	BranchMax int
+	// ShowPosition puts each tab's position in front of its title, which is
+	// the key that switches to that tab.
+	ShowPosition bool
 	// ManualPath is where tabs the user renamed by hand are remembered across
 	// restarts. Empty keeps them in memory only.
 	ManualPath string
@@ -45,10 +49,11 @@ type Config struct {
 // plugin from running.
 func LoadConfig() (Config, []string) {
 	cfg := Config{
-		Poll:       DefaultPoll,
-		MaxLength:  resolver.DefaultMaxLength,
-		BranchMax:  resolver.DefaultBranchMaxLength,
-		ManualPath: state.DefaultManualPath(),
+		Poll:         DefaultPoll,
+		MaxLength:    resolver.DefaultMaxLength,
+		BranchMax:    resolver.DefaultBranchMaxLength,
+		ShowPosition: true,
+		ManualPath:   state.DefaultManualPath(),
 	}
 	var warnings []string
 
@@ -57,6 +62,7 @@ func LoadConfig() (Config, []string) {
 	cfg.MaxLength = fromEnv(&warnings, EnvMaxLength, cfg.MaxLength, count)
 	// Zero is meaningful here, and only here: it leaves branches out of titles.
 	cfg.BranchMax = fromEnv(&warnings, EnvBranchMax, cfg.BranchMax, countOrNone)
+	cfg.ShowPosition = fromEnv(&warnings, EnvPosition, cfg.ShowPosition, boolean)
 	// A path needs neither parsing nor checking, so it does not go through
 	// fromEnv: any string the user set is the path they meant.
 	if raw := os.Getenv(EnvManual); raw != "" {

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -12,7 +12,7 @@ import (
 // sets and the environment the tests run in cannot change the outcome.
 func isolate(t *testing.T) {
 	t.Helper()
-	for _, name := range []string{EnvDebug, EnvPoll, EnvMaxLength, EnvBranchMax, EnvManual} {
+	for _, name := range []string{EnvDebug, EnvPoll, EnvMaxLength, EnvBranchMax, EnvPosition, EnvManual} {
 		t.Setenv(name, "")
 	}
 }
@@ -35,6 +35,22 @@ func TestLoadConfigDefaults(t *testing.T) {
 	}
 	if cfg.BranchMax != resolver.DefaultBranchMaxLength {
 		t.Errorf("branch max = %d, want %d", cfg.BranchMax, resolver.DefaultBranchMaxLength)
+	}
+	if !cfg.ShowPosition {
+		t.Error("positions are off by default")
+	}
+}
+
+func TestLoadConfigTurnsPositionsOff(t *testing.T) {
+	isolate(t)
+	t.Setenv(EnvPosition, "false")
+
+	cfg, warnings := LoadConfig()
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want none", warnings)
+	}
+	if cfg.ShowPosition {
+		t.Error("positions are on despite being disabled")
 	}
 }
 

--- a/internal/resolver/position.go
+++ b/internal/resolver/position.go
@@ -1,0 +1,53 @@
+package resolver
+
+import (
+	"strconv"
+
+	"github.com/rivo/uniseg"
+
+	"github.com/kryptamine/herdr-auto-title/internal/state"
+)
+
+// positionMark separates a tab's position from the name that follows it. It is
+// deliberately not Separator: the position is not one of the things a title
+// says about a tab, and the parts separator would read as if it were.
+const positionMark = " · "
+
+// Numbered prefixes every title with its tab's position, which is the key that
+// switches to that tab. It wraps a resolver rather than being part of one: the
+// position says nothing about what a tab holds, so no source can supply it.
+type Numbered struct {
+	inner *Deterministic
+}
+
+var _ TitleResolver = (*Numbered)(nil)
+
+// NewNumbered wraps inner. It takes no width of its own: the position is
+// counted against inner's bound rather than added on top of it, and two
+// numbers to keep in step would only be one to get wrong.
+func NewNumbered(inner *Deterministic) *Numbered {
+	return &Numbered{inner: inner}
+}
+
+// Resolve names the tab and puts its position in front, unless the tab bar is
+// too narrow to carry both.
+func (n *Numbered) Resolve(tab state.TabState) Decision {
+	decision := n.inner.Resolve(tab)
+
+	// The prefix goes in front because truncation cuts the tail: a position at
+	// the end is the first thing a title too wide for the tab bar would lose.
+	prefix := strconv.Itoa(tab.Position) + positionMark
+	room := n.inner.maxLength - uniseg.StringWidth(prefix)
+	// Sanitize takes a width of zero as "no bound at all", and a title reduced
+	// to nothing has lost more than the position is worth.
+	if room <= 0 {
+		return decision
+	}
+	name := Sanitize(decision.Name, room)
+	if name == "" {
+		return decision
+	}
+
+	decision.Name = prefix + name
+	return decision
+}

--- a/internal/resolver/position_test.go
+++ b/internal/resolver/position_test.go
@@ -1,0 +1,77 @@
+package resolver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rivo/uniseg"
+
+	"github.com/kryptamine/herdr-auto-title/internal/state"
+)
+
+// numberedCWD names a tab after its directory and puts its position in front.
+func numberedCWD(maxLength int) *Numbered {
+	return NewNumbered(New(maxLength, NewCWD()))
+}
+
+// atPosition builds a one-pane tab sitting at a position in its workspace.
+func atPosition(position int, dir string) state.TabState {
+	tab := tabWithCWD(dir)
+	tab.Position = position
+	return tab
+}
+
+func TestPositionLeadsTheTitle(t *testing.T) {
+	r := numberedCWD(DefaultMaxLength)
+
+	tests := []struct {
+		name     string
+		position int
+		dir      string
+		want     string
+	}{
+		{"the first tab", 1, "/Users/dev/work/dashboard", "1 · dashboard"},
+		{"a tab past the ninth", 12, "/Users/dev/work/dashboard", "12 · dashboard"},
+		{"a tab with nothing to say", 3, "/", "3 · " + GenericFallback},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := r.Resolve(atPosition(tc.position, tc.dir)); got.Name != tc.want {
+				t.Errorf("name = %q, want %q", got.Name, tc.want)
+			}
+		})
+	}
+}
+
+func TestPositionKeepsTheDecisionItWraps(t *testing.T) {
+	got := numberedCWD(DefaultMaxLength).Resolve(atPosition(1, "/Users/dev/work/dashboard"))
+	if got.Reason != "cwd" {
+		t.Errorf("reason = %q, want cwd", got.Reason)
+	}
+	if got.Confidence != ConfidenceCWD {
+		t.Errorf("confidence = %d, want %d", got.Confidence, ConfidenceCWD)
+	}
+}
+
+func TestAPositionIsCountedAgainstTheWidth(t *testing.T) {
+	const maxLength = 16
+	long := "/Users/dev/work/" + strings.Repeat("a", 40)
+
+	got := numberedCWD(maxLength).Resolve(atPosition(7, long))
+	if width := uniseg.StringWidth(got.Name); width > maxLength {
+		t.Errorf("name %q is %d columns wide, want at most %d", got.Name, width, maxLength)
+	}
+	if !strings.HasPrefix(got.Name, "7 · ") {
+		t.Errorf("name = %q, want it to lead with its position", got.Name)
+	}
+}
+
+// A tab bar narrower than the position itself keeps the name over the number:
+// a title cut down to nothing has lost more than the position is worth.
+func TestAPositionWithNoRoomIsDropped(t *testing.T) {
+	got := numberedCWD(3).Resolve(atPosition(10, "/Users/dev/work/dashboard"))
+	if got.Name != "das" {
+		t.Errorf("name = %q, want the bare title", got.Name)
+	}
+}

--- a/internal/resolver/sanitize.go
+++ b/internal/resolver/sanitize.go
@@ -8,9 +8,9 @@ import (
 	"github.com/rivo/uniseg"
 )
 
-// Separator joins every part of a title, and there is only one: where a part
-// came from is not something a separator can convey, and a second kind would
-// ask the reader to learn a distinction they cannot see.
+// Separator joins the parts of a title, and every part shares it: where a part
+// came from is not something a separator can convey. A tab's position is not a
+// part of its title and carries a mark of its own.
 const Separator = " " + separatorRune + " "
 
 const separatorRune = "›"

--- a/internal/state/tab.go
+++ b/internal/state/tab.go
@@ -4,7 +4,6 @@ package state
 
 import (
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -109,11 +108,12 @@ type TabState struct {
 	CurrentName string
 	// WorkspaceName is the label Herdr shows above this tab.
 	WorkspaceName string
-	// DefaultName is the label Herdr gives an unnamed tab: its place in the
-	// workspace, counted from one. Not TabInfo.number, which is a counter that
-	// never repeats — see docs/architecture/herdr-socket-api.md.
-	DefaultName string
-	Panes       map[string]*PaneState
+	// Position is the tab's place in its workspace, counted from one, which is
+	// both the key that switches to it and the label Herdr gives it while it
+	// is unnamed. Not TabInfo.number, which is a counter that never repeats —
+	// see docs/architecture/herdr-socket-api.md.
+	Position int
+	Panes    map[string]*PaneState
 }
 
 // TabFrom builds tab state from what a read returned. Position is the tab's
@@ -123,7 +123,7 @@ func TabFrom(info herdr.TabInfo, workspaceName string, position int, panes []*Pa
 		ID:            info.TabID,
 		CurrentName:   info.Label,
 		WorkspaceName: workspaceName,
-		DefaultName:   strconv.Itoa(position),
+		Position:      position,
 		Panes:         make(map[string]*PaneState, len(panes)),
 	}
 	for _, pane := range panes {

--- a/internal/state/tab_test.go
+++ b/internal/state/tab_test.go
@@ -54,8 +54,8 @@ func TestTabFromKeepsItsLabel(t *testing.T) {
 	if tab.WorkspaceName != "dashboard" {
 		t.Errorf("workspace name = %q, want dashboard", tab.WorkspaceName)
 	}
-	if tab.DefaultName != "1" {
-		t.Errorf("default name = %q, want the tab's position 1", tab.DefaultName)
+	if tab.Position != 1 {
+		t.Errorf("position = %d, want the tab's place in its workspace 1", tab.Position)
 	}
 	if pane := tab.Panes["wE:p1"]; pane == nil || pane.Dir != "/work/dashboard" {
 		t.Errorf("pane wE:p1 = %+v, want dir /work/dashboard", pane)


### PR DESCRIPTION
Herdr labels an unnamed tab with its position in the workspace, and that
position is the key that switches to the tab. Naming a tab is therefore what
takes the key away: a tab bar of names has to be counted along to reach the
fourth one. Every generated title now carries that position in front of it.

```
1 · dashboard › MC-13200
2 · nvim › auth.provider.ts
3 · claude › Implement OAuth scopes
10 · ssh › prod-01
```

## What it does

- The position **leads** the title. Truncation cuts the tail, so a position at
  the end is the first thing a long title loses — exactly the title a user is
  scanning when they reach for a key. In front it also puts every number in one
  column.
- It carries a **mark of its own**, `·`, not the parts separator `›`: the
  position is not one of the things a title says about a tab, and `›` would
  read as if it were.
- It is **counted against `MaxLength`**, not added on top of it. The decorator
  reads that bound off the resolver it wraps, so there are not two widths to
  keep in step. Where nothing would be left, the number goes and the name stays.
- Every position is numbered, past the ninth included, so the behaviour is
  uniform even where a workspace has more tabs than keys.
- **Tabs renamed by hand are untouched**, as before: a locked tab never reaches
  the resolver.
- `HERDR_AUTO_TITLE_POSITION=false` leaves the position out.

## How

`Numbered` (`internal/resolver/position.go`) wraps a `TitleResolver` rather
than sitting on the confidence ladder as a source: the position says nothing
about what a tab holds, so no source could supply it. Wrapping also keeps
`Resolve` returning the label that will actually be set, which is what the
manual-rename bookkeeping compares against — that path is unchanged.

`TabState` now keeps the position as a number instead of the pre-formatted
label, which is the first commit and stands on its own.

## Notes

`internal/resolver/sanitize.go` and `docs/architecture/title-resolution.md`
both asserted that a title has exactly one separator. Both now say that every
*part* shares one and that the position is marked off differently, rather than
being left to contradict the code.

Docs: a new section in
[title-resolution.md](docs/architecture/title-resolution.md), plus README.

`make check` passes, and so does the first commit on its own.
