### PR TITLE
feat: name an agent tab from the session its agent holds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,16 @@ listed here** (`make probe-*`, `scripts/probe.py`).
   `pane_id`.
 - `PaneInfo.title` is the agent's own title. It was null for every Claude Code
   pane observed; that agent reports its topic through `terminal_title_stripped`.
+  `pane.report_metadata` sets it from outside Herdr (probed: a reported title
+  reached the snapshot and a tab within one poll), but nothing installs a source
+  for it today.
+- `PaneInfo.agent_session` says which conversation a pane's agent holds, and is
+  null until that agent's integration reports one.
+  `herdr integration install <agent>` installs the hook (`herdr integration
+  status` lists all seventeen). Claude Code's runs on `SessionStart` and calls
+  `pane.report_agent_session`; Herdr keeps only the id, answering `kind: "id"`
+  even when a transcript path was reported too. It arrives in the snapshot, so
+  reading it costs no request.
 - `agent_status` is `idle | working | blocked | done | unknown`; a pane with no
   agent reports `unknown`. `TabInfo` carries one too, aggregated over the tab's
   panes: with a single Claude Code pane working, its tab reported `working`
@@ -175,10 +185,12 @@ which carries the same facts in full.
   background, and check `make ps` when something behaves oddly.
 - **Decide from freshly read state.** Every poll reads the session and throws
   the result away again. What is carried between polls is only what a snapshot
-  cannot say: when each pane last changed, and what it was running when it was
-  last asked — the latter reused only until that pane's revision moves, and for
-  no longer than `processRefresh` either way, because a revision does not track
-  what runs in a pane.
+  cannot say: when each pane last changed, what it was running when it was last
+  asked — reused only until that pane's revision moves, and for no longer than
+  `processRefresh` either way, because a revision does not track what runs in a
+  pane — and how far each agent transcript has been read, because a transcript
+  only grows and re-reading megabytes twice a second to find one new line would
+  cost more than the rest of the loop together.
 - Never pass terminal-derived values to a shell. Renames go over the socket API.
 - How the plugin works and why — the poll loop, title resolution, sanitizing
   untrusted values, manual rename protection — is in

--- a/README.md
+++ b/README.md
@@ -43,6 +43,47 @@ Herdr clones the repository, builds the binary and registers it. Until the
 server has restarted, nothing is renamed. `herdr plugin list` shows the plugin,
 `herdr plugin disable` turns it off.
 
+### Better names for agent tabs
+
+A coding agent usually says what it is working on through its terminal title,
+and that is where Auto Title reads it. Claude Code has one blind spot: a session
+you opened with a slash command and never typed a prompt into is never given a
+title, so its tab stays `claude`. One command closes it:
+
+```sh
+herdr integration install claude
+```
+
+That is Herdr's own hook, not this plugin's. It tells Herdr which session each
+pane is holding, which lets Auto Title read the topic from the session itself.
+Reading transcripts can be turned off with `HERDR_AUTO_TITLE_TRANSCRIPT=false`.
+
+**Only Claude Code is read so far.** Herdr installs the same hook for seventeen
+agents (`herdr integration status`), and Auto Title accepts the session it
+reports from any of them — but every agent keeps its own transcript in its own
+format, so each needs a reader of its own:
+
+- [x] `claude` — Claude Code
+- [ ] `antigravity-cli`
+- [ ] `codex`
+- [ ] `copilot`
+- [ ] `cursor`
+- [ ] `devin`
+- [ ] `droid`
+- [ ] `grok`
+- [ ] `hermes`
+- [ ] `kilo`
+- [ ] `kimi`
+- [ ] `mastracode`
+- [ ] `omp`
+- [ ] `opencode`
+- [ ] `pi`
+- [ ] `qodercli`
+- [ ] `qwen`
+
+An agent that is not ticked loses nothing: its tab is named from its terminal
+title, exactly as before.
+
 Working on the plugin rather than using it? [Development](docs/development.md)
 covers linking a local checkout, which Herdr makes you unlink before `install`
 will run.
@@ -81,6 +122,8 @@ These rules explain most surprises:
 - A tab with several panes takes its name from one of them: the focused pane, a
   pane running a busy agent, or the pane that changed last.
 - **A tab you renamed is yours.** Auto Title never touches it again.
+- An agent tab can also be named from the agent's own session — see
+  [better names for agent tabs](#better-names-for-agent-tabs).
 
 > [!WARNING]
 > Renaming it again does not hand it back. To get automatic naming for that tab,

--- a/docs/architecture/herdr-socket-api.md
+++ b/docs/architecture/herdr-socket-api.md
@@ -106,6 +106,22 @@ reads, so this section describes Herdr rather than those types.
   through `terminal_title_stripped` instead. This is why most agent context
   reaches a title one rung below the agent source — see
   [title resolution](./title-resolution.md).
+- **`PaneInfo.agent_session` says which conversation the pane's agent holds**,
+  and it is null until an agent's integration reports one.
+  `herdr integration install <agent>` installs the hook that does — Herdr ships
+  one for seventeen agents, Claude Code among them, and `herdr integration
+  status` lists them with the path each is written to. The Claude hook runs on
+  `SessionStart` and calls `pane.report_agent_session` with the session id and
+  the transcript path; Herdr keeps only the id, answering `kind: "id"` even when
+  both were reported, so a reader that wants the file finds it by id. Auto Title
+  reads it from the snapshot — no extra request — and what it does with it is in
+  [title resolution](./title-resolution.md).
+- **`pane.report_metadata` is how anything outside Herdr sets `PaneInfo.title`.**
+  Probed directly: `herdr pane report-metadata <pane> --source X --title T` put
+  `T` in the snapshot's `title` and a tab bearing it appeared within one poll;
+  `--clear-title` undid it. Nothing installs a source for it today, which is why
+  `title` is null in practice. It also carries `--display-agent`,
+  `--state-label`, `--token` and a `--ttl-ms`.
 - **`agent_status` is `idle | working | blocked | done | unknown`.** Every pane
   carries one, and a pane with no agent reports `unknown`. `TabInfo` carries one
   as well, aggregated over the tab's panes: with a single Claude Code pane

--- a/docs/architecture/poll-loop.md
+++ b/docs/architecture/poll-loop.md
@@ -55,7 +55,7 @@ name is derived from the state read for that poll, which is what makes the
 resolver's determinism worth anything: identical session state always yields an
 identical title.
 
-Three things are carried between polls, and each exists because a snapshot
+Four things are carried between polls, and each exists because a snapshot
 cannot express it:
 
 - **When each pane last changed** (`internal/state/changes.go`). A snapshot says
@@ -80,6 +80,20 @@ cannot express it:
   provokes. So the reuse is bounded twice: by the revision, which catches the
   common case in the very next poll, and by `processRefresh` (2 s), which is
   what actually bounds how wrong the answer can be.
+- **How far each agent transcript has been read** (`internal/claude/transcript.go`).
+  A transcript is append-only, so a poll reads the bytes appended since the last
+  one rather than the file: a session that has run all day is megabytes, and
+  re-reading it twice a second to learn the one line that changed would cost
+  more than every other read in the loop together. What is kept per session is a
+  path, a byte offset and the topic read so far. Sessions the snapshot no longer
+  holds are dropped the same way panes are.
+
+  A session whose transcript is *not* found is remembered too. Herdr can name a
+  session before the agent has written a line of it, so the search has to be
+  repeated — but finding the file means scanning every project directory the
+  user has, and doing that twice a second for the life of a pane costs more than
+  every other read in the loop. A failed search is therefore left alone for
+  `locateRetry` (10 s).
 - **What Auto Title last named each tab** (`internal/state/manual.go`), which is
   how a rename by the user is told from the plugin's own work. That is a design
   of its own: [manual rename protection](./manual-rename-protection.md).

--- a/docs/architecture/sanitization.md
+++ b/docs/architecture/sanitization.md
@@ -10,7 +10,8 @@ generated: { by: claude-code/opus-5, at: 2026-08-25T12:46:22+03:00 }
 # Sanitizing Untrusted Values
 
 Every candidate for a title — a directory name, a terminal title, an agent
-title, an ssh destination — originates in terminal output or in a path someone
+title, an ssh destination, a topic read out of an agent's own transcript —
+originates in terminal output, in a file an agent wrote, or in a path someone
 chose. All of it is treated as untrusted input.
 
 The one rule that is never bent: **nothing derived from terminal output is

--- a/docs/architecture/title-resolution.md
+++ b/docs/architecture/title-resolution.md
@@ -52,6 +52,7 @@ rather than by the order the sources happen to be listed in
 |---:|---|---|---|
 | 90 | Agent title | `agent.go` | Activity |
 | 80 | Terminal title | `terminal.go` | Activity |
+| 75 | Session transcript | `transcript.go` | Activity |
 | 70 | Foreground process | `process.go` | Activity |
 | 60 | SSH session | `ssh.go` | Context |
 | 40 | Git branch | `git.go` | Branch |
@@ -91,6 +92,49 @@ the pane rather than against a list — and reappears as a *kind*, so a tab read
 The richest source in practice, and the one that carries most agent context. Its
 value is cleaned hard before it is trusted — see
 [sanitization](./sanitization.md).
+
+### The session transcript
+
+An agent that has titled its terminal has already said what it is doing, sooner
+and for free. This source answers when it has not, which is a real and repeatable
+case rather than an edge: Claude Code derives its terminal title from the user's
+own prompts, so **a session opened with a slash command and answered by the
+agent alone never gets one**. Its tab read `3 · claude` however long it ran.
+
+Herdr's own integration hook is what makes the transcript reachable.
+`herdr integration install claude` writes a `SessionStart` hook that reports the
+session id through `pane.report_agent_session`, and it arrives in the snapshot
+as `PaneInfo.agent_session` — no extra request. Without the hook the field is
+null, this source declines, and every other rung works as it always did.
+
+The transcript is then read from disk (`internal/claude/transcript.go`), and two
+lines in it can name a session:
+
+- `ai-title`, the title Claude Code generates and puts in its terminal title.
+  The last one wins — a session is renamed as it goes.
+- failing that, the **first prompt the user actually typed**, which is what
+  Claude Code's own session list shows for an untitled session. A prompt that is
+  a slash command yields the command and what it was called with
+  (`/code-review spec.md` → `code-review spec.md`): the argument is usually what
+  tells one run of a command from the next.
+
+Telling the user's prompt from the rest is not cosmetic. A slash command expands
+into the conversation as further user messages, and a resumed session opens with
+a caveat block written by the tool; either would name a tab after the plumbing.
+The transcript marks what the user typed with `origin.kind: "human"`, and only
+those lines are read.
+
+Three costs are worth stating plainly:
+
+- **It reads what the user said to their agent.** That is why it can be turned
+  off with `HERDR_AUTO_TITLE_TRANSCRIPT=false`, and why nothing else in the
+  plugin reads a file it was not pointed at.
+- **The format is undocumented.** `ai-title` and `origin.kind` are Claude Code's
+  internals and can change in any release. A transcript that no longer carries
+  them yields nothing and the source declines — the failure mode is the tab
+  named as it was before this existed, not a wrong name.
+- **The session id becomes part of a path.** It arrives over the socket, so it
+  is refused unless it is shaped like a UUID rather than cleaned.
 
 ### Foreground process
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/kryptamine/herdr-auto-title/internal/claude"
 	"github.com/kryptamine/herdr-auto-title/internal/git"
 	"github.com/kryptamine/herdr-auto-title/internal/herdr"
 	"github.com/kryptamine/herdr-auto-title/internal/resolver"
@@ -24,6 +25,9 @@ type App struct {
 	titles  resolver.TitleResolver
 	changes *state.Changes
 	manual  *state.Manual
+	// topics reads what an agent's own session is about. It keeps its place in
+	// each transcript, so a poll reads only what was appended since the last.
+	topics *claude.Reader
 	// failures is the run of polls that have failed in a row, which decides
 	// how loudly the next one is reported.
 	failures failureLog
@@ -38,6 +42,7 @@ func New(cfg Config, log *slog.Logger, titles resolver.TitleResolver) *App {
 		titles:  titles,
 		changes: state.NewChanges(),
 		manual:  state.LoadManual(cfg.ManualPath),
+		topics:  claude.NewReader(),
 	}
 }
 
@@ -119,6 +124,7 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 		return err
 	}
 	a.changes.Observe(snapshot.Panes)
+	a.topics.Retain(sessionsIn(snapshot.Panes))
 
 	tabs := a.tabsIn(ctx, client, snapshot)
 	a.manual.Retain(labelsOf(tabs))
@@ -217,6 +223,33 @@ func (a *App) checkoutIn(pane herdr.PaneInfo) git.Checkout {
 	return checkout
 }
 
+// topicIn reports what the session the pane's agent is holding says it is
+// about. Only Claude Code's transcripts are understood, and only Herdr's
+// integration hook says which session a pane holds.
+func (a *App) topicIn(pane herdr.PaneInfo) string {
+	if !a.cfg.ReadTranscripts {
+		return ""
+	}
+
+	sessionID, ok := pane.AgentSession.IDFor(claude.Agent)
+	if !ok {
+		return ""
+	}
+	return a.topics.Topic(sessionID, pane.Dir()).Text()
+}
+
+// sessionsIn lists the agent sessions the snapshot holds, which is what the
+// transcript reader keeps its places for.
+func sessionsIn(panes []herdr.PaneInfo) []string {
+	sessions := make([]string, 0, len(panes))
+	for _, pane := range panes {
+		if pane.AgentSession != nil {
+			sessions = append(sessions, pane.AgentSession.Value)
+		}
+	}
+	return sessions
+}
+
 // tabsIn assembles the snapshot's tabs with their panes. What is running in a
 // pane needs a request of its own, which processesIn makes only when the last
 // answer will no longer do.
@@ -228,9 +261,12 @@ func (a *App) tabsIn(ctx context.Context, client herdr.Client, snapshot herdr.Sn
 
 	byTab := make(map[string][]*state.PaneState, len(snapshot.Tabs))
 	for _, pane := range snapshot.Panes {
-		byTab[pane.TabID] = append(byTab[pane.TabID],
-			state.PaneFrom(pane, a.processesIn(ctx, client, pane.PaneID),
-				a.checkoutIn(pane), a.changes.ChangedAt(pane.PaneID)))
+		byTab[pane.TabID] = append(byTab[pane.TabID], state.PaneFrom(pane, state.Reads{
+			Processes: a.processesIn(ctx, client, pane.PaneID),
+			Git:       a.checkoutIn(pane),
+			Topic:     a.topicIn(pane),
+			ChangedAt: a.changes.ChangedAt(pane.PaneID),
+		}))
 	}
 
 	// An unnamed tab carries its place in the workspace, and the snapshot lists

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,8 +57,14 @@ func start(t *testing.T, tabs []herdr.TabInfo, panes []herdr.PaneInfo) *harness 
 // how a test arranges for the very first poll to fail.
 func startWith(t *testing.T, client *herdr.StubClient) *harness {
 	t.Helper()
+	return startConfigured(t, client, testConfig())
+}
 
-	app := New(testConfig(), discardLogger(), testResolver(t))
+// startConfigured runs an App whose configuration the test has changed.
+func startConfigured(t *testing.T, client *herdr.StubClient, cfg Config) *harness {
+	t.Helper()
+
+	app := New(cfg, discardLogger(), testResolver(t))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	h := &harness{t: t, client: client, done: make(chan struct{}), cancel: cancel}
@@ -670,5 +677,77 @@ func TestBranchesSwitchedOffAreNotRead(t *testing.T) {
 
 	if checkout := app.checkoutIn(herdr.PaneInfo{PaneID: "wE:p1", CWD: repo}); checkout != (git.Checkout{}) {
 		t.Errorf("checkout = %+v, want nothing read", checkout)
+	}
+}
+
+// The session an agent pane is holding in the tests below.
+const (
+	testSession = "8852bfe0-8b24-4a23-a35e-7521d04da061"
+	testDir     = "/Users/dev/work/dashboard"
+)
+
+// transcript lays down a Claude Code session transcript and points the plugin
+// at the state directory holding it. Which project directory it lands in is
+// the transcript reader's business, and its own tests cover that.
+func transcript(t *testing.T, lines ...string) {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", root)
+
+	path := filepath.Join(root, "projects", "any-project", testSession+".jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// agentPane is a pane holding a Claude Code session that never titled its
+// terminal, which is the only pane shape these tests care about.
+func agentPane() herdr.PaneInfo {
+	return herdr.PaneInfo{
+		PaneID: "wE:p1", TabID: "wE:t1", Focused: true, CWD: testDir,
+		TerminalTitleStripped: "Claude Code",
+		Agent:                 "claude",
+		AgentStatus:           herdr.AgentStatusIdle,
+		AgentSession: &herdr.AgentSessionInfo{
+			Agent: "claude", Kind: herdr.SessionRefID, Value: testSession,
+		},
+	}
+}
+
+func TestATabIsNamedFromTheAgentsOwnSession(t *testing.T) {
+	// The agent never titled its terminal, so the transcript Herdr pointed at
+	// is the only thing that says what the session is about.
+	transcript(t,
+		`{"type":"user","origin":{"kind":"human"},"message":{"role":"user","content":"rework the poll loop"}}`,
+		`{"type":"ai-title","aiTitle":"Poll loop rework","sessionId":"`+testSession+`"}`,
+	)
+
+	cfg := testConfig()
+	cfg.ReadTranscripts = true
+	h := startConfigured(t, herdr.NewStub(
+		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		[]herdr.PaneInfo{agentPane()},
+	), cfg)
+
+	renames := h.awaitRenames(1)
+	if want := "dashboard › claude › Poll loop rework"; renames[0].Label != want {
+		t.Errorf("rename = %q, want %q", renames[0].Label, want)
+	}
+}
+
+func TestTranscriptsAreLeftUnreadWhenTurnedOff(t *testing.T) {
+	transcript(t, `{"type":"ai-title","aiTitle":"Poll loop rework","sessionId":"`+testSession+`"}`)
+
+	h := start(t,
+		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		[]herdr.PaneInfo{agentPane()},
+	)
+
+	renames := h.awaitRenames(1)
+	if want := "dashboard › claude"; renames[0].Label != want {
+		t.Errorf("rename = %q, want %q", renames[0].Label, want)
 	}
 }

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -13,12 +13,13 @@ import (
 
 // Environment variables Auto Title reads. V1 has no configuration file.
 const (
-	EnvDebug     = "HERDR_AUTO_TITLE_DEBUG"
-	EnvPoll      = "HERDR_AUTO_TITLE_POLL_MS"
-	EnvMaxLength = "HERDR_AUTO_TITLE_MAX_LENGTH"
-	EnvBranchMax = "HERDR_AUTO_TITLE_BRANCH_MAX"
-	EnvPosition  = "HERDR_AUTO_TITLE_POSITION"
-	EnvManual    = "HERDR_AUTO_TITLE_MANUAL_FILE"
+	EnvDebug      = "HERDR_AUTO_TITLE_DEBUG"
+	EnvPoll       = "HERDR_AUTO_TITLE_POLL_MS"
+	EnvMaxLength  = "HERDR_AUTO_TITLE_MAX_LENGTH"
+	EnvBranchMax  = "HERDR_AUTO_TITLE_BRANCH_MAX"
+	EnvPosition   = "HERDR_AUTO_TITLE_POSITION"
+	EnvManual     = "HERDR_AUTO_TITLE_MANUAL_FILE"
+	EnvTranscript = "HERDR_AUTO_TITLE_TRANSCRIPT"
 )
 
 // DefaultPoll is how often the session is read. A six-pane snapshot measured
@@ -42,6 +43,10 @@ type Config struct {
 	// ManualPath is where tabs the user renamed by hand are remembered across
 	// restarts. Empty keeps them in memory only.
 	ManualPath string
+	// ReadTranscripts lets a title come from an agent's own session transcript
+	// when the agent has not titled its terminal. It reads what the user has
+	// been saying to that agent, so it can be turned off.
+	ReadTranscripts bool
 }
 
 // LoadConfig reads configuration from the environment. Unusable values are
@@ -49,11 +54,12 @@ type Config struct {
 // plugin from running.
 func LoadConfig() (Config, []string) {
 	cfg := Config{
-		Poll:         DefaultPoll,
-		MaxLength:    resolver.DefaultMaxLength,
-		BranchMax:    resolver.DefaultBranchMaxLength,
-		ShowPosition: true,
-		ManualPath:   state.DefaultManualPath(),
+		Poll:            DefaultPoll,
+		MaxLength:       resolver.DefaultMaxLength,
+		BranchMax:       resolver.DefaultBranchMaxLength,
+		ShowPosition:    true,
+		ManualPath:      state.DefaultManualPath(),
+		ReadTranscripts: true,
 	}
 	var warnings []string
 
@@ -63,6 +69,7 @@ func LoadConfig() (Config, []string) {
 	// Zero is meaningful here, and only here: it leaves branches out of titles.
 	cfg.BranchMax = fromEnv(&warnings, EnvBranchMax, cfg.BranchMax, countOrNone)
 	cfg.ShowPosition = fromEnv(&warnings, EnvPosition, cfg.ShowPosition, boolean)
+	cfg.ReadTranscripts = fromEnv(&warnings, EnvTranscript, cfg.ReadTranscripts, boolean)
 	// A path needs neither parsing nor checking, so it does not go through
 	// fromEnv: any string the user set is the path they meant.
 	if raw := os.Getenv(EnvManual); raw != "" {

--- a/internal/claude/transcript.go
+++ b/internal/claude/transcript.go
@@ -1,0 +1,374 @@
+// Package claude reads what a Claude Code session is about from the transcript
+// the agent appends to. Herdr says which session a pane holds; the transcript
+// is where that session says what it is doing.
+package claude
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Agent is the label Herdr gives Claude Code, and the only agent whose
+// transcript this package knows how to read.
+const Agent = "claude"
+
+// maxScan bounds one read. A transcript is append-only, so this bounds the
+// catch-up on a session first seen mid-flight, not the steady state.
+const maxScan = 2 << 20
+
+// maxOpening bounds what an opening prompt contributes. A title is 64 columns;
+// the rest is only carried so the truncation can happen against the tab bar.
+const maxOpening = 200
+
+// locateRetry is how long a session whose transcript was not found is left
+// alone. Herdr can name a session before the agent has written its first line,
+// so the search is repeated — just not twice a second for the pane's whole life.
+const locateRetry = 10 * time.Second
+
+// Topic is what a session says it is about.
+type Topic struct {
+	// Title is what Claude Code named the session, which it derives from the
+	// user's own prompts and leaves empty until it has seen one.
+	Title string
+	// Opening is what the session started with. It names a session that has
+	// not earned a title yet: one opened with a slash command and answered by
+	// the agent alone never gets one.
+	Opening string
+}
+
+// Text is what the topic contributes to a title, the generated name first.
+func (t Topic) Text() string {
+	if t.Title != "" {
+		return t.Title
+	}
+	return t.Opening
+}
+
+// Reader reads session transcripts, remembering how far it has read each one.
+// Transcripts are append-only, so a poll reads the bytes appended since the
+// last one rather than the file.
+type Reader struct {
+	mu       sync.Mutex
+	root     string
+	sessions map[string]*transcript
+	now      func() time.Time
+}
+
+// transcript is one session's file and what has been read out of it. A path
+// that is still empty is a session whose transcript has been looked for and not
+// found, and searchedAt is when that search last ran.
+type transcript struct {
+	path       string
+	offset     int64
+	topic      Topic
+	searchedAt time.Time
+}
+
+// NewReader builds a reader over Claude Code's configuration directory.
+func NewReader() *Reader {
+	return &Reader{root: root(), sessions: make(map[string]*transcript), now: time.Now}
+}
+
+// root is where Claude Code keeps its state. The environment variable is what
+// a user who moved it sets.
+func root() string {
+	if dir := os.Getenv("CLAUDE_CONFIG_DIR"); dir != "" {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude")
+}
+
+// Topic reports what the session is about, and the zero topic when nothing can
+// be read: no transcript, an unreadable one, or one that has said nothing yet.
+// dir is the pane's directory, where the transcript is looked for first.
+func (r *Reader) Topic(sessionID, dir string) Topic {
+	if r.root == "" || !isSessionID(sessionID) {
+		return Topic{}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	session, known := r.sessions[sessionID]
+	if !known {
+		session = &transcript{}
+		r.sessions[sessionID] = session
+	}
+	if session.path == "" && !r.find(session, sessionID, dir) {
+		return Topic{}
+	}
+
+	r.readInto(session)
+	return session.topic
+}
+
+// find fills in the session's transcript path, and reports whether there is one
+// to read. A search that came up empty is not repeated until locateRetry has
+// passed, because the scan behind it walks every project directory.
+func (r *Reader) find(session *transcript, sessionID, dir string) bool {
+	now := r.now()
+	if !session.searchedAt.IsZero() && now.Sub(session.searchedAt) < locateRetry {
+		return false
+	}
+	session.searchedAt = now
+
+	path, found := r.locate(sessionID, dir)
+	if !found {
+		return false
+	}
+	session.path = path
+	return true
+}
+
+// Retain forgets every session but these, which is how the sessions a run has
+// outlived are let go.
+func (r *Reader) Retain(sessionIDs []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	kept := make(map[string]*transcript, len(sessionIDs))
+	for _, id := range sessionIDs {
+		if session, known := r.sessions[id]; known {
+			kept[id] = session
+		}
+	}
+	r.sessions = kept
+}
+
+// sessionIDPattern is the shape of a session id. The id arrives over the socket
+// and becomes part of a path, so anything else is refused rather than cleaned.
+var sessionIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$`)
+
+func isSessionID(value string) bool {
+	return sessionIDPattern.MatchString(value)
+}
+
+// locate finds the transcript. Claude Code files a session under the directory
+// it was started in, which is usually the pane's, so that is tried before the
+// scan across every project.
+func (r *Reader) locate(sessionID, dir string) (string, bool) {
+	name := sessionID + ".jsonl"
+	projects := filepath.Join(r.root, "projects")
+
+	if dir != "" {
+		candidate := filepath.Join(projects, slugOf(dir), name)
+		if info, err := os.Stat(candidate); err == nil && info.Mode().IsRegular() {
+			return candidate, true
+		}
+	}
+
+	// A pane that has changed directory since the session started files it
+	// elsewhere, and only the whole projects directory says where.
+	matches, err := filepath.Glob(filepath.Join(projects, "*", name))
+	if err != nil || len(matches) == 0 {
+		return "", false
+	}
+	return matches[0], true
+}
+
+// slugOf is how Claude Code names a project directory: every character that is
+// not a letter or a digit becomes a dash, the leading separator included.
+func slugOf(dir string) string {
+	var slug strings.Builder
+	slug.Grow(len(dir))
+	for _, r := range dir {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			slug.WriteRune(r)
+		default:
+			slug.WriteByte('-')
+		}
+	}
+	return slug.String()
+}
+
+// readInto reads what has been appended since the last read and updates the
+// topic from it. A transcript only grows, so one that is shorter than what has
+// been read out of it is no longer the file that was read.
+func (r *Reader) readInto(session *transcript) {
+	info, err := os.Stat(session.path)
+	if err != nil {
+		return
+	}
+
+	size := info.Size()
+	switch {
+	case size == session.offset:
+		return
+	case size < session.offset:
+		session.offset, session.topic = 0, Topic{}
+	}
+
+	file, err := os.Open(session.path)
+	if err != nil {
+		return
+	}
+	defer file.Close() //nolint:errcheck // a read-only file has nothing to report on close
+
+	// A session first seen long after it started is caught up on from its tail,
+	// which is where a title it has already been given is repeated.
+	from, fromTail := session.offset, size-session.offset > maxScan
+	if fromTail {
+		from = size - maxScan
+	}
+	if _, err := file.Seek(from, io.SeekStart); err != nil {
+		return
+	}
+
+	content, err := io.ReadAll(io.LimitReader(file, maxScan))
+	if err != nil {
+		return
+	}
+
+	// Only whole lines are read: the agent may have been writing one while
+	// this ran, and the rest of it arrives next poll.
+	end := bytes.LastIndexByte(content, '\n')
+	if end < 0 {
+		return
+	}
+	session.offset = from + int64(end) + 1
+
+	complete := string(content[:end])
+	if fromTail {
+		// A tail read starts mid-line, and that fragment is not JSON.
+		_, complete, _ = strings.Cut(complete, "\n")
+	}
+	session.absorb(complete)
+}
+
+// entry is one transcript line. A transcript carries far more per line — uuids,
+// timestamps, token counts, the whole assistant turn — and none of it says what
+// the session is about.
+type entry struct {
+	Type    string `json:"type"`
+	AITitle string `json:"aiTitle"`
+	Origin  *struct {
+		Kind string `json:"kind"`
+	} `json:"origin"`
+	Message struct {
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+// humanOrigin marks a line the user typed, as against one a slash command
+// expanded into the conversation or a tool answered with.
+const humanOrigin = "human"
+
+// absorb updates the topic from a run of transcript lines. The last title wins
+// and the first opening does: a session is renamed as it goes, but it opened
+// only once.
+func (t *transcript) absorb(lines string) {
+	for line := range strings.SplitSeq(lines, "\n") {
+		if line == "" {
+			continue
+		}
+
+		var read entry
+		if json.Unmarshal([]byte(line), &read) != nil {
+			continue
+		}
+
+		switch {
+		case read.Type == "ai-title" && read.AITitle != "":
+			t.topic.Title = read.AITitle
+		case read.Type == "user" && t.topic.Opening == "" && read.Origin != nil && read.Origin.Kind == humanOrigin:
+			t.topic.Opening = opening(read.Message.Content)
+		}
+	}
+}
+
+// commandPattern matches the marker Claude Code wraps a slash command in.
+var commandPattern = regexp.MustCompile(`<command-name>\s*/?([^<\s]+)\s*</command-name>`)
+
+// argsPattern matches what a slash command was called with, which Claude Code
+// records beside the command's name and leaves empty when there was nothing.
+var argsPattern = regexp.MustCompile(`(?s)<command-args>(.*?)</command-args>`)
+
+// markupPattern matches the blocks Claude Code wraps around text the user did
+// not type: a command's expansion, the caveat on a resumed session.
+var markupPattern = regexp.MustCompile(`(?s)<[a-z][a-z-]*>.*?</[a-z][a-z-]*>`)
+
+// opening reduces a user's first message to what can name a session. Content is
+// either the text itself or the blocks a message was assembled from.
+func opening(content json.RawMessage) string {
+	text, ok := textOf(content)
+	if !ok {
+		return ""
+	}
+
+	// A session opened with a slash command is named after the command, which
+	// is what Claude Code's own session list shows for it.
+	if command := commandPattern.FindStringSubmatch(text); command != nil {
+		return truncate(withArgs(command[1], text), maxOpening)
+	}
+
+	text = strings.TrimSpace(markupPattern.ReplaceAllString(text, " "))
+	if text == "" {
+		return ""
+	}
+
+	line, _, _ := strings.Cut(text, "\n")
+	return truncate(strings.TrimSpace(line), maxOpening)
+}
+
+// withArgs appends what the command was called with: `/code-review spec.md`
+// says which review is running, and the command alone does not.
+func withArgs(command, text string) string {
+	args := argsPattern.FindStringSubmatch(text)
+	if args == nil {
+		return command
+	}
+
+	line, _, _ := strings.Cut(strings.TrimSpace(args[1]), "\n")
+	if line = strings.TrimSpace(line); line == "" {
+		return command
+	}
+	return command + " " + line
+}
+
+// textOf reads a message's content, which is a string when the user typed one
+// and a list of blocks when it was assembled from several.
+func textOf(content json.RawMessage) (string, bool) {
+	var text string
+	if json.Unmarshal(content, &text) == nil {
+		return text, true
+	}
+
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(content, &blocks) != nil {
+		return "", false
+	}
+
+	var joined []string
+	for _, block := range blocks {
+		if block.Type == "text" && block.Text != "" {
+			joined = append(joined, block.Text)
+		}
+	}
+	if len(joined) == 0 {
+		return "", false
+	}
+	return strings.Join(joined, " "), true
+}
+
+func truncate(value string, limit int) string {
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	return string(runes[:limit])
+}

--- a/internal/claude/transcript_test.go
+++ b/internal/claude/transcript_test.go
@@ -1,0 +1,311 @@
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	session = "8852bfe0-8b24-4a23-a35e-7521d04da061"
+	// started is the directory the session was opened in, which is what Claude
+	// Code files its transcript under.
+	started = "/work/dashboard"
+)
+
+// project is a Claude Code state directory built out of files, so the tests
+// describe the transcript format they parse rather than depend on the agent.
+type project struct {
+	t    *testing.T
+	root string
+	dir  string
+}
+
+// newProject points the reader at a temporary state directory.
+func newProject(t *testing.T) project {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", root)
+	return project{t: t, root: root, dir: started}
+}
+
+func (p project) path() string {
+	return filepath.Join(p.root, "projects", slugOf(p.dir), session+".jsonl")
+}
+
+// write lays down a transcript, replacing whatever was there.
+func (p project) write(lines ...string) {
+	p.t.Helper()
+	path := p.path()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		p.t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(joined(lines)), 0o644); err != nil {
+		p.t.Fatal(err)
+	}
+}
+
+// appendLines adds to a transcript the way the agent does.
+func (p project) appendLines(lines ...string) {
+	p.t.Helper()
+	file, err := os.OpenFile(p.path(), os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		p.t.Fatal(err)
+	}
+	defer file.Close() //nolint:errcheck // the write is checked below
+	if _, err := file.WriteString(joined(lines)); err != nil {
+		p.t.Fatal(err)
+	}
+}
+
+func joined(lines []string) string {
+	if len(lines) == 0 {
+		return ""
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// The transcript lines the reader looks for, as Claude Code writes them.
+func aiTitle(title string) string {
+	return `{"type":"ai-title","aiTitle":"` + title + `","sessionId":"` + session + `"}`
+}
+
+func human(text string) string {
+	return `{"type":"user","origin":{"kind":"human"},"message":{"role":"user","content":"` + text + `"}}`
+}
+
+func expanded(text string) string {
+	return `{"type":"user","origin":null,"message":{"role":"user","content":"` + text + `"}}`
+}
+
+func toolResult() string {
+	return `{"type":"user","origin":null,"message":{"role":"user","content":[{"type":"tool_result"}]}}`
+}
+
+func TestTitleNamesASession(t *testing.T) {
+	p := newProject(t)
+	p.write(human("fix the redirect"), aiTitle("OAuth redirect fix"))
+
+	if got := NewReader().Topic(session, started); got.Text() != "OAuth redirect fix" {
+		t.Errorf("topic = %+v, want the generated title", got)
+	}
+}
+
+func TestTheLastTitleWins(t *testing.T) {
+	p := newProject(t)
+	p.write(aiTitle("First guess"), aiTitle("What it turned into"))
+
+	if got := NewReader().Topic(session, started); got.Text() != "What it turned into" {
+		t.Errorf("topic = %+v, want the last title", got)
+	}
+}
+
+func TestASlashCommandNamesASessionWithNoTitle(t *testing.T) {
+	// The session this whole source exists for: opened with a command and
+	// answered by the agent alone, so Claude Code never titles it.
+	p := newProject(t)
+	p.write(
+		human(`<command-message>grill-me</command-message>\n<command-name>/grill-me</command-name>`),
+		expanded("Run a `/grilling` session."),
+		toolResult(),
+	)
+
+	got := NewReader().Topic(session, started)
+	if got.Text() != "grill-me" {
+		t.Errorf("topic = %+v, want the command it opened with", got)
+	}
+}
+
+func TestASlashCommandKeepsWhatItWasCalledWith(t *testing.T) {
+	p := newProject(t)
+	p.write(human(`<command-name>/code-review</command-name>\n<command-message>code-review</command-message>\n<command-args>spec.md</command-args>`))
+
+	if got := NewReader().Topic(session, started); got.Text() != "code-review spec.md" {
+		t.Errorf("topic = %+v, want the command and its argument", got)
+	}
+}
+
+func TestACommandCalledWithNothingStandsAlone(t *testing.T) {
+	p := newProject(t)
+	p.write(human(`<command-name>/grill-me</command-name>\n<command-message>grill-me</command-message>\n<command-args></command-args>`))
+
+	if got := NewReader().Topic(session, started); got.Text() != "grill-me" {
+		t.Errorf("topic = %+v, want the command alone", got)
+	}
+}
+
+func TestATitleOutranksTheOpening(t *testing.T) {
+	p := newProject(t)
+	p.write(human("rework the poll loop"), aiTitle("Poll loop rework"))
+
+	got := NewReader().Topic(session, started)
+	switch {
+	case got.Text() != "Poll loop rework":
+		t.Errorf("text = %q, want the title", got.Text())
+	case got.Opening != "rework the poll loop":
+		t.Errorf("opening = %q, want the first prompt kept", got.Opening)
+	}
+}
+
+func TestOnlyTheUsersOwnPromptOpensASession(t *testing.T) {
+	// A slash command expands into the conversation as another user message.
+	// Only the one the user typed says what the session is about.
+	p := newProject(t)
+	p.write(expanded("Base directory for this skill: /skills/grilling"), toolResult())
+
+	if got := NewReader().Topic(session, started); got.Text() != "" {
+		t.Errorf("topic = %+v, want nothing from an expansion", got)
+	}
+}
+
+func TestAResumedSessionsCaveatIsNotItsOpening(t *testing.T) {
+	p := newProject(t)
+	p.write(human(`<local-command-caveat>Caveat: The messages below were generated by a command</local-command-caveat>`))
+
+	if got := NewReader().Topic(session, started); got.Text() != "" {
+		t.Errorf("topic = %+v, want nothing from a caveat", got)
+	}
+}
+
+func TestOnlyTheFirstLineOfAPromptOpensASession(t *testing.T) {
+	p := newProject(t)
+	p.write(human(`rework the poll loop\nand say why in the commit`))
+
+	if got := NewReader().Topic(session, started); got.Text() != "rework the poll loop" {
+		t.Errorf("topic = %+v, want the first line alone", got)
+	}
+}
+
+func TestAppendedLinesAreReadOnTheNextPoll(t *testing.T) {
+	p := newProject(t)
+	p.write(human("fix the redirect"))
+	reader := NewReader()
+
+	if got := reader.Topic(session, started); got.Text() != "fix the redirect" {
+		t.Fatalf("topic = %+v, want the opening prompt", got)
+	}
+
+	p.appendLines(aiTitle("OAuth redirect fix"))
+	if got := reader.Topic(session, started); got.Text() != "OAuth redirect fix" {
+		t.Errorf("topic = %+v, want the title that arrived since", got)
+	}
+}
+
+func TestAHalfWrittenLineIsReadWhenItIsWhole(t *testing.T) {
+	// The agent may be mid-write when a poll reads. The fragment must not be
+	// parsed, and must not be skipped once the rest of it lands either.
+	p := newProject(t)
+	p.write(human("fix the redirect"))
+	path := p.path()
+	half := aiTitle("OAuth redirect fix")
+	if err := os.WriteFile(path, []byte(joined([]string{human("fix the redirect")})+half[:20]), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := NewReader()
+	if got := reader.Topic(session, started); got.Text() != "fix the redirect" {
+		t.Fatalf("topic = %+v, want the fragment ignored", got)
+	}
+
+	if err := os.WriteFile(path, []byte(joined([]string{human("fix the redirect"), half})), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := reader.Topic(session, started); got.Text() != "OAuth redirect fix" {
+		t.Errorf("topic = %+v, want the line read once it was whole", got)
+	}
+}
+
+func TestATranscriptThatShrankIsReadAgain(t *testing.T) {
+	p := newProject(t)
+	p.write(human("fix the redirect"), aiTitle("OAuth redirect fix"))
+	reader := NewReader()
+	if got := reader.Topic(session, started); got.Text() != "OAuth redirect fix" {
+		t.Fatalf("topic = %+v", got)
+	}
+
+	// Only a file that is no longer the one that was read can be shorter than
+	// what has already been read out of it.
+	p.write(human("something else"))
+	if got := reader.Topic(session, started); got.Text() != "something else" {
+		t.Errorf("topic = %+v, want the transcript read from the start again", got)
+	}
+}
+
+func TestASessionFiledUnderAnotherDirectoryIsStillFound(t *testing.T) {
+	// The pane has changed directory since the session started, so the slug
+	// does not lead to it and only the scan does.
+	p := newProject(t)
+	p.write(aiTitle("OAuth redirect fix"))
+
+	if got := NewReader().Topic(session, "/somewhere/else"); got.Text() != "OAuth redirect fix" {
+		t.Errorf("topic = %+v, want the transcript found by scanning", got)
+	}
+}
+
+func TestAnIdThatIsNotASessionIsRefused(t *testing.T) {
+	// The id arrives over the socket and becomes part of a path.
+	newProject(t)
+	reader := NewReader()
+
+	for _, id := range []string{"", "../../../etc/passwd", "8852bfe0", strings.Repeat("a", 36)} {
+		if got := reader.Topic(id, started); got.Text() != "" {
+			t.Errorf("id %q resolved to %+v", id, got)
+		}
+	}
+}
+
+func TestASessionWithNoTranscriptSaysNothing(t *testing.T) {
+	newProject(t)
+
+	if got := NewReader().Topic(session, started); got.Text() != "" {
+		t.Errorf("topic = %+v, want nothing", got)
+	}
+}
+
+func TestATranscriptThatWasNotThereYetIsLookedForAgain(t *testing.T) {
+	// Herdr can name a session before the agent has written a line of it, so a
+	// search that found nothing has to be repeated — but not every poll: it
+	// walks every project directory the user has.
+	p := newProject(t)
+	reader := NewReader()
+	clock := time.Now()
+	reader.now = func() time.Time { return clock }
+
+	if got := reader.Topic(session, started); got.Text() != "" {
+		t.Fatalf("topic = %+v, want nothing before the transcript exists", got)
+	}
+
+	p.write(aiTitle("OAuth redirect fix"))
+	if got := reader.Topic(session, started); got.Text() != "" {
+		t.Errorf("topic = %+v, want the failed search left alone until it expires", got)
+	}
+
+	clock = clock.Add(locateRetry)
+	if got := reader.Topic(session, started); got.Text() != "OAuth redirect fix" {
+		t.Errorf("topic = %+v, want the transcript found on the next search", got)
+	}
+}
+
+func TestRetainForgetsTheSessionsARunOutlived(t *testing.T) {
+	p := newProject(t)
+	p.write(aiTitle("OAuth redirect fix"))
+
+	reader := NewReader()
+	reader.Topic(session, started)
+	if len(reader.sessions) != 1 {
+		t.Fatalf("sessions = %d, want the read one remembered", len(reader.sessions))
+	}
+
+	reader.Retain(nil)
+	if len(reader.sessions) != 0 {
+		t.Errorf("sessions = %d, want the session let go", len(reader.sessions))
+	}
+}
+
+func TestSlugMatchesHowClaudeCodeNamesAProject(t *testing.T) {
+	if got := slugOf("/Users/dev/.claude/skills"); got != "-Users-dev--claude-skills" {
+		t.Errorf("slug = %q", got)
+	}
+}

--- a/internal/herdr/session.go
+++ b/internal/herdr/session.go
@@ -47,6 +47,33 @@ type PaneInfo struct {
 	Agent        string `json:"agent"`
 	DisplayAgent string `json:"display_agent"`
 	AgentStatus  string `json:"agent_status"`
+
+	// AgentSession identifies the conversation the pane's agent is holding.
+	// It is null until the agent's Herdr integration reports one.
+	AgentSession *AgentSessionInfo `json:"agent_session"`
+}
+
+// SessionRefID is the only reference kind Herdr has been seen to answer with.
+// It accepts a path from an integration and reports the id anyway.
+const SessionRefID = "id"
+
+// AgentSessionInfo identifies an agent's own session, as its integration hook
+// reported it. Which agent reported it decides how the reference is read, so
+// the label is part of the reference.
+type AgentSessionInfo struct {
+	Agent string `json:"agent"`
+	Kind  string `json:"kind"`
+	Value string `json:"value"`
+}
+
+// IDFor reports the session id this reference holds, and false unless it names
+// a session of the given agent by id. A nil reference is a pane whose agent has
+// reported nothing, which is every pane until an integration is installed.
+func (s *AgentSessionInfo) IDFor(agent string) (string, bool) {
+	if s == nil || s.Agent != agent || s.Kind != SessionRefID {
+		return "", false
+	}
+	return s.Value, true
 }
 
 // Dir is the directory a pane speaks for. The shell's own is preferred over

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1,6 +1,6 @@
 // Package resolver turns a tab's read state into a tab title. Resolution is
 // deterministic: identical state always yields an identical decision. No
-// network call, no LLM, no transcript reading.
+// network call and no LLM: every source names a tab from state already read.
 package resolver
 
 import (
@@ -26,6 +26,7 @@ const (
 	ConfidenceGit           = 40
 	ConfidenceSSH           = 60
 	ConfidenceProcess       = 70
+	ConfidenceTranscript    = 75
 	ConfidenceTerminalTitle = 80
 	ConfidenceAgent         = 90
 )
@@ -93,6 +94,7 @@ func Default(maxLength, branchMax int) *Deterministic {
 	return New(maxLength,
 		NewAgent(),
 		NewTerminalTitle(),
+		NewTranscript(),
 		NewProcess(),
 		NewSSH(),
 		NewGit(branchMax),

--- a/internal/resolver/transcript.go
+++ b/internal/resolver/transcript.go
@@ -1,0 +1,30 @@
+package resolver
+
+import "github.com/kryptamine/herdr-auto-title/internal/state"
+
+// Transcript derives the activity from what the agent's own session says it is
+// about. It sits below TerminalTitle because an agent that titles its window
+// has already said the same thing, sooner; this answers when it has not.
+type Transcript struct{}
+
+var _ Source = Transcript{}
+
+// NewTranscript builds the source.
+func NewTranscript() Transcript { return Transcript{} }
+
+func (Transcript) Name() string    { return "transcript" }
+func (Transcript) Confidence() int { return ConfidenceTranscript }
+
+func (Transcript) Resolve(pane *state.PaneState) (Parts, bool) {
+	if pane == nil || !pane.HasAgent() {
+		return Parts{}, false
+	}
+
+	// Truncation belongs to the assembled name, so no limit is applied here.
+	activity, ok := Meaningful(Sanitize(pane.AgentTopic, 0))
+	if !ok {
+		return Parts{}, false
+	}
+
+	return Parts{Activity: qualify(activity, paneKind(pane))}, true
+}

--- a/internal/resolver/transcript_test.go
+++ b/internal/resolver/transcript_test.go
@@ -1,0 +1,78 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/kryptamine/herdr-auto-title/internal/herdr"
+	"github.com/kryptamine/herdr-auto-title/internal/state"
+)
+
+func TestATopicNamesATabTheTerminalTitleCannot(t *testing.T) {
+	// The session that motivated the source: the agent never titled its
+	// terminal, so without the transcript the tab is just `claude`.
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+		Dir:           "/Users/dev/work/dashboard",
+		TerminalTitle: "Claude Code",
+		Agent:         "claude",
+		AgentStatus:   herdr.AgentStatusIdle,
+		AgentTopic:    "grill-me",
+	}))
+
+	if want := "dashboard › claude › grill-me"; got.Name != want {
+		t.Errorf("name = %q, want %q", got.Name, want)
+	}
+	if got.Reason != "transcript" {
+		t.Errorf("reason = %q, want transcript", got.Reason)
+	}
+	if got.Confidence != ConfidenceTranscript {
+		t.Errorf("confidence = %d, want %d", got.Confidence, ConfidenceTranscript)
+	}
+}
+
+func TestATerminalTitleOutranksTheTranscript(t *testing.T) {
+	// Both say what the session is about, and the agent says it sooner.
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+		Dir:           "/Users/dev/work/dashboard",
+		TerminalTitle: "Fix OAuth redirect",
+		Agent:         "claude",
+		AgentStatus:   herdr.AgentStatusWorking,
+		AgentTopic:    "Something the session was called earlier",
+	}))
+
+	if want := "dashboard › claude › Fix OAuth redirect"; got.Name != want {
+		t.Errorf("name = %q, want %q", got.Name, want)
+	}
+	if got.Reason != "terminal_title" {
+		t.Errorf("reason = %q, want terminal_title", got.Reason)
+	}
+}
+
+func TestATopicWithoutAnAgentIsIgnored(t *testing.T) {
+	// A pane whose agent Herdr no longer recognizes keeps whatever was read of
+	// its session, and that is no longer what the pane is doing.
+	if _, ok := NewTranscript().Resolve(&state.PaneState{
+		Dir:        "/Users/dev/work/dashboard",
+		AgentTopic: "grill-me",
+	}); ok {
+		t.Error("the transcript source claimed a pane with no agent")
+	}
+}
+
+func TestATopicThatNamesTheAgentFallsThrough(t *testing.T) {
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+		Dir:         "/Users/dev/work/dashboard",
+		Agent:       "claude",
+		AgentStatus: herdr.AgentStatusIdle,
+		AgentTopic:  "Claude Code",
+	}))
+
+	if want := "dashboard › claude"; got.Name != want {
+		t.Errorf("name = %q, want %q", got.Name, want)
+	}
+}
+
+func TestTranscriptSourceOnANilPane(t *testing.T) {
+	if _, ok := NewTranscript().Resolve(nil); ok {
+		t.Fatal("resolved a nil pane")
+	}
+}

--- a/internal/state/tab.go
+++ b/internal/state/tab.go
@@ -30,6 +30,10 @@ type PaneState struct {
 	DisplayAgent string
 	AgentTitle   string
 	AgentStatus  string
+	// AgentTopic is what the agent's own session says it is about, read from
+	// the transcript Herdr pointed at. Empty unless the agent's integration
+	// hook is installed — see docs/architecture/title-resolution.md.
+	AgentTopic string
 
 	// Processes are the pane's foreground process and its descendants.
 	Processes []Process
@@ -51,10 +55,19 @@ type Process struct {
 	Args []string
 }
 
-// PaneFrom builds pane context from what a read returned.
-func PaneFrom(info herdr.PaneInfo, processes []herdr.PaneProcessInfoProcess,
-	checkout git.Checkout, changedAt time.Time,
-) *PaneState {
+// Reads is what a poll learned about a pane that its snapshot entry does not
+// carry: each field costs a request or a file of its own.
+type Reads struct {
+	Processes []herdr.PaneProcessInfoProcess
+	Git       git.Checkout
+	// Topic is what the agent's own session says it is about.
+	Topic string
+	// ChangedAt is when a poll last saw the pane's revision move.
+	ChangedAt time.Time
+}
+
+// PaneFrom builds pane context from a snapshot entry and what was read around it.
+func PaneFrom(info herdr.PaneInfo, reads Reads) *PaneState {
 	return &PaneState{
 		ID:               info.PaneID,
 		Dir:              info.Dir(),
@@ -64,10 +77,11 @@ func PaneFrom(info herdr.PaneInfo, processes []herdr.PaneProcessInfoProcess,
 		DisplayAgent:     info.DisplayAgent,
 		AgentTitle:       info.Title,
 		AgentStatus:      info.AgentStatus,
-		Processes:        processesFrom(processes),
-		Git:              checkout,
+		AgentTopic:       reads.Topic,
+		Processes:        processesFrom(reads.Processes),
+		Git:              reads.Git,
 		Focused:          info.Focused,
-		ChangedAt:        changedAt,
+		ChangedAt:        reads.ChangedAt,
 	}
 }
 

--- a/internal/state/tab_test.go
+++ b/internal/state/tab_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kryptamine/herdr-auto-title/internal/git"
 	"github.com/kryptamine/herdr-auto-title/internal/herdr"
 )
 
@@ -73,7 +72,7 @@ func TestPaneFromReadsAgentContext(t *testing.T) {
 		Agent:                 "claude",
 		DisplayAgent:          "Claude Code",
 		AgentStatus:           herdr.AgentStatusWorking,
-	}, nil, git.Checkout{}, stamp)
+	}, Reads{Topic: "Rework the poll loop", ChangedAt: stamp})
 
 	switch {
 	case pane.TerminalTitle != "Claude Code":
@@ -82,6 +81,8 @@ func TestPaneFromReadsAgentContext(t *testing.T) {
 		t.Errorf("raw terminal title = %q", pane.TerminalTitleRaw)
 	case pane.AgentTitle != "Implement OAuth scopes":
 		t.Errorf("agent title = %q", pane.AgentTitle)
+	case pane.AgentTopic != "Rework the poll loop":
+		t.Errorf("agent topic = %q", pane.AgentTopic)
 	case !pane.AgentIsActive():
 		t.Error("a working agent is not active")
 	case !pane.ChangedAt.Equal(stamp):
@@ -90,7 +91,7 @@ func TestPaneFromReadsAgentContext(t *testing.T) {
 }
 
 func TestPaneWithoutAnAgent(t *testing.T) {
-	pane := PaneFrom(herdr.PaneInfo{PaneID: "wE:p1", AgentStatus: herdr.AgentStatusUnknown}, nil, git.Checkout{}, time.Now())
+	pane := PaneFrom(herdr.PaneInfo{PaneID: "wE:p1", AgentStatus: herdr.AgentStatusUnknown}, Reads{})
 	if pane.HasAgent() || pane.AgentIsActive() {
 		t.Errorf("pane %+v reported an agent", pane)
 	}
@@ -201,14 +202,14 @@ func TestPaneFromPrefersTheShellsDirectory(t *testing.T) {
 	// when the shell's own directory is missing.
 	both := PaneFrom(herdr.PaneInfo{
 		PaneID: "wE:p1", CWD: "/work/dashboard", ForegroundCWD: "/tmp",
-	}, nil, git.Checkout{}, time.Now())
+	}, Reads{})
 	if both.Dir != "/work/dashboard" {
 		t.Errorf("dir = %q, want the shell's own", both.Dir)
 	}
 
 	foreground := PaneFrom(herdr.PaneInfo{
 		PaneID: "wE:p1", ForegroundCWD: "/work/api",
-	}, nil, git.Checkout{}, time.Now())
+	}, Reads{})
 	if foreground.Dir != "/work/api" {
 		t.Errorf("dir = %q, want the foreground process's", foreground.Dir)
 	}


### PR DESCRIPTION
A Claude Code pane whose agent never titled its terminal gives a tab named
`3 · claude` and nothing more. That is not an edge case: Claude Code derives
its terminal title from the user's own prompts, so **a session opened with a
slash command and answered by the agent alone never gets one**, however long
it runs.

## How it works

`herdr integration install claude` — Herdr's own hook, not this plugin's —
reports the agent's session id through `pane.report_agent_session`. It arrives
in `session.snapshot` as `PaneInfo.agent_session`, so reading it costs no
request. Auto Title then finds that session's transcript by id and reads the
topic out of it: the last `ai-title`, or failing that the first prompt the user
actually typed (`origin.kind: "human"`), with a slash command yielding the
command and its arguments — `/code-review spec.md` → `code-review spec.md`.

Telling the user's prompt from the rest is not cosmetic: a slash command
expands into the conversation as further user messages, and a resumed session
opens with a caveat block, either of which would name a tab after the plumbing.

## Cost

A transcript is append-only and reaches megabytes while the loop polls twice a
second, so a poll parses only the bytes appended since the last one. What is
kept per session is a path, a byte offset and the topic so far. A search that
finds nothing is remembered too and repeated only every 10 s, because finding a
transcript means scanning every project directory the user has.

## Degradation

Installing no hook costs nothing: the session reference is null, the source
declines, and every other rung of the ladder works as before. The source reads
what the user said to their agent, so `HERDR_AUTO_TITLE_TRANSCRIPT=false` turns
it off.

Only Claude Code is read. Herdr installs the same hook for seventeen agents and
the plugin accepts a session from any of them, but each keeps its transcript in
its own format and needs a reader of its own — the readme carries the tick list.

## Verified

Live against Herdr 0.8.2, protocol 20: the tab under review read
`3 · claude › code-review foo` while this was written. `make check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)