### PR TITLE
feat: cap a generated title at 50 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,6 @@ format, so each needs a reader of its own:
 An agent that is not ticked loses nothing: its tab is named from its terminal
 title, exactly as before.
 
-Working on the plugin rather than using it? [Development](docs/development.md)
-covers linking a local checkout, which Herdr makes you unlink before `install`
-will run.
-
 ## What your tabs will be called
 
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ ssh into prod-01                       →  5 · ssh › prod-01
 $HOME                                  →  6 · Shell
 ```
 
-Titles read `<position> · <context> › <activity>`, capped at 64 columns of the
+Titles read `<position> · <context> › <activity>`, capped at 50 columns of the
 tab bar. The activity is the first of these that has something to say: what an
 agent reports it is working on, then the terminal title, then a lone program in
 the pane. The context is the directory you are in, or the machine you reached

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -144,7 +145,7 @@ func TestAnUnusableValueIsReportedInFull(t *testing.T) {
 	}
 	// The warning has to say which variable, what was in it, and what is being
 	// used instead — it is all the user gets.
-	for _, want := range []string{EnvMaxLength, `"0"`, "must be positive", "64"} {
+	for _, want := range []string{EnvMaxLength, `"0"`, "must be positive", strconv.Itoa(resolver.DefaultMaxLength)} {
 		if !strings.Contains(warnings[0], want) {
 			t.Errorf("warning %q does not mention %q", warnings[0], want)
 		}

--- a/internal/claude/transcript.go
+++ b/internal/claude/transcript.go
@@ -23,7 +23,7 @@ const Agent = "claude"
 // catch-up on a session first seen mid-flight, not the steady state.
 const maxScan = 2 << 20
 
-// maxOpening bounds what an opening prompt contributes. A title is 64 columns;
+// maxOpening bounds what an opening prompt contributes. A title is 50 columns;
 // the rest is only carried so the truncation can happen against the tab bar.
 const maxOpening = 200
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -12,7 +12,7 @@ import (
 )
 
 // DefaultMaxLength bounds a generated title, in columns of the tab bar.
-const DefaultMaxLength = 64
+const DefaultMaxLength = 50
 
 // GenericFallback names a tab whose context tells us nothing.
 const GenericFallback = "Shell"

--- a/internal/resolver/terminal_test.go
+++ b/internal/resolver/terminal_test.go
@@ -156,9 +156,12 @@ func TestEditorTitleKeepsTheFileAndDropsThePath(t *testing.T) {
 		},
 	}
 
+	// The cap is not what this tests, and the longest of the three outgrows it.
+	const wide = 80
+
 	for _, tc := range tests {
 		t.Run(tc.title, func(t *testing.T) {
-			got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+			got := Default(wide, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 				Dir:           "/Users/dev/Work/herdr-auto-title",
 				TerminalTitle: tc.title,
 			}))


### PR DESCRIPTION
Lowers `DefaultMaxLength` from 64 to 50, and drops a README paragraph that
repeated what the Documentation list already links.

### Title cap

Sixty-four columns is more of the tab bar than a tab gets once a workspace
holds several, so the width past fifty bought nothing. The three places
that carried `64` as prose rather than reading the constant are updated
with it:

- `README.md` — "capped at 50 columns".
- `internal/claude/transcript.go` — the comment above `maxOpening`. The
  value itself stays at 200: it was already well past the cap, because the
  truncation happens against the tab bar rather than there.
- `internal/app/config_test.go` — the warning assertion had `"64"` written
  out; it now reads `strconv.Itoa(resolver.DefaultMaxLength)`, so the next
  change to the default does not break it.

`TestEditorTitleKeepsTheFileAndDropsThePath` runs against a wider cap of
its own. It is there for the path an editor title drops, not for the
truncation — which `TestResolveTruncatesToMaxLength` covers — and the
longest of its three observed titles is 53 columns.

### README

The mid-page "Working on the plugin rather than using it?" paragraph is
gone; the Documentation section at the foot of the file already links
`docs/development.md`.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)