### PR TITLE
feat(app): read settings from a configuration file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,17 @@ listed here** (`make probe-*`, `scripts/probe.py`).
   *position* in the workspace, counted from one, and that label shifts down when
   a tab to its left closes. The snapshot lists tabs in display order, so the
   position is their count within the workspace.
+- **A plugin the server starts inherits the server's environment**, not the
+  shell of whoever installed it, which is why `HERDR_AUTO_TITLE_*` settings
+  arrive through `config.env` (see
+  [docs/architecture/configuration.md](docs/architecture/configuration.md)).
+  Herdr creates `~/.config/herdr/plugins/config/<plugin id>/` and prints it from
+  `herdr plugin config-dir <id>` and `herdr plugin list` (confirmed directly),
+  and the 0.8.2 binary names `HERDR_PLUGIN_ROOT`, `HERDR_PLUGIN_CONFIG_DIR` and
+  `HERDR_PLUGIN_STATE_DIR` for a plugin process — that half is read out of the
+  binary's strings, **not observed on a live plugin**, because seeing it needs a
+  `herdr server stop`. Auto Title uses its own directory and depends on none of
+  them.
 - `tab.get` and `pane.get` read one object each; `pane.list` filters by
   workspace only, not by tab. Neither is needed while the snapshot is one call.
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,66 @@ These rules explain most surprises:
 > stop the plugin, delete its entry from `manual-names.json` (or delete the
 > whole file), and start the plugin again.
 
+## Configuration
+
+Everything is optional; the defaults are what the section above describes.
+Settings live in a file Auto Title reads once, at startup:
+
+| Platform | File |
+|----------|------|
+| macOS | `~/Library/Application Support/herdr-auto-title/config.env` |
+| Linux | `~/.config/herdr-auto-title/config.env` |
+
+Nothing creates it for you. [`config.env.example`](config.env.example) lists
+every setting commented out, so a copy of it changes nothing until you uncomment
+a line.
+
+**Editing the file changes nothing until the plugin restarts**, and the plugin
+is restarted by the server:
+
+```sh
+herdr server stop   # closes the session; `herdr` brings it back
+```
+
+Reopening your terminal will not do it, for the same reason it does not start a
+freshly installed plugin: a new client attaches and the server, with your
+plugin, carries on as it was.
+
+> [!NOTE]
+> `herdr plugin list` prints a config directory of Herdr's own,
+> `~/.config/herdr/plugins/config/herdr.auto-title`. Auto Title does not read
+> it — a plugin you start by hand would never see it. Use the path above.
+
+| Setting | Default | What it does |
+|---------|---------|--------------|
+| `HERDR_AUTO_TITLE_DEBUG` | `false` | Log at DEBUG rather than INFO |
+| `HERDR_AUTO_TITLE_POLL_MS` | `500` | How often the session is read, in milliseconds |
+| `HERDR_AUTO_TITLE_MAX_LENGTH` | `50` | Longest title, in columns of the tab bar |
+| `HERDR_AUTO_TITLE_BRANCH_MAX` | `12` | Longest branch a title may carry, in columns; `0` leaves branches out |
+| `HERDR_AUTO_TITLE_POSITION` | `true` | Put each tab's position in front of its title |
+| `HERDR_AUTO_TITLE_MANUAL_FILE` | `manual-names.json`, next to `config.env` | Where tabs you renamed by hand are remembered |
+| `HERDR_AUTO_TITLE_TRANSCRIPT` | `true` | Read an agent's own session transcript when it has not titled its terminal |
+
+The same names work as environment variables, and **an environment variable
+overrides the file** — which is how you try a setting for one run without
+editing anything.
+
+Each line is `KEY=value`, and `#` starts a comment. Two things in that format
+catch people out:
+
+- **`${VAR}` is expanded from this file only, never from the environment**, so
+  `HERDR_AUTO_TITLE_MANUAL_FILE=${HOME}/names.json` gives you `/names.json`.
+  Write paths out in full.
+- **One bad line loses the whole file.** Every setting falls back to its
+  default, and the plugin warns at startup, naming the file and what the parser
+  objected to.
+
+A key that is not in the table is ignored and nothing warns you, so check the
+spelling against the table when a setting seems to do nothing.
+
 ## Documentation
 
 - [Architecture](docs/architecture/) — how it works and why: the poll loop, how
-  a tab becomes a name, and the measured facts about the Herdr socket API.
+  a tab becomes a name, where configuration comes from, and the measured facts
+  about the Herdr socket API.
 - [Development](docs/development.md) — working on it.

--- a/config.env.example
+++ b/config.env.example
@@ -1,0 +1,29 @@
+# Auto Title configuration. Copy to the directory Auto Title reads it from:
+#
+#   macOS  ~/Library/Application Support/herdr-auto-title/config.env
+#   Linux  ~/.config/herdr-auto-title/config.env
+#
+# Every line below is the default, so this file as it stands changes nothing.
+# A variable set in the environment overrides what is written here.
+
+# Log at DEBUG rather than INFO.
+#HERDR_AUTO_TITLE_DEBUG=false
+
+# How often the session is read, in milliseconds.
+#HERDR_AUTO_TITLE_POLL_MS=500
+
+# Longest title, in columns of the tab bar.
+#HERDR_AUTO_TITLE_MAX_LENGTH=50
+
+# Longest branch name a title may carry, in columns. 0 leaves branches out.
+#HERDR_AUTO_TITLE_BRANCH_MAX=12
+
+# Put each tab's position in front of its title.
+#HERDR_AUTO_TITLE_POSITION=true
+
+# Where tabs you renamed by hand are remembered. Defaults to manual-names.json
+# next to this file; write the path in full, "~" is not expanded here.
+#HERDR_AUTO_TITLE_MANUAL_FILE=/home/you/.config/herdr-auto-title/manual-names.json
+
+# Read an agent's own session transcript when it has not titled its terminal.
+#HERDR_AUTO_TITLE_TRANSCRIPT=true

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -21,6 +21,7 @@ that settled it.
 | [Title resolution](./title-resolution.md) | Which pane speaks for a tab, the confidence ladder, what each source contributes, why the workspace name is not repeated, and why the tab position leads the title |
 | [Sanitizing untrusted values](./sanitization.md) | What is stripped from terminal-derived values, what is rejected as saying nothing, and why the length limit is counted in columns |
 | [Manual rename protection](./manual-rename-protection.md) | Telling your rename from the plugin's own using nothing but successive polls, and what that costs |
+| [Configuration](./configuration.md) | Why a configuration file exists at all, where it lives, why the environment overrides it, and what the file format does and does not do |
 | [Herdr socket API](./herdr-socket-api.md) | The wire protocol and the measured facts about Herdr 0.8.2 that everything else rests on |
 
 Two things are worth knowing before reading any of them:

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -1,0 +1,99 @@
+---
+type: doc
+title: 'Configuration'
+description: 'Why Auto Title reads a configuration file at all, where that file lives and why it is not the directory Herdr offers, why the environment beats the file, why the parsing is a library rather than ten lines of our own, and why nothing is reread while the plugin runs.'
+tags: [architecture]
+created: 2026-08-26
+generated: { by: claude-code/opus-5, at: 2026-08-26T14:14:17+03:00 }
+---
+
+# Configuration
+
+Every setting Auto Title has is one of seven `HERDR_AUTO_TITLE_*` variables,
+read in `internal/app/config.go`. They can be set in the environment, or written
+into a file that is loaded into the environment before anything reads it.
+
+## Why a file exists
+
+Auto Title is started by the Herdr **server**, through the `[[startup]]` entry
+in `herdr-plugin.toml`. That process inherits the server's environment — not the
+shell you were in when you exported anything, and not the shell of the pane you
+happen to be looking at. Exporting a variable from your shell profile only
+reaches the plugin if the server itself was started after that profile ran, and
+it stops reaching it the moment the server is restarted from somewhere else.
+
+So the variables were, in practice, unsettable. The file is not a second way to
+configure the plugin; it is the only reliable delivery for the settings that
+already existed. It is read once, at startup, by `readConfigFile`, which loads
+it into the process environment; `fromEnv` then reads the environment exactly as
+it did before.
+
+## Where the file lives
+
+`config.env`, in the directory that already holds the manual-rename locks:
+
+| Platform | Path |
+|----------|------|
+| macOS | `~/Library/Application Support/herdr-auto-title/config.env` |
+| Linux | `~/.config/herdr-auto-title/config.env` (`$XDG_CONFIG_HOME` if set) |
+
+That is `os.UserConfigDir()`, the same call `state.DefaultManualPath` makes.
+One directory holds everything Auto Title owns, and a user who has found one
+file has found the other. The path is fixed: no variable and no flag moves it,
+because a configuration file whose location is itself configurable needs a
+configuration file to find it.
+
+**Herdr offers a directory of its own and Auto Title does not use it.** Herdr
+creates `~/.config/herdr/plugins/config/<plugin id>/` and prints it in `herdr
+plugin list`, and it names `HERDR_PLUGIN_CONFIG_DIR` among the variables it
+passes a plugin it starts — see [the socket API note](./herdr-socket-api.md) for
+how far that second half is verified. Two reasons against it: it exists only when the server starts the
+plugin, so a plugin run by hand — `make run`, `make dev`, every debugging
+session — would look somewhere else than the same plugin run normally, and it
+would split Auto Title's own files across two directories for no gain. The
+README says so out loud, because `herdr plugin list` will keep suggesting
+otherwise.
+
+## Why the environment still wins
+
+A variable already in the environment is left as it is; the file only fills what
+the environment does not say. `godotenv.Load` works that way by contract, so
+this costs no code.
+
+The file is where a setting lives permanently; the environment is how one run
+overrides it. That is what `make run` does — `HERDR_AUTO_TITLE_DEBUG=1` in front
+of the binary — and what anyone debugging does without thinking about it. Had
+the file won, a debug flag on the command line would have been silently ignored,
+which is the worst behaviour available.
+
+## Why a library
+
+`github.com/joho/godotenv` v1.5.1: about 500 lines, MIT, and **no transitive
+dependencies** — it is the plugin's second dependency and adds nothing below
+itself. Auto Title's own needs are narrower than what it does, so the syntax the
+file accepts is the library's, not a specification of ours:
+
+- `KEY=value`, `#` comments, blank lines, and `export KEY=value`.
+- Surrounding quotes are stripped, and `\n` inside double quotes is a newline.
+- `${VAR}` and `$VAR` are expanded **from the file itself, never from the
+  environment** (`expandVariables` is handed the map parsed from that file).
+  `MANUAL_FILE=${HOME}/names.json` therefore yields `/names.json`. This is the
+  one trap in the format, so the README warns about it.
+- **A single bad line costs the whole file.** The parser returns an error and no
+  values, so there is nothing to salvage line by line: Auto Title warns, naming
+  the file and what the parser objected to, and every setting keeps its default.
+
+Not warning about a key that is not ours is deliberate: `godotenv` puts every
+pair it reads into the environment, and a key Auto Title does not read simply
+has no effect. Nothing checks names against a list, so a typo is silent — the
+cost of that is one line in the README table.
+
+## Why it is not reread
+
+The file is read once. Half the settings are consumed in `main.run` while it
+builds the resolver chain — `MAX_LENGTH` and `BRANCH_MAX` are baked into
+`resolver.Default`, `POSITION` decides whether the chain is wrapped at all — so
+rereading the file mid-run would apply some settings and quietly ignore others.
+An honest restart is better than a reload that works half the time, and the
+plugin restarts in the time it takes the server to start it again: `herdr server
+stop`, then `herdr`.

--- a/docs/architecture/herdr-socket-api.md
+++ b/docs/architecture/herdr-socket-api.md
@@ -32,6 +32,25 @@ See [the poll loop](./poll-loop.md).
 A malformed request is answered with an uncorrelated error frame, and the
 connection is then closed.
 
+## What Herdr gives a plugin process
+
+A plugin the server starts inherits **the server's** environment, not the shell
+of whoever installed it — which is why settings reach Auto Title through a file;
+see [configuration](./configuration.md).
+
+Alongside `HERDR_SOCKET_PATH` and `HERDR_BIN_PATH`, the 0.8.2 binary names
+`HERDR_PLUGIN_ROOT`, `HERDR_PLUGIN_CONFIG_DIR` and `HERDR_PLUGIN_STATE_DIR` for
+a plugin process (and `HERDR_PLUGIN_ID`, `HERDR_PLUGIN_ENTRYPOINT_ID`,
+`HERDR_PLUGIN_CONTEXT_JSON` with it). `herdr plugin config-dir <plugin id>`
+prints the config directory, `herdr plugin list` repeats it, and Herdr creates
+it empty at install time: `~/.config/herdr/plugins/config/herdr.auto-title/`
+exists here.
+
+> **Not observed live.** The variable names come from strings in the `herdr`
+> 0.8.2 binary, not from the environment of a running plugin — seeing that needs
+> `herdr server stop`, which closes the session. The directory and the two CLI
+> commands were confirmed directly. Auto Title depends on none of it.
+
 ## The methods Auto Title uses
 
 Three, and no others (`internal/herdr/session.go`):

--- a/docs/development.md
+++ b/docs/development.md
@@ -174,6 +174,12 @@ lands, a name you set by hand is overwritten on the next context change.
 second by default, however fast its pane is churning. If a tab renames more
 often than you can read it, raise `HERDR_AUTO_TITLE_POLL_MS`.
 
+**`config.env` is read once, and `make dev` does not watch it.** The watcher
+rebuilds on `*.go` in the checkout, so a setting you change in the configuration
+directory reaches the plugin only when the process starts again: Ctrl+C and
+`make run`. Note that `make run` sets `HERDR_AUTO_TITLE_DEBUG=1` in the
+environment, which beats whatever the file says about it.
+
 **Short-lived tabs produce `tab_not_found`.** Herdr creates and closes tabs for
 its own purposes between a snapshot and the rename it leads to. That is handled
 and logged at DEBUG; if you see it as a warning, something regressed.

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/kryptamine/herdr-auto-title
 go 1.24
 
 require github.com/rivo/uniseg v0.4.7
+
+require github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -3,15 +3,20 @@ package app
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
+
+	"github.com/joho/godotenv"
 
 	"github.com/kryptamine/herdr-auto-title/internal/resolver"
 	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
 
-// Environment variables Auto Title reads. V1 has no configuration file.
+// Environment variables Auto Title reads. The configuration file holds the
+// same names; see docs/architecture/configuration.md.
 const (
 	EnvDebug      = "HERDR_AUTO_TITLE_DEBUG"
 	EnvPoll       = "HERDR_AUTO_TITLE_POLL_MS"
@@ -21,6 +26,10 @@ const (
 	EnvManual     = "HERDR_AUTO_TITLE_MANUAL_FILE"
 	EnvTranscript = "HERDR_AUTO_TITLE_TRANSCRIPT"
 )
+
+// ConfigFile is the configuration file, read from the same directory the
+// manual-rename locks are kept in.
+const ConfigFile = "config.env"
 
 // DefaultPoll is how often the session is read. A six-pane snapshot measured
 // 0.47 ms and 6 KB, so twice a second costs about a thousandth of a core, and
@@ -49,10 +58,15 @@ type Config struct {
 	ReadTranscripts bool
 }
 
-// LoadConfig reads configuration from the environment. Unusable values are
-// reported as warnings and the default is kept, so a typo never stops the
-// plugin from running.
+// LoadConfig reads configuration from the configuration file and the
+// environment. Unusable values are reported as warnings and the default is
+// kept, so a typo never stops the plugin from running.
 func LoadConfig() (Config, []string) {
+	var warnings []string
+	if warning := readConfigFile(); warning != "" {
+		warnings = append(warnings, warning)
+	}
+
 	cfg := Config{
 		Poll:            DefaultPoll,
 		MaxLength:       resolver.DefaultMaxLength,
@@ -61,7 +75,6 @@ func LoadConfig() (Config, []string) {
 		ManualPath:      state.DefaultManualPath(),
 		ReadTranscripts: true,
 	}
-	var warnings []string
 
 	cfg.Debug = fromEnv(&warnings, EnvDebug, cfg.Debug, boolean)
 	cfg.Poll = fromEnv(&warnings, EnvPoll, cfg.Poll, milliseconds)
@@ -77,6 +90,34 @@ func LoadConfig() (Config, []string) {
 	}
 
 	return cfg, warnings
+}
+
+// readConfigFile puts the file's settings into the environment, which is how a
+// setting reaches a plugin the Herdr server starts: that process inherits the
+// server's environment, never the user's shell.
+func readConfigFile() string {
+	path := configPath()
+	if path == "" {
+		return ""
+	}
+	// Load leaves a variable already in the environment alone, which is what
+	// makes the environment win over the file.
+	err := godotenv.Load(path)
+	if err == nil || errors.Is(err, fs.ErrNotExist) {
+		return ""
+	}
+	// One bad line costs the whole file: godotenv parses it or nothing.
+	return fmt.Sprintf("%s %s, so nothing in it is used", path, err)
+}
+
+// configPath is where the configuration file lives, or empty when the user has
+// no configuration directory at all.
+func configPath() string {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "herdr-auto-title", ConfigFile)
 }
 
 // fromEnv returns what the environment says name is, or fallback when it says

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -9,12 +11,35 @@ import (
 	"github.com/kryptamine/herdr-auto-title/internal/resolver"
 )
 
-// isolate clears every variable Auto Title reads, so a test sees only what it
-// sets and the environment the tests run in cannot change the outcome.
+// isolate takes a test off the developer's machine: HOME decides where the
+// configuration file is looked for, and every variable Auto Title reads is
+// removed so the test sees only what it sets.
 func isolate(t *testing.T) {
 	t.Helper()
-	for _, name := range []string{EnvDebug, EnvPoll, EnvMaxLength, EnvBranchMax, EnvPosition, EnvManual} {
+	t.Setenv("HOME", t.TempDir())
+	// Where os.UserConfigDir looks first on Linux, so HOME alone does not
+	// isolate anything until it is out of the way.
+	t.Setenv("XDG_CONFIG_HOME", "")
+	for _, name := range []string{EnvDebug, EnvPoll, EnvMaxLength, EnvBranchMax, EnvPosition, EnvManual, EnvTranscript} {
+		// Setenv first for its cleanup, which then also undoes what the
+		// configuration file sets; an empty variable is not an absent one.
 		t.Setenv(name, "")
+		os.Unsetenv(name)
+	}
+}
+
+// writeConfig puts contents where LoadConfig looks for the configuration file.
+func writeConfig(t *testing.T, contents string) {
+	t.Helper()
+	path := configPath()
+	if path == "" {
+		t.Fatal("no configuration directory")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -149,5 +174,108 @@ func TestAnUnusableValueIsReportedInFull(t *testing.T) {
 		if !strings.Contains(warnings[0], want) {
 			t.Errorf("warning %q does not mention %q", warnings[0], want)
 		}
+	}
+}
+
+func TestLoadConfigReadsTheFile(t *testing.T) {
+	isolate(t)
+	writeConfig(t, `# every setting the file can carry
+HERDR_AUTO_TITLE_DEBUG=true
+HERDR_AUTO_TITLE_POLL_MS=800
+HERDR_AUTO_TITLE_MAX_LENGTH=32
+HERDR_AUTO_TITLE_BRANCH_MAX=0
+HERDR_AUTO_TITLE_POSITION=false
+HERDR_AUTO_TITLE_TRANSCRIPT=false
+HERDR_AUTO_TITLE_MANUAL_FILE=/tmp/names.json
+`)
+
+	cfg, warnings := LoadConfig()
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want none", warnings)
+	}
+	if !cfg.Debug {
+		t.Error("debug is off despite the file enabling it")
+	}
+	if cfg.Poll != 800*time.Millisecond {
+		t.Errorf("poll = %s, want 800ms", cfg.Poll)
+	}
+	if cfg.MaxLength != 32 {
+		t.Errorf("max length = %d, want 32", cfg.MaxLength)
+	}
+	if cfg.BranchMax != 0 {
+		t.Errorf("branch max = %d, want 0", cfg.BranchMax)
+	}
+	if cfg.ShowPosition {
+		t.Error("positions are on despite the file turning them off")
+	}
+	if cfg.ReadTranscripts {
+		t.Error("transcripts are read despite the file turning them off")
+	}
+	if cfg.ManualPath != "/tmp/names.json" {
+		t.Errorf("manual path = %q, want the one the file names", cfg.ManualPath)
+	}
+}
+
+func TestTheEnvironmentBeatsTheFile(t *testing.T) {
+	// The file is where a setting lives permanently; the environment is how it
+	// is overridden for one run, which is what `make run` does with debug.
+	isolate(t)
+	writeConfig(t, "HERDR_AUTO_TITLE_POLL_MS=800\n")
+	t.Setenv(EnvPoll, "250")
+
+	cfg, warnings := LoadConfig()
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want none", warnings)
+	}
+	if cfg.Poll != 250*time.Millisecond {
+		t.Errorf("poll = %s, want the 250ms the environment asked for", cfg.Poll)
+	}
+}
+
+func TestAMissingConfigFileIsSilent(t *testing.T) {
+	isolate(t)
+
+	cfg, warnings := LoadConfig()
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want none", warnings)
+	}
+	if cfg.Poll != DefaultPoll {
+		t.Errorf("poll = %s, want the default %s", cfg.Poll, DefaultPoll)
+	}
+}
+
+func TestABrokenConfigFileCostsTheWholeFile(t *testing.T) {
+	// godotenv parses the file or nothing, so a good line next to a bad one is
+	// lost with it. The warning is all the user gets.
+	isolate(t)
+	writeConfig(t, "HERDR_AUTO_TITLE_POLL_MS=800\nHERDR_AUTO_TITLE_MAX_LENGTH=\"32\n")
+
+	cfg, warnings := LoadConfig()
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want one", warnings)
+	}
+	if !strings.Contains(warnings[0], ConfigFile) {
+		t.Errorf("warning %q does not name the file", warnings[0])
+	}
+	if cfg.Poll != DefaultPoll {
+		t.Errorf("poll = %s, want the default %s", cfg.Poll, DefaultPoll)
+	}
+	if cfg.MaxLength != resolver.DefaultMaxLength {
+		t.Errorf("max length = %d, want the default %d", cfg.MaxLength, resolver.DefaultMaxLength)
+	}
+}
+
+func TestAKeyOfSomeoneElsesIsIgnored(t *testing.T) {
+	// godotenv puts every key in the file into the environment; only the ones
+	// Auto Title reads mean anything to it.
+	isolate(t)
+	writeConfig(t, "HERDR_AUTO_TITLE_POL_MS=800\nSOMETHING_ELSE=1\n")
+
+	cfg, warnings := LoadConfig()
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want none", warnings)
+	}
+	if cfg.Poll != DefaultPoll {
+		t.Errorf("poll = %s, want the default %s", cfg.Poll, DefaultPoll)
 	}
 }


### PR DESCRIPTION
## Why

A plugin the Herdr server starts inherits **the server's** environment, not the shell of whoever installed it. Exporting `HERDR_AUTO_TITLE_*` from a shell profile only reached the plugin if the server happened to be started after that profile ran, and stopped reaching it as soon as the server was restarted from somewhere else. The seven settings were, in practice, unsettable.

## What

`config.env`, in the directory that already holds the manual-rename locks, is loaded into the environment before anything reads it:

| Platform | File |
|----------|------|
| macOS | `~/Library/Application Support/herdr-auto-title/config.env` |
| Linux | `~/.config/herdr-auto-title/config.env` |

- The settings keep their names, so one name works in the file, in a shell and in the docs, and `fromEnv` keeps its job.
- **A variable already in the environment wins**, which is what leaves `make run` and a one-off override on the command line working. `godotenv.Load` behaves that way by contract, so it costs no code.
- No file, or no config directory at all: silence and defaults. Unreadable or unparseable: one warning naming the file and what the parser objected to, and every setting keeps its default. The plugin never refuses to start.
- Read once, at startup. Half the settings are consumed while `main.run` builds the resolver chain, so a reload would apply some and quietly ignore others.

Herdr offers `HERDR_PLUGIN_CONFIG_DIR` and creates `~/.config/herdr/plugins/config/<id>/`, and Auto Title deliberately does not use it: it exists only when the server starts the plugin, so `make run` and every debugging session would read a different file than the same plugin run normally. The README says so, because `herdr plugin list` keeps suggesting otherwise.

Second dependency: `github.com/joho/godotenv` v1.5.1, MIT, ~500 lines, no transitive dependencies. Its syntax is the file's syntax, including the two traps documented in the README: `${VAR}` expands from the file and never from the environment, and one bad line costs the whole file.

## Verified

`make check` green. Run against a temp `HOME` with `HERDR_SOCKET_PATH` empty, so the process prints its configuration and exits without touching any tab:

```
poll=800ms max_length=32                    # from the file
poll=250ms max_length=32                    # HERDR_AUTO_TITLE_POLL_MS=250 beat the file
WARN …/config.env unterminated quoted value "32, so nothing in it is used
poll=500ms max_length=50                    # broken file, everything on defaults
```

New tests cover: the file is read; the environment beats the file; a missing file is silent; a broken file warns and loses everything in it; a key that is not ours does nothing. `isolate` now points `HOME` at a temp directory and clears `XDG_CONFIG_HOME`, so the tests no longer depend on what the developer has in their own config directory.

## Docs

README gets a Configuration section with every setting and its default, `config.env.example` lands in the repository root, and [docs/architecture/configuration.md](docs/architecture/configuration.md) records why the file exists and why it is not Herdr's directory. `CLAUDE.md` and the socket API note gain the plugin-environment facts, with the honest caveat: the directory and both `herdr plugin` commands were confirmed directly, while the `HERDR_PLUGIN_*` variable names come from strings in the 0.8.2 binary and were not observed on a live plugin, since that needs a `herdr server stop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)