### PR TITLE
Spend the poll's reads where they are used, and hand a cleared tab back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,10 @@ listed here** (`make probe-*`, `scripts/probe.py`).
   *position* in the workspace, counted from one, and that label shifts down when
   a tab to its left closes. The snapshot lists tabs in display order, so the
   position is their count within the workspace.
+- **An unnamed tab reports one of two labels.** A tab nobody has named carries
+  its position, but `tab.rename` with an empty label stores the empty string and
+  the snapshot reports it. Both render as the position in the tab bar, so code
+  reading the label to mean "unnamed" must accept either.
 - **A plugin the server starts inherits the server's environment**, not the
   shell of whoever installed it, which is why `HERDR_AUTO_TITLE_*` settings
   arrive through `config.env` (see

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ These rules explain most surprises:
 - **A branch shows when it distinguishes.** Your repository's default branch
   says nothing, so it is left out; anything else is shown, shortened to what
   identifies it (`bugfix-asa-cpanel-uapi-mc-13675` → `MC-13675`).
-- **A tab you renamed is yours** and Auto Title never touches it again. Renaming
-  it back does not hand it over: stop the plugin, delete the tab's entry from
-  `manual-names.json`, and start the plugin again.
+- **A tab you renamed is yours** and Auto Title never touches it again. Clear
+  its name and it is handed back, on the next poll; renaming it to something
+  else keeps it yours under the new name.
 - Paths, shell prompts, bare program names and your workspace name are left out,
   because they only repeat what the screen already shows.
 - A tab with several panes takes its name from one of them: the focused pane, a

--- a/docs/architecture/herdr-socket-api.md
+++ b/docs/architecture/herdr-socket-api.md
@@ -157,3 +157,9 @@ reads, so this section describes Herdr rather than those types.
 
   Reading `number` as the default label locked every tab created after startup;
   the story is in [manual rename protection](./manual-rename-protection.md).
+- **A tab has two unnamed shapes, and only one of them is the position.** A tab
+  nobody has named reports its position (`herdr tab create` in a four-tab
+  workspace answered `label: "5"`), but clearing a name stores exactly what it
+  was given: `herdr tab rename wG:tS ""` answered `label: ""`, and the snapshot
+  reported the same. The tab bar shows the position for both. Anything reading
+  the label to mean "unnamed" has to accept the empty string as well.

--- a/docs/architecture/manual-rename-protection.md
+++ b/docs/architecture/manual-rename-protection.md
@@ -75,6 +75,14 @@ others for every tab. The cost is a user who renames a tab to exactly the digits
 of its position and is not protected, which is the same trade the *Desired*
 check already makes.
 
+There is a second shape of it. A tab nobody has named reports its position, but
+**clearing a name stores the empty string** — `tab.rename` keeps exactly what it
+is given, and the tab bar renders the position for both. Until that was probed,
+clearing a tab's name read as a rename to a label Auto Title had never seen, so
+the gesture a user reaches for to hand a tab back was the one that locked it for
+good. An empty label is therefore nobody's too, on the same line as the
+position.
+
 ## Locks outlive the process, guarded by the label
 
 Herdr can restart a plugin mid-session, and losing every manual name to that is
@@ -91,16 +99,23 @@ not running is not remembered.** It cannot be told apart from an id reused by a
 different session, and wrongly locking a stranger's tab is worse than forgetting
 a rename made in the seconds the plugin was down.
 
-## What this design cannot do
+## Handing a tab back
 
-**Once a tab is locked, it cannot return to automatic naming while the plugin is
-running.** Renaming it again does not release it: `Retain` drops the old lock
-because the label moved, and the same poll takes a new one on the new label.
+**Clear the tab's name and Auto Title takes it again**, on the next poll, with
+the plugin running. Nothing implements that: `Retain` releases the lock because
+the label moved off the one it was taken with, and `Observe` declines to take a
+new one because an unnamed tab is nobody's. Renaming the tab to its position
+does the same thing for the same reason.
 
-The way back is to stop the plugin, remove the tab's entry from
-`manual-names.json` (or delete the file), and start it again — editing the file
-under a running plugin achieves nothing, because the locks live in memory and
-the file is rewritten from them.
+Renaming it to anything else does **not** hand it back. The lock is released and
+retaken within the poll, now on the new label — which is what keeps a tab the
+user renames twice theirs.
+
+What remains impossible while the plugin runs is releasing a lock without
+touching the tab. The way to that is still to stop the plugin, remove the tab's
+entry from `manual-names.json` (or delete the file), and start it again —
+editing the file under a running plugin achieves nothing, because the locks live
+in memory and the file is rewritten from them.
 
 A `reset` subcommand talking to the running process over a control channel of
 its own is specified and not built.

--- a/docs/architecture/poll-loop.md
+++ b/docs/architecture/poll-loop.md
@@ -80,6 +80,10 @@ cannot express it:
   provokes. So the reuse is bounded twice: by the revision, which catches the
   common case in the very next poll, and by `processRefresh` (2 s), which is
   what actually bounds how wrong the answer can be.
+
+  Only the pane a tab is named from is asked about, so the request is per tab
+  rather than per pane. The reuse still earns its keep: focus moves between the
+  panes of a tab, and what was read for one is still there when it comes back.
 - **How far each agent transcript has been read** (`internal/claude/transcript.go`).
   A transcript is append-only, so a poll reads the bytes appended since the last
   one rather than the file: a session that has run all day is megabytes, and
@@ -106,17 +110,31 @@ changes name at most once per poll however fast its pane is churning, so
 
 1. `session.snapshot` — the whole session in one request.
 2. `Changes.Observe` — note which panes' revisions advanced.
-3. `tabsIn` — assemble tabs with their panes, asking `pane.process_info` about
-   the panes that moved since they were last read and reusing the last answer
-   for the rest. A pane whose processes cannot be read simply has none, and a
-   failed read is not remembered as an answer. Each pane's directory is read for
-   the branch it has checked out, every poll and without a cache: two small file
-   reads at 0.038 ms are cheaper than the bookkeeping that would keep a stale
-   answer — see [title resolution](./title-resolution.md#the-git-branch).
-4. `Manual.Retain` — drop bookkeeping for tabs the session no longer holds.
-5. Per tab: skip it if locked, otherwise resolve a title, check whether the
-   label moved under us, and rename when the result differs from the label the
-   tab already carries.
+3. `Manual.Retain` — drop bookkeeping for tabs the session no longer holds,
+   and release a lock whose tab has moved on. This runs off the snapshot's own
+   labels, because it is what decides which tabs the next step can skip.
+4. `tabsIn` — assemble tabs with their panes from the snapshot alone. Nothing
+   is read here: assembly is what says which pane will be asked about.
+5. Per tab: skip it if locked, otherwise read the one pane the tab is named
+   from (`readInto`), resolve a title, check whether the label moved under us,
+   and rename when the result differs from the label the tab already carries.
+
+**Only the pane that names its tab is read**, and only while its tab is
+nobody's. `pane.process_info` is asked about the panes that moved since they
+were last read, reusing the last answer for the rest; a pane whose processes
+cannot be read simply has none, and a failed read is not remembered as an
+answer. That pane's directory is read for the branch it has checked out, every
+poll and without a cache: two small file reads at 0.038 ms are cheaper than the
+bookkeeping that would keep a stale answer — see
+[title resolution](./title-resolution.md#the-git-branch).
+
+The reads are left out rather than made and discarded because a tab is named
+from one pane (`SelectContextPane`) and a locked tab is not named at all. A
+four-pane tab therefore costs one process request rather than four, and a
+session the user has named by hand costs the snapshot and nothing else. The
+choice of pane is made from state the snapshot already carries — focus, agent
+status, and which pane last drew — so it can be made before anything is read,
+and the resolver arrives at the same pane on its own.
 
 **Deduplication is what keeps the loop quiet.** The snapshot reports each tab's
 current label, and a rename is skipped when the resolved title already equals

--- a/docs/architecture/title-resolution.md
+++ b/docs/architecture/title-resolution.md
@@ -186,7 +186,8 @@ The branch checked out in the pane's directory, read from the files under
 0.019 ms for reading `HEAD`, on a poll whose whole snapshot costs 0.47 ms. The
 reading is not cached — at 0.038 ms including the walk up to the repository, a
 fresh answer costs less than remembering a stale one, and a checkout shows up in
-the tab within one poll.
+the tab within one poll. It is read for the pane the tab is named from and no
+other, so the cost is one walk per tab rather than one per pane.
 
 A branch says which slice of a project a tab is on, so it qualifies the
 **context**: `dashboard › feat/oauth › nvim › auth.ts`. Three rules keep it from

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/kryptamine/herdr-auto-title/internal/claude"
-	"github.com/kryptamine/herdr-auto-title/internal/git"
 	"github.com/kryptamine/herdr-auto-title/internal/herdr"
 	"github.com/kryptamine/herdr-auto-title/internal/resolver"
 	"github.com/kryptamine/herdr-auto-title/internal/state"
@@ -88,36 +87,6 @@ func (a *App) poll(ctx context.Context, client herdr.Client) {
 	}
 }
 
-// failureLog decides how often a run of failing polls is worth mentioning. At
-// two polls a second, logging every one turns an hour of Herdr being down into
-// thousands of identical lines; logging as the run doubles costs a dozen.
-type failureLog struct {
-	run  int
-	next int
-}
-
-// failed records a failed poll and returns the length of the run when it is
-// worth logging, or zero when it is not.
-func (f *failureLog) failed() int {
-	f.run++
-	if f.run < f.next {
-		return 0
-	}
-
-	f.next = f.run * 2
-
-	return f.run
-}
-
-// recovered records a successful poll and returns how many polls the run of
-// failures it ended cost, or zero when nothing was wrong.
-func (f *failureLog) recovered() int {
-	run := f.run
-	f.run, f.next = 0, 0
-
-	return run
-}
-
 // readAndRename reads the session and renames every tab whose title no longer
 // fits.
 func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
@@ -154,29 +123,7 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 			continue
 		}
 
-		if err := herdr.RenameTab(ctx, client, tab.ID, decision.Name); err != nil {
-			if herdr.ErrorCode(err) == herdr.CodeTabNotFound {
-				// The tab closed between the snapshot and the rename. The next
-				// poll will not see it at all.
-				a.log.Debug("tab closed before it could be renamed", "tab_id", tab.ID)
-				continue
-			}
-
-			a.log.Warn("rename failed", "tab_id", tab.ID, "name", decision.Name, "error", err)
-
-			continue
-		}
-
-		// Recorded before the log line so the next poll cannot read this
-		// rename as the user's.
-		a.manual.Applied(tab.ID, decision.Name)
-		a.log.Info("tab renamed",
-			"tab_id", tab.ID,
-			"old", tab.CurrentName,
-			"new", decision.Name,
-			"reason", decision.Reason,
-			"confidence", decision.Confidence,
-		)
+		a.rename(ctx, client, tab, decision)
 	}
 
 	// Reached only when every tab was seen. Deferring this would settle after a
@@ -184,6 +131,40 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 	a.manual.Settled()
 
 	return nil
+}
+
+// rename gives the tab the name the resolver chose. Nothing that goes wrong
+// here is worth cutting the poll short: the next one decides again from state
+// it has read again.
+func (a *App) rename(
+	ctx context.Context,
+	client herdr.Client,
+	tab state.TabState,
+	decision resolver.Decision,
+) {
+	if err := herdr.RenameTab(ctx, client, tab.ID, decision.Name); err != nil {
+		if herdr.ErrorCode(err) == herdr.CodeTabNotFound {
+			// The tab closed between the snapshot and the rename. The next
+			// poll will not see it at all.
+			a.log.Debug("tab closed before it could be renamed", "tab_id", tab.ID)
+			return
+		}
+
+		a.log.Warn("rename failed", "tab_id", tab.ID, "name", decision.Name, "error", err)
+
+		return
+	}
+
+	// Recorded before the log line so the next poll cannot read this rename as
+	// the user's.
+	a.manual.Applied(tab.ID, decision.Name)
+	a.log.Info("tab renamed",
+		"tab_id", tab.ID,
+		"old", tab.CurrentName,
+		"new", decision.Name,
+		"reason", decision.Reason,
+		"confidence", decision.Confidence,
+	)
 }
 
 // labelsOf indexes tabs by id for the manual-name bookkeeping, which needs both
@@ -195,132 +176,4 @@ func labelsOf(tabs []state.TabState) map[string]string {
 	}
 
 	return labels
-}
-
-// processesIn reports what a pane is running, reusing the last read while the
-// pane's revision holds and that read is recent. Neither test is exact, which
-// is why there are two — see docs/architecture/poll-loop.md.
-func (a *App) processesIn(
-	ctx context.Context,
-	client herdr.Client,
-	paneID string,
-) []herdr.PaneProcessInfoProcess {
-	if processes, read := a.changes.Processes(paneID); read {
-		return processes
-	}
-
-	processes, err := herdr.PaneProcesses(ctx, client, paneID)
-	if err != nil {
-		if herdr.ErrorCode(err) != herdr.CodePaneNotFound && ctx.Err() == nil {
-			a.log.Debug("could not read what a pane is running", "pane_id", paneID, "error", err)
-		}
-
-		return nil
-	}
-
-	a.changes.Ran(paneID, processes)
-
-	return processes
-}
-
-// checkoutIn reports what the repository holding the pane has checked out.
-// Unlike a process read it is not cached, and why not is in
-// docs/architecture/title-resolution.md.
-func (a *App) checkoutIn(ctx context.Context, pane herdr.PaneInfo) git.Checkout {
-	// A branch width of zero is how branches are turned off, and a read whose
-	// answer is thrown away is still a read on every pane twice a second.
-	if a.cfg.BranchMax <= 0 {
-		return git.Checkout{}
-	}
-
-	if spentPoll(ctx) {
-		return git.Checkout{}
-	}
-
-	checkout, _ := git.Read(pane.Dir())
-
-	return checkout
-}
-
-// topicIn reports what the session the pane's agent is holding says it is
-// about. Only Claude Code's transcripts are understood, and only Herdr's
-// integration hook says which session a pane holds.
-func (a *App) topicIn(ctx context.Context, pane herdr.PaneInfo) string {
-	if !a.cfg.ReadTranscripts || spentPoll(ctx) {
-		return ""
-	}
-
-	sessionID, ok := pane.AgentSession.IDFor(claude.Agent)
-	if !ok {
-		return ""
-	}
-
-	return a.topics.Topic(sessionID, pane.Dir()).Text()
-}
-
-// spentPoll reports that this poll is past its deadline, in which case the tab
-// loop will discard it. The reads it guards go to the filesystem, which takes
-// no context, so the only way to bound them is not to start them.
-func spentPoll(ctx context.Context) bool {
-	return ctx.Err() != nil
-}
-
-// sessionsIn lists the agent sessions the snapshot holds, which is what the
-// transcript reader keeps its places for.
-func sessionsIn(panes []herdr.PaneInfo) []string {
-	sessions := make([]string, 0, len(panes))
-	for _, pane := range panes {
-		if pane.AgentSession != nil {
-			sessions = append(sessions, pane.AgentSession.Value)
-		}
-	}
-
-	return sessions
-}
-
-// tabsIn assembles the snapshot's tabs with their panes. What is running in a
-// pane needs a request of its own, which processesIn makes only when the last
-// answer will no longer do.
-func (a *App) tabsIn(
-	ctx context.Context,
-	client herdr.Client,
-	snapshot herdr.Snapshot,
-) []state.TabState {
-	workspaces := make(map[string]string, len(snapshot.Workspaces))
-
-	for _, workspace := range snapshot.Workspaces {
-		workspaces[workspace.WorkspaceID] = workspace.Label
-	}
-
-	byTab := make(map[string][]*state.PaneState, len(snapshot.Tabs))
-
-	for _, pane := range snapshot.Panes {
-		byTab[pane.TabID] = append(byTab[pane.TabID], state.PaneFrom(pane, state.Reads{
-			Processes: a.processesIn(ctx, client, pane.PaneID),
-			Git:       a.checkoutIn(ctx, pane),
-			Topic:     a.topicIn(ctx, pane),
-			ChangedAt: a.changes.ChangedAt(pane.PaneID),
-		}))
-	}
-
-	// An unnamed tab carries its place in the workspace, and the snapshot lists
-	// tabs in display order, so counting them gives that label.
-	positions := make(map[string]int, len(snapshot.Workspaces))
-	tabs := make([]state.TabState, 0, len(snapshot.Tabs))
-
-	for _, info := range snapshot.Tabs {
-		positions[info.WorkspaceID]++
-
-		tabs = append(
-			tabs,
-			state.TabFrom(
-				info,
-				workspaces[info.WorkspaceID],
-				positions[info.WorkspaceID],
-				byTab[info.TabID],
-			),
-		)
-	}
-
-	return tabs
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -100,9 +100,11 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 
 	a.changes.Observe(snapshot.Panes)
 	a.topics.Retain(sessionsIn(snapshot.Panes))
+	// Taken from the snapshot rather than from the tabs below, because this is
+	// what decides which of them are locked, and a locked tab is never read.
+	a.manual.Retain(labelsIn(snapshot.Tabs))
 
-	tabs := a.tabsIn(ctx, client, snapshot)
-	a.manual.Retain(labelsOf(tabs))
+	tabs := a.tabsIn(snapshot)
 
 	for _, tab := range tabs {
 		if ctx.Err() != nil {
@@ -112,6 +114,12 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 		if a.manual.Locked(tab.ID) {
 			continue
 		}
+
+		// The reads happen here rather than during assembly: they are what a
+		// poll spends, and this is where it is known they will be used. The
+		// resolver picks the same pane again, which the choice being made from
+		// state alone is what guarantees.
+		a.readInto(ctx, client, state.SelectContextPane(tab))
 
 		decision := a.titles.Resolve(tab)
 		if a.manual.Observe(state.SightingFrom(tab, decision.Name)) {
@@ -167,12 +175,12 @@ func (a *App) rename(
 	)
 }
 
-// labelsOf indexes tabs by id for the manual-name bookkeeping, which needs both
-// an id that is gone and a label that has moved on.
-func labelsOf(tabs []state.TabState) map[string]string {
+// labelsIn indexes the session's tabs by id for the manual-name bookkeeping,
+// which needs both an id that is gone and a label that has moved on.
+func labelsIn(tabs []herdr.TabInfo) map[string]string {
 	labels := make(map[string]string, len(tabs))
 	for _, tab := range tabs {
-		labels[tab.ID] = tab.CurrentName
+		labels[tab.TabID] = tab.Label
 	}
 
 	return labels

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -416,7 +416,7 @@ func TestAgentContextNamesTheTab(t *testing.T) {
 
 func TestARemoteSessionIsNamedAfterItsHost(t *testing.T) {
 	// What is running in a pane is not in the snapshot, so this exercises the
-	// extra read the poll makes for every pane.
+	// extra read the poll makes for the pane that names the tab.
 	h := start(
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
@@ -696,6 +696,57 @@ func TestAPaneThatCannotBeReadIsAskedAgain(t *testing.T) {
 	}
 }
 
+func TestAPaneThatDoesNotNameItsTabIsNotRead(t *testing.T) {
+	// A tab is named from one pane, so asking what the others are running is a
+	// request each whose answer nothing would look at.
+	h := start(
+		t,
+		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		[]herdr.PaneInfo{
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p2", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard"},
+			{PaneID: "wE:p3", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard"},
+		},
+	)
+	h.awaitRenames(1)
+	h.awaitPolls(10)
+
+	if reads := h.client.ProcessReads(); reads != 1 {
+		t.Errorf("read %d panes, want only the one the tab is named from", reads)
+	}
+}
+
+func TestALockedTabIsNotReadEither(t *testing.T) {
+	// A tab the user has claimed is never renamed, so everything a rename
+	// would have been decided from is a read nobody asked for.
+	h := start(
+		t,
+		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		[]herdr.PaneInfo{
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+		},
+	)
+	h.awaitRenames(1)
+
+	h.client.SetTab(herdr.TabInfo{TabID: "wE:t1", Label: "Important work"})
+	h.awaitPolls(h.client.Polls() + 3)
+
+	before := h.client.ProcessReads()
+
+	// The pane keeps drawing, which is what makes a poll ask again.
+	for i := range 4 {
+		h.client.SetPane(herdr.PaneInfo{
+			PaneID: "wE:p1", TabID: "wE:t1", Focused: true, Revision: uint64(i + 2),
+			CWD: "/Users/dev/work/dashboard",
+		})
+		h.awaitPolls(h.client.Polls() + 2)
+	}
+
+	if reads := h.client.ProcessReads() - before; reads != 0 {
+		t.Errorf("asked what a locked tab's pane runs %d times, want never", reads)
+	}
+}
+
 // repoAt builds a repository on disk, since the branch is the one thing a poll
 // reads from the filesystem rather than from the session. Its trunk is always
 // `main`, so passing that as the branch is how a tab on the trunk is written.
@@ -765,10 +816,7 @@ func TestBranchesSwitchedOffAreNotRead(t *testing.T) {
 	cfg.BranchMax = 0
 	app := New(cfg, discardLogger(), testResolver(t))
 
-	if checkout := app.checkoutIn(
-		context.Background(),
-		herdr.PaneInfo{PaneID: "wE:p1", CWD: repo},
-	); checkout != (git.Checkout{}) {
+	if checkout := app.checkoutIn(context.Background(), repo); checkout != (git.Checkout{}) {
 		t.Errorf("checkout = %+v, want nothing read", checkout)
 	}
 }
@@ -862,7 +910,9 @@ func TestAPollPastItsDeadlineStopsReadingTheFilesystem(t *testing.T) {
 
 	// The live read first, so a checkout that never resolves cannot make the
 	// spent one below look like the guard working.
-	live := app.tabsIn(context.Background(), client, snapshot)
+	live := app.tabsIn(snapshot)
+	app.readInto(context.Background(), client, live[0].Panes[0])
+
 	if got := live[0].Panes[0].Git.Branch; got != "feat/oauth" {
 		t.Fatalf("branch = %q with time left, so this test proves nothing", got)
 	}
@@ -870,7 +920,9 @@ func TestAPollPastItsDeadlineStopsReadingTheFilesystem(t *testing.T) {
 	spent, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	tabs := app.tabsIn(spent, client, snapshot)
+	tabs := app.tabsIn(snapshot)
+	app.readInto(spent, client, tabs[0].Panes[0])
+
 	if got := tabs[0].Panes[0].Git; got != (git.Checkout{}) {
 		t.Errorf("checkout = %+v, want a poll past its deadline to read nothing", got)
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -534,6 +534,50 @@ func TestARenameByTheUserTurnsAutomaticNamingOff(t *testing.T) {
 	}
 }
 
+func TestClearingTheNameHandsTheTabBack(t *testing.T) {
+	// The way out of a lock, and the one a user reaches for: clear the name and
+	// the tab is nobody's again. Herdr stores that as an empty label.
+	h := start(
+		t,
+		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		[]herdr.PaneInfo{
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+		},
+	)
+	h.awaitRenames(1)
+
+	h.client.SetTab(herdr.TabInfo{TabID: "wE:t1", Label: "Important work"})
+	h.awaitPolls(h.client.Polls() + 3)
+
+	h.client.SetTab(herdr.TabInfo{TabID: "wE:t1", Label: ""})
+
+	if got := h.awaitRenames(2)[1].Label; got != "dashboard" {
+		t.Errorf("rename = %q, want the tab named again", got)
+	}
+}
+
+func TestATabPutBackOnItsPositionIsHandedBack(t *testing.T) {
+	// The same way out, spelled the other way Herdr says a tab is unnamed: the
+	// position it carries while nobody has named it.
+	h := start(
+		t,
+		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		[]herdr.PaneInfo{
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+		},
+	)
+	h.awaitRenames(1)
+
+	h.client.SetTab(herdr.TabInfo{TabID: "wE:t1", Label: "Important work"})
+	h.awaitPolls(h.client.Polls() + 3)
+
+	h.client.SetTab(herdr.TabInfo{TabID: "wE:t1", Label: "1"})
+
+	if got := h.awaitRenames(2)[1].Label; got != "dashboard" {
+		t.Errorf("rename = %q, want the tab named again", got)
+	}
+}
+
 func TestThePluginsOwnRenamesDoNotLockTheTab(t *testing.T) {
 	// Every rename changes a label the plugin then sees again. Reading its own
 	// work as the user's would stop it naming anything after the first time.

--- a/internal/app/failures.go
+++ b/internal/app/failures.go
@@ -1,0 +1,31 @@
+package app
+
+// failureLog decides how often a run of failing polls is worth mentioning. At
+// two polls a second, logging every one turns an hour of Herdr being down into
+// thousands of identical lines; logging as the run doubles costs a dozen.
+type failureLog struct {
+	run  int
+	next int
+}
+
+// failed records a failed poll and returns the length of the run when it is
+// worth logging, or zero when it is not.
+func (f *failureLog) failed() int {
+	f.run++
+	if f.run < f.next {
+		return 0
+	}
+
+	f.next = f.run * 2
+
+	return f.run
+}
+
+// recovered records a successful poll and returns how many polls the run of
+// failures it ended cost, or zero when nothing was wrong.
+func (f *failureLog) recovered() int {
+	run := f.run
+	f.run, f.next = 0, 0
+
+	return run
+}

--- a/internal/app/reads.go
+++ b/internal/app/reads.go
@@ -9,14 +9,10 @@ import (
 	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
 
-// tabsIn assembles the snapshot's tabs with their panes. What is running in a
-// pane needs a request of its own, which processesIn makes only when the last
-// answer will no longer do.
-func (a *App) tabsIn(
-	ctx context.Context,
-	client herdr.Client,
-	snapshot herdr.Snapshot,
-) []state.TabState {
+// tabsIn assembles the snapshot's tabs with their panes, and reads nothing:
+// what a pane is running, has checked out and is talking about each costs a
+// request or a file, and readInto spends that on the panes that earn it.
+func (a *App) tabsIn(snapshot herdr.Snapshot) []state.TabState {
 	workspaces := make(map[string]string, len(snapshot.Workspaces))
 
 	for _, workspace := range snapshot.Workspaces {
@@ -26,12 +22,10 @@ func (a *App) tabsIn(
 	byTab := make(map[string][]*state.PaneState, len(snapshot.Tabs))
 
 	for _, pane := range snapshot.Panes {
-		byTab[pane.TabID] = append(byTab[pane.TabID], state.PaneFrom(pane, state.Reads{
-			Processes: a.processesIn(ctx, client, pane.PaneID),
-			Git:       a.checkoutIn(ctx, pane),
-			Topic:     a.topicIn(ctx, pane),
-			ChangedAt: a.changes.ChangedAt(pane.PaneID),
-		}))
+		byTab[pane.TabID] = append(
+			byTab[pane.TabID],
+			state.PaneFrom(pane, a.changes.ChangedAt(pane.PaneID)),
+		)
 	}
 
 	// An unnamed tab carries its place in the workspace, and the snapshot lists
@@ -54,6 +48,21 @@ func (a *App) tabsIn(
 	}
 
 	return tabs
+}
+
+// readInto fills in what the snapshot could not say about the one pane a tab
+// is named from. The other panes of that tab keep what the snapshot said,
+// because nothing reads any more of them.
+func (a *App) readInto(ctx context.Context, client herdr.Client, pane *state.PaneState) {
+	if pane == nil {
+		return
+	}
+
+	pane.Read(state.Reads{
+		Processes: a.processesIn(ctx, client, pane.ID),
+		Git:       a.checkoutIn(ctx, pane.Dir),
+		Topic:     a.topicIn(ctx, pane),
+	})
 }
 
 // processesIn reports what a pane is running, reusing the last read while the
@@ -85,7 +94,7 @@ func (a *App) processesIn(
 // checkoutIn reports what the repository holding the pane has checked out.
 // Unlike a process read it is not cached, and why not is in
 // docs/architecture/title-resolution.md.
-func (a *App) checkoutIn(ctx context.Context, pane herdr.PaneInfo) git.Checkout {
+func (a *App) checkoutIn(ctx context.Context, dir string) git.Checkout {
 	// A branch width of zero is how branches are turned off, and a read whose
 	// answer is thrown away is still a read on every pane twice a second.
 	if a.cfg.BranchMax <= 0 {
@@ -96,7 +105,7 @@ func (a *App) checkoutIn(ctx context.Context, pane herdr.PaneInfo) git.Checkout 
 		return git.Checkout{}
 	}
 
-	checkout, _ := git.Read(pane.Dir())
+	checkout, _ := git.Read(dir)
 
 	return checkout
 }
@@ -104,7 +113,7 @@ func (a *App) checkoutIn(ctx context.Context, pane herdr.PaneInfo) git.Checkout 
 // topicIn reports what the session the pane's agent is holding says it is
 // about. Only Claude Code's transcripts are understood, and only Herdr's
 // integration hook says which session a pane holds.
-func (a *App) topicIn(ctx context.Context, pane herdr.PaneInfo) string {
+func (a *App) topicIn(ctx context.Context, pane *state.PaneState) string {
 	if !a.cfg.ReadTranscripts || spentPoll(ctx) {
 		return ""
 	}
@@ -114,7 +123,7 @@ func (a *App) topicIn(ctx context.Context, pane herdr.PaneInfo) string {
 		return ""
 	}
 
-	return a.topics.Topic(sessionID, pane.Dir()).Text()
+	return a.topics.Topic(sessionID, pane.Dir).Text()
 }
 
 // spentPoll reports that this poll is past its deadline, in which case the tab

--- a/internal/app/reads.go
+++ b/internal/app/reads.go
@@ -1,0 +1,138 @@
+package app
+
+import (
+	"context"
+
+	"github.com/kryptamine/herdr-auto-title/internal/claude"
+	"github.com/kryptamine/herdr-auto-title/internal/git"
+	"github.com/kryptamine/herdr-auto-title/internal/herdr"
+	"github.com/kryptamine/herdr-auto-title/internal/state"
+)
+
+// tabsIn assembles the snapshot's tabs with their panes. What is running in a
+// pane needs a request of its own, which processesIn makes only when the last
+// answer will no longer do.
+func (a *App) tabsIn(
+	ctx context.Context,
+	client herdr.Client,
+	snapshot herdr.Snapshot,
+) []state.TabState {
+	workspaces := make(map[string]string, len(snapshot.Workspaces))
+
+	for _, workspace := range snapshot.Workspaces {
+		workspaces[workspace.WorkspaceID] = workspace.Label
+	}
+
+	byTab := make(map[string][]*state.PaneState, len(snapshot.Tabs))
+
+	for _, pane := range snapshot.Panes {
+		byTab[pane.TabID] = append(byTab[pane.TabID], state.PaneFrom(pane, state.Reads{
+			Processes: a.processesIn(ctx, client, pane.PaneID),
+			Git:       a.checkoutIn(ctx, pane),
+			Topic:     a.topicIn(ctx, pane),
+			ChangedAt: a.changes.ChangedAt(pane.PaneID),
+		}))
+	}
+
+	// An unnamed tab carries its place in the workspace, and the snapshot lists
+	// tabs in display order, so counting them gives that label.
+	positions := make(map[string]int, len(snapshot.Workspaces))
+	tabs := make([]state.TabState, 0, len(snapshot.Tabs))
+
+	for _, info := range snapshot.Tabs {
+		positions[info.WorkspaceID]++
+
+		tabs = append(
+			tabs,
+			state.TabFrom(
+				info,
+				workspaces[info.WorkspaceID],
+				positions[info.WorkspaceID],
+				byTab[info.TabID],
+			),
+		)
+	}
+
+	return tabs
+}
+
+// processesIn reports what a pane is running, reusing the last read while the
+// pane's revision holds and that read is recent. Neither test is exact, which
+// is why there are two — see docs/architecture/poll-loop.md.
+func (a *App) processesIn(
+	ctx context.Context,
+	client herdr.Client,
+	paneID string,
+) []herdr.PaneProcessInfoProcess {
+	if processes, read := a.changes.Processes(paneID); read {
+		return processes
+	}
+
+	processes, err := herdr.PaneProcesses(ctx, client, paneID)
+	if err != nil {
+		if herdr.ErrorCode(err) != herdr.CodePaneNotFound && ctx.Err() == nil {
+			a.log.Debug("could not read what a pane is running", "pane_id", paneID, "error", err)
+		}
+
+		return nil
+	}
+
+	a.changes.Ran(paneID, processes)
+
+	return processes
+}
+
+// checkoutIn reports what the repository holding the pane has checked out.
+// Unlike a process read it is not cached, and why not is in
+// docs/architecture/title-resolution.md.
+func (a *App) checkoutIn(ctx context.Context, pane herdr.PaneInfo) git.Checkout {
+	// A branch width of zero is how branches are turned off, and a read whose
+	// answer is thrown away is still a read on every pane twice a second.
+	if a.cfg.BranchMax <= 0 {
+		return git.Checkout{}
+	}
+
+	if spentPoll(ctx) {
+		return git.Checkout{}
+	}
+
+	checkout, _ := git.Read(pane.Dir())
+
+	return checkout
+}
+
+// topicIn reports what the session the pane's agent is holding says it is
+// about. Only Claude Code's transcripts are understood, and only Herdr's
+// integration hook says which session a pane holds.
+func (a *App) topicIn(ctx context.Context, pane herdr.PaneInfo) string {
+	if !a.cfg.ReadTranscripts || spentPoll(ctx) {
+		return ""
+	}
+
+	sessionID, ok := pane.AgentSession.IDFor(claude.Agent)
+	if !ok {
+		return ""
+	}
+
+	return a.topics.Topic(sessionID, pane.Dir()).Text()
+}
+
+// spentPoll reports that this poll is past its deadline, in which case the tab
+// loop will discard it. The reads it guards go to the filesystem, which takes
+// no context, so the only way to bound them is not to start them.
+func spentPoll(ctx context.Context) bool {
+	return ctx.Err() != nil
+}
+
+// sessionsIn lists the agent sessions the snapshot holds, which is what the
+// transcript reader keeps its places for.
+func sessionsIn(panes []herdr.PaneInfo) []string {
+	sessions := make([]string, 0, len(panes))
+	for _, pane := range panes {
+		if pane.AgentSession != nil {
+			sessions = append(sessions, pane.AgentSession.Value)
+		}
+	}
+
+	return sessions
+}

--- a/internal/state/manual.go
+++ b/internal/state/manual.go
@@ -108,9 +108,10 @@ func (m *Manual) Observe(s Sighting) bool {
 	switch {
 	case s.Current == s.Desired:
 		return false
-	case s.Current == s.Default:
-		// Nobody has named it. A known tab can wear this too: the label comes
-		// back, and closing a tab shifts every label after it.
+	case s.Current == "", s.Current == s.Default:
+		// Nobody has named it. A known tab can wear either: clearing a name
+		// empties the label rather than putting the position back, and the
+		// position itself slides down when a tab to the left closes.
 		return false
 	case known:
 		if s.Current == previous {

--- a/internal/state/manual_test.go
+++ b/internal/state/manual_test.go
@@ -101,6 +101,23 @@ func TestATabFallingBackToItsDefaultLabelIsNotTheUsers(t *testing.T) {
 	}
 }
 
+func TestATabWhoseNameWasClearedIsNotTheUsers(t *testing.T) {
+	// Clearing a tab's name empties its label rather than putting the position
+	// back, so an empty label is Herdr's other way of saying nobody named it —
+	// see docs/architecture/herdr-socket-api.md.
+	m := newManual(t)
+	m.Observe(sighting("1"))
+	m.Applied("wE:t1", "dashboard")
+
+	if m.Observe(sighting("")) {
+		t.Fatal("a tab whose name was cleared was read as the user's")
+	}
+
+	if m.Locked("wE:t1") {
+		t.Error("the tab is locked")
+	}
+}
+
 func TestARenameByTheUserLocksTheTab(t *testing.T) {
 	m := newManual(t)
 	m.Observe(sighting("1"))

--- a/internal/state/tab.go
+++ b/internal/state/tab.go
@@ -34,6 +34,10 @@ type PaneState struct {
 	// the transcript Herdr pointed at. Empty unless the agent's integration
 	// hook is installed — see docs/architecture/title-resolution.md.
 	AgentTopic string
+	// AgentSession names the conversation that agent holds, which is how the
+	// transcript behind AgentTopic is found. Nil until the agent's integration
+	// reports one.
+	AgentSession *herdr.AgentSessionInfo
 
 	// Processes are the pane's foreground process and its descendants.
 	Processes []Process
@@ -56,18 +60,19 @@ type Process struct {
 }
 
 // Reads is what a poll learned about a pane that its snapshot entry does not
-// carry: each field costs a request or a file of its own.
+// carry: each field costs a request or a file of its own, which is why only
+// the pane that names its tab is read.
 type Reads struct {
 	Processes []herdr.PaneProcessInfoProcess
 	Git       git.Checkout
 	// Topic is what the agent's own session says it is about.
 	Topic string
-	// ChangedAt is when a poll last saw the pane's revision move.
-	ChangedAt time.Time
 }
 
-// PaneFrom builds pane context from a snapshot entry and what was read around it.
-func PaneFrom(info herdr.PaneInfo, reads Reads) *PaneState {
+// PaneFrom builds pane context from a snapshot entry and when a poll last saw
+// the pane's revision move. What the snapshot cannot say is filled in by Read,
+// and for most panes never is.
+func PaneFrom(info herdr.PaneInfo, changedAt time.Time) *PaneState {
 	return &PaneState{
 		ID:               info.PaneID,
 		Dir:              info.Dir(),
@@ -77,12 +82,19 @@ func PaneFrom(info herdr.PaneInfo, reads Reads) *PaneState {
 		DisplayAgent:     info.DisplayAgent,
 		AgentTitle:       info.Title,
 		AgentStatus:      info.AgentStatus,
-		AgentTopic:       reads.Topic,
-		Processes:        processesFrom(reads.Processes),
-		Git:              reads.Git,
+		AgentSession:     info.AgentSession,
 		Focused:          info.Focused,
-		ChangedAt:        reads.ChangedAt,
+		ChangedAt:        changedAt,
 	}
+}
+
+// Read fills in what a snapshot does not carry. It is a step of its own so a
+// poll can leave it out: a tab is named from one pane, and every read behind
+// this costs a request or a file — see docs/architecture/poll-loop.md.
+func (p *PaneState) Read(reads Reads) {
+	p.Processes = processesFrom(reads.Processes)
+	p.Git = reads.Git
+	p.AgentTopic = reads.Topic
 }
 
 func processesFrom(processes []herdr.PaneProcessInfoProcess) []Process {

--- a/internal/state/tab_test.go
+++ b/internal/state/tab_test.go
@@ -75,7 +75,8 @@ func TestPaneFromReadsAgentContext(t *testing.T) {
 		Agent:                 "claude",
 		DisplayAgent:          "Claude Code",
 		AgentStatus:           herdr.AgentStatusWorking,
-	}, Reads{Topic: "Rework the poll loop", ChangedAt: stamp})
+	}, stamp)
+	pane.Read(Reads{Topic: "Rework the poll loop"})
 
 	switch {
 	case pane.TerminalTitle != "Claude Code":
@@ -96,7 +97,7 @@ func TestPaneFromReadsAgentContext(t *testing.T) {
 func TestPaneWithoutAnAgent(t *testing.T) {
 	pane := PaneFrom(
 		herdr.PaneInfo{PaneID: "wE:p1", AgentStatus: herdr.AgentStatusUnknown},
-		Reads{},
+		time.Time{},
 	)
 	if pane.HasAgent() || pane.AgentIsActive() {
 		t.Errorf("pane %+v reported an agent", pane)
@@ -209,14 +210,14 @@ func TestPaneFromPrefersTheShellsDirectory(t *testing.T) {
 	// when the shell's own directory is missing.
 	both := PaneFrom(herdr.PaneInfo{
 		PaneID: "wE:p1", CWD: "/work/dashboard", ForegroundCWD: "/tmp",
-	}, Reads{})
+	}, time.Time{})
 	if both.Dir != "/work/dashboard" {
 		t.Errorf("dir = %q, want the shell's own", both.Dir)
 	}
 
 	foreground := PaneFrom(herdr.PaneInfo{
 		PaneID: "wE:p1", ForegroundCWD: "/work/api",
-	}, Reads{})
+	}, time.Time{})
 	if foreground.Dir != "/work/api" {
 		t.Errorf("dir = %q, want the foreground process's", foreground.Dir)
 	}


### PR DESCRIPTION
Three changes to the poll loop, smallest first.

## `refactor(app)`: split the poll loop from its reads

`app.go` held four unrelated things: the loop, the backoff deciding how loudly a
run of failures is logged, the per-pane reads, and the assembly of tabs from a
snapshot. `failureLog` moves to `failures.go`, the reads and the assembly to
`reads.go`, and the rename itself becomes `App.rename` — the loop is now a list
of reasons to skip a tab and one line that acts. Code and comments move
verbatim.

## `perf(app)`: read only the pane that names a tab

A poll asked `pane.process_info` about every pane, walked every pane's directory
for its branch and read every agent transcript — then named each tab from one
pane and threw the rest away. A tab the user had renamed by hand paid all of it
too, only to be skipped a moment later.

The reads move out of assembly and into the tab loop, behind the lock check, and
are made for `SelectContextPane`'s choice alone. That choice comes from the
snapshot — focus, agent status, and which pane last drew — so it can be made
before anything is read, and the resolver reaches the same pane on its own.
`PaneFrom` now builds what the snapshot carries and `PaneState.Read` fills in
what costs a request or a file.

Measured on a stub session: three panes in one tab went from three process reads
a poll to one, and a locked tab from one per poll to none.

## `fix(state)`: hand a tab back when its name is cleared

Clearing a tab's name is the gesture a user reaches for to give a tab back, and
it did the opposite: it locked the tab for the rest of the session.

Probed against Herdr 0.8.2: `tab create` in a four-tab workspace answers
`label: "5"`, while `tab rename <id> ""` stores and reports the empty string.
The tab bar renders the position for both, so both are Herdr saying nobody has
named this tab — and `Observe` now reads them the same way. The fact is recorded
in `CLAUDE.md` and `docs/architecture/herdr-socket-api.md`.

The documents claimed there was no way back at all while the plugin ran. There
always was one — renaming a tab to its position released the lock — and that is
now documented beside clearing the name, in the design doc and the README.

## Verification

`make check` green. Live session, single instance, on a scratch tab created and
closed for it:

```
tab renamed  wG:t0  old=4   new="4 · herdr-auto-title"  reason=cwd
leaving a tab the user renamed  wG:t0  name="Important work"
tab renamed  wG:t0  old=""  new="4 · herdr-auto-title"  reason=cwd
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)