### PR TITLE
chore(github): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Bug report
+description: A tab is named wrongly, or the plugin does not behave as documented
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Two things account for most reports: installing does not start the
+        plugin until the Herdr server has restarted (`herdr server stop`), and
+        a tab you renamed by hand is left alone from then on.
+        `herdr plugin list` shows whether the plugin is registered and running.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: The title a tab carried, or what the plugin did instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce it
+      description: >-
+        What the pane held when it went wrong — the command, the agent, the
+        working directory, the branch, how many panes the tab had.
+      placeholder: |
+        1. Open a tab in ~/work/project on branch feature/x
+        2. The tab is named …
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Auto Title version
+      description: From `herdr plugin list`.
+      placeholder: "0.3.1"
+    validations:
+      required: true
+
+  - type: input
+    id: herdr-version
+    attributes:
+      label: Herdr version
+      description: From `herdr --version`.
+      placeholder: "herdr 0.8.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: >-
+        Any `HERDR_AUTO_TITLE_*` settings you changed, from your `config.env`.
+        Leave it empty if you run the defaults.
+      render: shell
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: DEBUG logs
+      description: >-
+        Set `HERDR_AUTO_TITLE_DEBUG=1` in your `config.env`, restart the server
+        and paste the lines around the bad rename. Logs carry tab titles,
+        commands and paths — remove anything you would rather not publish.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: How the plugin works
+    url: https://github.com/kryptamine/herdr-auto-title/tree/main/docs/architecture
+    about: The poll loop, title resolution, sanitizing, manual rename protection — the design and why it is that way.
+  - name: Contributing
+    url: https://github.com/kryptamine/herdr-auto-title/blob/main/CONTRIBUTING.md
+    about: What needs an issue first, how changes are made here, and how to get set up.
+  - name: Herdr itself
+    url: https://herdr.dev
+    about: A bug in the terminal rather than in this plugin belongs with Herdr.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: A title Auto Title should produce, or a setting it should offer
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Scope gets settled on the issue before anyone spends an evening on it,
+        so say what the tab bar should end up looking like rather than which
+        function should change.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What the tab is named today, and why that is not enough.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What it should do instead
+      description: >-
+        Give the tab label you want, as it would render — one line, 50 columns
+        by default.
+      placeholder: |
+        3 · dashboard › build
+    validations:
+      required: true
+
+  - type: textarea
+    id: source
+    attributes:
+      label: Where the plugin would read it from
+      description: >-
+        If you know which part of the session carries it — the pane's process,
+        its terminal title, the agent's session, the repository — say so.
+        Leave it empty if you do not.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you tried
+      description: >-
+        Settings you already changed, or a rename by hand that you would rather
+        not repeat.


### PR DESCRIPTION
Issues are open to anyone on a public repository, and until now the form was blank. A report is only actionable with the Herdr version, the plugin version and what the pane held, so the templates ask for those instead of hoping they turn up in the thread.

- **Bug report** (`bug`): what happened, what was expected, how to reproduce, Auto Title version from `herdr plugin list`, Herdr version from `herdr --version`, OS, changed `HERDR_AUTO_TITLE_*` settings and DEBUG logs — with a note to strip anything private, since logs carry tab titles, commands and paths. The intro heads off the two most common non-bugs: the plugin does not start until the server restarts, and a tab renamed by hand is left alone.
- **Feature request** (`enhancement`): asks for the tab label wanted, as it would render, rather than the function to change — CONTRIBUTING settles scope on the issue first.
- **config.yml**: blank issues stay enabled (Discussions are off, so questions outside the two forms need somewhere to land), plus links to `docs/architecture`, `CONTRIBUTING.md` and herdr.dev for bugs in the terminal itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)