### PR TITLE
Fold the duplication a code review found, and two rule cleanups

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -944,7 +944,7 @@ func agentPane() herdr.PaneInfo {
 		PaneID: "wE:p1", TabID: "wE:t1", Focused: true, CWD: testDir,
 		TerminalTitleStripped: "Claude Code",
 		Agent:                 "claude",
-		AgentStatus:           herdr.AgentStatusIdle,
+		AgentStatus:           "idle",
 		AgentSession: &herdr.AgentSessionInfo{
 			Agent: "claude", Kind: herdr.SessionRefID, Value: testSession,
 		},

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -165,28 +165,25 @@ func boolean(raw string) (bool, error) {
 // count reads a number that must be positive. Zero would stop the plugin doing
 // anything: a poll interval of zero spins, and a title of no length is no title.
 func count(raw string) (int, error) {
-	value, err := strconv.Atoi(raw)
-	if err != nil {
-		return 0, errNotNumber
-	}
-
-	if value <= 0 {
-		return 0, errNotPositive
-	}
-
-	return value, nil
+	return atLeast(raw, 1, errNotPositive)
 }
 
 // countOrNone reads a number that may be zero, for a setting where zero means
 // "none of this" rather than a value that would stop the plugin working.
 func countOrNone(raw string) (int, error) {
+	return atLeast(raw, 0, errNegative)
+}
+
+// atLeast reads a number that may not fall below lowest, which is the whole of
+// what separates one count from the other.
+func atLeast(raw string, lowest int, tooSmall error) (int, error) {
 	value, err := strconv.Atoi(raw)
 	if err != nil {
 		return 0, errNotNumber
 	}
 
-	if value < 0 {
-		return 0, errNegative
+	if value < lowest {
+		return 0, tooSmall
 	}
 
 	return value, nil

--- a/internal/claude/transcript.go
+++ b/internal/claude/transcript.go
@@ -233,7 +233,7 @@ func (r *Reader) readInto(session *transcript) {
 	if err != nil {
 		return
 	}
-	defer file.Close() //nolint:errcheck // a read-only file has nothing to report on close
+	defer file.Close() // a read-only file has nothing to report on close
 
 	// A session first seen long after it started is caught up on from its tail,
 	// which is where a title it has already been given is repeated.

--- a/internal/claude/transcript_test.go
+++ b/internal/claude/transcript_test.go
@@ -58,7 +58,7 @@ func (p project) appendLines(lines ...string) {
 	if err != nil {
 		p.t.Fatal(err)
 	}
-	defer file.Close() //nolint:errcheck // the write is checked below
+	defer file.Close() // the write is checked below
 
 	if _, err := file.WriteString(joined(lines)); err != nil {
 		p.t.Fatal(err)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -191,7 +191,7 @@ func readRef(path string) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	defer file.Close() //nolint:errcheck // a read-only file has nothing to report on close
+	defer file.Close() // a read-only file has nothing to report on close
 
 	content, err := io.ReadAll(io.LimitReader(file, maxRefFileSize))
 	if err != nil {

--- a/internal/herdr/session.go
+++ b/internal/herdr/session.go
@@ -1,13 +1,11 @@
 package herdr
 
-// Agent statuses Herdr reports. Every pane carries one: a pane with no agent
-// reports AgentStatusUnknown.
+// Agent statuses a tab is named differently for. Herdr reports three more —
+// idle, done and unknown — and none of them changes what a tab says, so
+// nothing here names them.
 const (
-	AgentStatusIdle    = "idle"
 	AgentStatusWorking = "working"
 	AgentStatusBlocked = "blocked"
-	AgentStatusDone    = "done"
-	AgentStatusUnknown = "unknown"
 )
 
 // Wire types carry only the fields Auto Title reads: a field nothing uses makes

--- a/internal/resolver/agent.go
+++ b/internal/resolver/agent.go
@@ -1,10 +1,6 @@
 package resolver
 
-import (
-	"strings"
-
-	"github.com/kryptamine/herdr-auto-title/internal/state"
-)
+import "github.com/kryptamine/herdr-auto-title/internal/state"
 
 // Agent derives the activity from what the pane's agent says it is working on,
 // which outranks every other source. Many agents leave the field empty and fall
@@ -24,18 +20,5 @@ func (Agent) Resolve(pane *state.PaneState) (Parts, bool) {
 		return Parts{}, false
 	}
 
-	// Truncation belongs to the assembled name, so no limit is applied here.
-	activity, ok := Meaningful(Sanitize(pane.AgentTitle, 0))
-	if !ok {
-		return Parts{}, false
-	}
-
-	// An agent with nothing to report often echoes its own name. That is as
-	// generic as anything in the table, but the name differs per agent, so it
-	// is compared against the pane instead of being listed.
-	if strings.EqualFold(activity, pane.Agent) || strings.EqualFold(activity, pane.DisplayAgent) {
-		return Parts{}, false
-	}
-
-	return Parts{Activity: qualify(activity, paneKind(pane))}, true
+	return activityFrom(pane, pane.AgentTitle)
 }

--- a/internal/resolver/agent.go
+++ b/internal/resolver/agent.go
@@ -20,10 +20,6 @@ func (Agent) Name() string    { return "agent" }
 func (Agent) Confidence() int { return ConfidenceAgent }
 
 func (Agent) Resolve(pane *state.PaneState) (Parts, bool) {
-	if pane == nil {
-		return Parts{}, false
-	}
-
 	if !pane.HasAgent() {
 		return Parts{}, false
 	}

--- a/internal/resolver/agent_test.go
+++ b/internal/resolver/agent_test.go
@@ -96,6 +96,32 @@ func TestAgentEchoingItsOwnNameIsNotAgentContext(t *testing.T) {
 	}
 }
 
+func TestAnEchoedAgentNameIsDeclinedWhateverReportsIt(t *testing.T) {
+	// A terminal title and a transcript topic carry the echo as readily as the
+	// agent title does, and it says no more about the work there.
+	pane := &state.PaneState{
+		Dir:           "/Users/dev/work/dashboard",
+		Agent:         "acme-bot",
+		DisplayAgent:  "Acme Bot",
+		AgentStatus:   herdr.AgentStatusWorking,
+		TerminalTitle: "Acme Bot",
+		AgentTopic:    "acme-bot",
+	}
+
+	if _, ok := NewTerminalTitle().Resolve(pane); ok {
+		t.Error("the terminal title source claimed an agent naming itself")
+	}
+
+	if _, ok := NewTranscript().Resolve(pane); ok {
+		t.Error("the transcript source claimed an agent naming itself")
+	}
+
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	if want := "dashboard › acme-bot"; got.Name != want {
+		t.Errorf("name = %q, want %q", got.Name, want)
+	}
+}
+
 func TestAgentTitleWithoutAnAgentIsIgnored(t *testing.T) {
 	// Herdr leaves the title on a pane whose agent it no longer recognizes;
 	// without an agent it is not agent context.

--- a/internal/resolver/agent_test.go
+++ b/internal/resolver/agent_test.go
@@ -109,12 +109,6 @@ func TestAgentTitleWithoutAnAgentIsIgnored(t *testing.T) {
 	}
 }
 
-func TestAgentSourceOnANilPane(t *testing.T) {
-	if _, ok := NewAgent().Resolve(nil); ok {
-		t.Fatal("resolved a nil pane")
-	}
-}
-
 func TestAgentTitleWithNoDirectoryStandsAlone(t *testing.T) {
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		Agent:       "claude",

--- a/internal/resolver/cwd.go
+++ b/internal/resolver/cwd.go
@@ -30,10 +30,6 @@ func (CWD) Name() string    { return "cwd" }
 func (CWD) Confidence() int { return ConfidenceCWD }
 
 func (c CWD) Resolve(pane *state.PaneState) (Parts, bool) {
-	if pane == nil {
-		return Parts{}, false
-	}
-
 	name := c.base(pane.Dir)
 	if name == "" {
 		return Parts{}, false

--- a/internal/resolver/git.go
+++ b/internal/resolver/git.go
@@ -40,7 +40,7 @@ func (Git) Name() string    { return "git" }
 func (Git) Confidence() int { return ConfidenceGit }
 
 func (g Git) Resolve(pane *state.PaneState) (Parts, bool) {
-	if pane == nil || g.maxLength <= 0 {
+	if g.maxLength <= 0 {
 		return Parts{}, false
 	}
 

--- a/internal/resolver/process.go
+++ b/internal/resolver/process.go
@@ -17,10 +17,6 @@ var shellNames = map[string]struct{}{
 // agent comes first because a process list never names one, and only a lone
 // process names a pane: a build tool is `esbuild` and five `node`s.
 func paneKind(pane *state.PaneState) string {
-	if pane == nil {
-		return ""
-	}
-
 	if pane.HasAgent() {
 		// An agent's name is in the generic table, because an agent naming
 		// itself is not a report of its work. As a kind it is exactly right:
@@ -118,10 +114,6 @@ func (Process) Name() string    { return "process" }
 func (Process) Confidence() int { return ConfidenceProcess }
 
 func (Process) Resolve(pane *state.PaneState) (Parts, bool) {
-	if pane == nil {
-		return Parts{}, false
-	}
-
 	kind := paneKind(pane)
 	if kind == "" {
 		return Parts{}, false

--- a/internal/resolver/process_test.go
+++ b/internal/resolver/process_test.go
@@ -139,12 +139,6 @@ func TestAProjectNeverTakesAColon(t *testing.T) {
 	}
 }
 
-func TestProcessSourceOnANilPane(t *testing.T) {
-	if _, ok := NewProcess().Resolve(nil); ok {
-		t.Fatal("resolved a nil pane")
-	}
-}
-
 func TestAnAgentIsItsOwnKind(t *testing.T) {
 	// Herdr recognizes the agent directly. Its process list does not: a coding
 	// agent shows up as a caffeinate, several nodes and an MCP helper, with its

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -41,6 +41,18 @@ type Parts struct {
 	Activity string
 }
 
+// activityFrom turns an untrusted value into the activity of a title, bound to
+// the kind of program the pane is running. No limit is applied: truncation
+// belongs to the assembled name.
+func activityFrom(pane *state.PaneState, value string) (Parts, bool) {
+	activity, ok := Meaningful(Sanitize(value, 0))
+	if !ok {
+		return Parts{}, false
+	}
+
+	return Parts{Activity: qualify(activity, paneKind(pane))}, true
+}
+
 // Source contributes title parts from a pane's context.
 type Source interface {
 	// Name identifies the source in the rename reason.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -50,8 +50,8 @@ type Source interface {
 	// what it reads, not for what it happened to find this time.
 	Confidence() int
 	// Resolve reports the parts this source derives, or false when the pane
-	// carries nothing this source recognizes. A nil pane is a tab with no
-	// panes at all, and every source declines it rather than panicking.
+	// carries nothing this source recognizes. The pane is never nil: a tab
+	// with no panes is declined by collect, before any source is asked.
 	Resolve(pane *state.PaneState) (Parts, bool)
 }
 
@@ -135,6 +135,12 @@ type collected struct {
 // can complete a title a higher one only half answered.
 func (d *Deterministic) collect(pane *state.PaneState) collected {
 	var found collected
+
+	// A tab with no panes has nothing for any source to read, which is what
+	// lets every one of them take a pane it can dereference.
+	if pane == nil {
+		return found
+	}
 
 	for _, source := range d.sources {
 		parts, ok := source.Resolve(pane)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -50,7 +50,19 @@ func activityFrom(pane *state.PaneState, value string) (Parts, bool) {
 		return Parts{}, false
 	}
 
+	if echoesAgentName(pane, activity) {
+		return Parts{}, false
+	}
+
 	return Parts{Activity: qualify(activity, paneKind(pane))}, true
+}
+
+// echoesAgentName reports an activity that is no more than the agent's own
+// name. That is as generic as anything in genericValues, but the name differs
+// per agent, so it is compared against the pane instead of being listed.
+func echoesAgentName(pane *state.PaneState, activity string) bool {
+	return strings.EqualFold(activity, pane.Agent) ||
+		strings.EqualFold(activity, pane.DisplayAgent)
 }
 
 // Source contributes title parts from a pane's context.

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -288,12 +288,6 @@ func TestSourcesAreOrderedByConfidenceNotByArgument(t *testing.T) {
 	}
 }
 
-func TestCWDSourceOnANilPane(t *testing.T) {
-	if _, ok := NewCWD().Resolve(nil); ok {
-		t.Fatal("resolved a nil pane")
-	}
-}
-
 func TestTheShippedChainResolvesATabWithNoPanes(t *testing.T) {
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(state.TabState{ID: "wE:t1"})
 	if got.Name != GenericFallback {

--- a/internal/resolver/ssh.go
+++ b/internal/resolver/ssh.go
@@ -36,10 +36,6 @@ func (SSH) Name() string    { return "ssh" }
 func (SSH) Confidence() int { return ConfidenceSSH }
 
 func (SSH) Resolve(pane *state.PaneState) (Parts, bool) {
-	if pane == nil {
-		return Parts{}, false
-	}
-
 	args, running := sshArgs(pane)
 	if !running {
 		return Parts{}, false

--- a/internal/resolver/ssh_test.go
+++ b/internal/resolver/ssh_test.go
@@ -165,12 +165,6 @@ func TestTheMarkSurvivesARemoteTitle(t *testing.T) {
 	}
 }
 
-func TestSSHSourceOnANilPane(t *testing.T) {
-	if _, ok := NewSSH().Resolve(nil); ok {
-		t.Fatal("resolved a nil pane")
-	}
-}
-
 func TestHostsFromArgvAreSanitized(t *testing.T) {
 	// argv is terminal-derived input like any other.
 	pane := sshPane("ssh", "root@prod\x1b[31m-01")

--- a/internal/resolver/terminal.go
+++ b/internal/resolver/terminal.go
@@ -16,10 +16,6 @@ func (TerminalTitle) Name() string    { return "terminal_title" }
 func (TerminalTitle) Confidence() int { return ConfidenceTerminalTitle }
 
 func (TerminalTitle) Resolve(pane *state.PaneState) (Parts, bool) {
-	if pane == nil {
-		return Parts{}, false
-	}
-
 	// Herdr strips escapes and decorative prefixes for us; the raw field is
 	// only a fallback for when it has not.
 	title := pane.TerminalTitle

--- a/internal/resolver/terminal.go
+++ b/internal/resolver/terminal.go
@@ -23,11 +23,5 @@ func (TerminalTitle) Resolve(pane *state.PaneState) (Parts, bool) {
 		title = pane.TerminalTitleRaw
 	}
 
-	// Truncation belongs to the assembled name, so no limit is applied here.
-	activity, ok := Meaningful(Sanitize(title, 0))
-	if !ok {
-		return Parts{}, false
-	}
-
-	return Parts{Activity: qualify(activity, paneKind(pane))}, true
+	return activityFrom(pane, title)
 }

--- a/internal/resolver/terminal_test.go
+++ b/internal/resolver/terminal_test.go
@@ -180,9 +180,3 @@ func TestEditorTitleKeepsTheFileAndDropsThePath(t *testing.T) {
 		})
 	}
 }
-
-func TestTerminalTitleSourceOnANilPane(t *testing.T) {
-	if _, ok := NewTerminalTitle().Resolve(nil); ok {
-		t.Fatal("resolved a nil pane")
-	}
-}

--- a/internal/resolver/transcript.go
+++ b/internal/resolver/transcript.go
@@ -20,11 +20,5 @@ func (Transcript) Resolve(pane *state.PaneState) (Parts, bool) {
 		return Parts{}, false
 	}
 
-	// Truncation belongs to the assembled name, so no limit is applied here.
-	activity, ok := Meaningful(Sanitize(pane.AgentTopic, 0))
-	if !ok {
-		return Parts{}, false
-	}
-
-	return Parts{Activity: qualify(activity, paneKind(pane))}, true
+	return activityFrom(pane, pane.AgentTopic)
 }

--- a/internal/resolver/transcript.go
+++ b/internal/resolver/transcript.go
@@ -16,7 +16,7 @@ func (Transcript) Name() string    { return "transcript" }
 func (Transcript) Confidence() int { return ConfidenceTranscript }
 
 func (Transcript) Resolve(pane *state.PaneState) (Parts, bool) {
-	if pane == nil || !pane.HasAgent() {
+	if !pane.HasAgent() {
 		return Parts{}, false
 	}
 

--- a/internal/resolver/transcript_test.go
+++ b/internal/resolver/transcript_test.go
@@ -73,9 +73,3 @@ func TestATopicThatNamesTheAgentFallsThrough(t *testing.T) {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
 }
-
-func TestTranscriptSourceOnANilPane(t *testing.T) {
-	if _, ok := NewTranscript().Resolve(nil); ok {
-		t.Fatal("resolved a nil pane")
-	}
-}

--- a/internal/resolver/transcript_test.go
+++ b/internal/resolver/transcript_test.go
@@ -14,7 +14,7 @@ func TestATopicNamesATabTheTerminalTitleCannot(t *testing.T) {
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Claude Code",
 		Agent:         "claude",
-		AgentStatus:   herdr.AgentStatusIdle,
+		AgentStatus:   "idle",
 		AgentTopic:    "grill-me",
 	}))
 
@@ -65,7 +65,7 @@ func TestATopicThatNamesTheAgentFallsThrough(t *testing.T) {
 	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
 		Dir:         "/Users/dev/work/dashboard",
 		Agent:       "claude",
-		AgentStatus: herdr.AgentStatusIdle,
+		AgentStatus: "idle",
 		AgentTopic:  "Claude Code",
 	}))
 

--- a/internal/state/tab_test.go
+++ b/internal/state/tab_test.go
@@ -96,7 +96,7 @@ func TestPaneFromReadsAgentContext(t *testing.T) {
 
 func TestPaneWithoutAnAgent(t *testing.T) {
 	pane := PaneFrom(
-		herdr.PaneInfo{PaneID: "wE:p1", AgentStatus: herdr.AgentStatusUnknown},
+		herdr.PaneInfo{PaneID: "wE:p1", AgentStatus: "unknown"},
 		time.Time{},
 	)
 	if pane.HasAgent() || pane.AgentIsActive() {
@@ -145,7 +145,7 @@ func TestSelectContextPanePrefersAnActiveAgent(t *testing.T) {
 func TestSelectContextPaneIgnoresAnIdleAgent(t *testing.T) {
 	now := time.Now()
 
-	for _, status := range []string{herdr.AgentStatusIdle, herdr.AgentStatusDone, herdr.AgentStatusUnknown} {
+	for _, status := range []string{"idle", "done", "unknown"} {
 		t.Run(status, func(t *testing.T) {
 			tab := TabState{
 				ID: "wE:t1",


### PR DESCRIPTION
A pass over the findings of a two-axis review of the whole tree. Six
commits, each one logical change, ordered so every one builds on the
last.

| Commit | What |
|---|---|
| `refactor(resolver)` | The `pane == nil` guard moves into `collect`. It was written seven times for a case no source decides: a tab with no panes is not something a source has an opinion about. |
| `refactor(resolver)` | `activityFrom` names the shape `TerminalTitle` and `Transcript` both wrote out — clean the value, decline what nothing survived of, bind the rest to the pane's kind — down to a comment about truncation repeated verbatim. |
| `fix(resolver)` | The echoed-agent-name rule moves into that helper, so it guards every value that becomes an activity rather than the agent title alone. |
| `refactor(app)` | `count` and `countOrNone` read through one bound. They differed only in where the floor sits and which error says so. |
| `refactor(herdr)` | `AgentStatusIdle`, `Done` and `Unknown` go: only `Working` and `Blocked` decide anything, and the type rule is what refuses the rest. |
| `chore(lint)` | Three `//nolint:errcheck` directives go — `errcheck` is disabled, so they suppressed nothing. The reason each close may fail quietly stays, as the plain comment the config says these places are supposed to have. |

## The one behaviour change

`fix(resolver)` is not a rename. The rule that an agent naming itself is
not a report of its work lived in the `Agent` source alone, so the same
echo passed straight through when it arrived by terminal title or
transcript topic instead. Agents in the generic table were covered by
accident; anything else named its tab after itself twice over —
`acme-bot` with a terminal title of `Acme Bot`.

A pane with no agent has nothing to echo, so nothing changes there.
Covered by `TestAnEchoedAgentNameIsDeclinedWhateverReportsIt`.

## Worth knowing before review

Dropping the per-source nil guards makes `Source.Resolve` unsafe to call
with a nil pane, which is now stated on the interface. Every production
path was traced: `collect` is the only caller, `SelectContextPane` the
only producer of nil, and `PaneFrom` returns `&PaneState{...}`
unconditionally, so a pane in `TabState.Panes` is never nil. The six
tests that asserted the old guard per source went with it — what they
protected is the chain's answer for a tab with no panes, and that is
already covered end to end.

`make check` is green: fmt, vet, `golangci-lint` at 0 issues, and
`go test -race` with a cleared test cache.

CONTRIBUTING asks a PR to be one thing, and this is a refactor pass with
a `fix` in the middle of it. Splitting the `fix` out means stacking it,
since it depends on the helper the commit before it extracts — say the
word and I will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)