### PR TITLE
docs: drop the comments that only restate the code

### DIFF
--- a/cmd/herdr-auto-title/main.go
+++ b/cmd/herdr-auto-title/main.go
@@ -39,7 +39,6 @@ func run() error {
 
 	log.Info("starting auto title", "poll", cfg.Poll, "max_length", cfg.MaxLength)
 
-	// Terminate on the signals Herdr uses to stop a plugin.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -87,8 +87,6 @@ func (a *App) poll(ctx context.Context, client herdr.Client) {
 	}
 }
 
-// readAndRename reads the session and renames every tab whose title no longer
-// fits.
 func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 	ctx, cancel := context.WithTimeout(ctx, pollTimeout)
 	defer cancel()

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -96,7 +96,6 @@ func (h *harness) stop() {
 	}
 }
 
-// awaitRenames blocks until at least n renames have been issued.
 func (h *harness) awaitRenames(n int) []herdrtest.RenameCall {
 	h.t.Helper()
 

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -140,8 +140,6 @@ func fromEnv[T any](warnings *[]string, name string, fallback T, convert convert
 	return value
 }
 
-// converter turns the raw text of a variable into a value, or says what is
-// wrong with it.
 type converter[T any] func(raw string) (T, error)
 
 // The reasons a variable is rejected. Each reads as the middle of the warning

--- a/internal/app/reads.go
+++ b/internal/app/reads.go
@@ -155,8 +155,6 @@ func spentPoll(ctx context.Context) bool {
 	return ctx.Err() != nil
 }
 
-// sessionsIn lists the agent sessions the snapshot holds, which is what the
-// transcript reader keeps its places for.
 func sessionsIn(panes []herdr.PaneInfo) []string {
 	sessions := make([]string, 0, len(panes))
 	for _, pane := range panes {

--- a/internal/claude/transcript_test.go
+++ b/internal/claude/transcript_test.go
@@ -23,7 +23,6 @@ type project struct {
 	dir  string
 }
 
-// newProject points the reader at a temporary state directory.
 func newProject(t *testing.T) project {
 	t.Helper()
 	root := t.TempDir()

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -31,7 +31,6 @@ type SocketClient struct {
 
 var _ Client = (*SocketClient)(nil)
 
-// socketPath returns the configured Herdr socket path.
 func socketPath() (string, error) {
 	path := os.Getenv(socketPathEnv)
 	if path == "" {
@@ -52,7 +51,6 @@ func New() (*SocketClient, error) {
 	return newWithPath(path), nil
 }
 
-// newWithPath builds a client for an explicit socket path.
 func newWithPath(path string) *SocketClient {
 	return &SocketClient{path: path}
 }
@@ -141,7 +139,6 @@ func PaneProcesses(ctx context.Context, c Client, paneID string) ([]PaneProcessI
 	return res.ProcessInfo.ForegroundProcesses, nil
 }
 
-// RenameTab sets a tab's label.
 func RenameTab(ctx context.Context, c Client, tabID, label string) error {
 	return c.Call(ctx, MethodTabRename, TabRenameParams{TabID: tabID, Label: label}, nil)
 }

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -119,7 +119,6 @@ func (s *testServer) seen() []incoming {
 	return append([]incoming(nil), s.requests...)
 }
 
-// respondOK answers every method with an empty result.
 func respondOK(req incoming) string {
 	return `{"id":"` + req.ID + `","result":{}}`
 }

--- a/internal/herdr/herdrtest/stub.go
+++ b/internal/herdr/herdrtest/stub.go
@@ -27,7 +27,6 @@ type (
 	}
 )
 
-// RenameCall records one tab.rename issued through a Client.
 type RenameCall struct {
 	TabID string
 	Label string
@@ -51,7 +50,6 @@ type Client struct {
 
 var _ herdr.Client = (*Client)(nil)
 
-// New returns a client describing the given session.
 func New(tabs []herdr.TabInfo, panes []herdr.PaneInfo) *Client {
 	s := &Client{
 		tabs:      make(map[string]herdr.TabInfo, len(tabs)),
@@ -69,7 +67,6 @@ func New(tabs []herdr.TabInfo, panes []herdr.PaneInfo) *Client {
 	return s
 }
 
-// SetWorkspaces sets the workspaces the session reports.
 func (s *Client) SetWorkspaces(workspaces ...herdr.WorkspaceInfo) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -77,7 +74,6 @@ func (s *Client) SetWorkspaces(workspaces ...herdr.WorkspaceInfo) {
 	s.workspaces = workspaces
 }
 
-// SetTab adds or replaces a tab.
 func (s *Client) SetTab(tab herdr.TabInfo) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -85,7 +81,6 @@ func (s *Client) SetTab(tab herdr.TabInfo) {
 	s.tabs[tab.TabID] = tab
 }
 
-// SetProcesses sets what a read of this pane's processes will answer.
 func (s *Client) SetProcesses(paneID string, processes ...herdr.PaneProcessInfoProcess) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -93,7 +88,6 @@ func (s *Client) SetProcesses(paneID string, processes ...herdr.PaneProcessInfoP
 	s.processes[paneID] = processes
 }
 
-// SetPane adds or replaces a pane.
 func (s *Client) SetPane(pane herdr.PaneInfo) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -101,7 +95,6 @@ func (s *Client) SetPane(pane herdr.PaneInfo) {
 	s.panes[pane.PaneID] = pane
 }
 
-// CloseTab and ClosePane remove an object from the session.
 func (s *Client) CloseTab(tabID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -116,7 +109,6 @@ func (s *Client) ClosePane(paneID string) {
 	delete(s.panes, paneID)
 }
 
-// SetRenameError makes subsequent tab.rename calls fail.
 func (s *Client) SetRenameError(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -124,7 +116,6 @@ func (s *Client) SetRenameError(err error) {
 	s.renameErr = err
 }
 
-// SetProcessError makes subsequent pane.process_info calls fail.
 func (s *Client) SetProcessError(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -140,7 +131,6 @@ func (s *Client) SetCallError(err error) {
 	s.callErr = err
 }
 
-// Renames returns the renames received so far.
 func (s *Client) Renames() []RenameCall {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -203,7 +193,6 @@ func (s *Client) Call(ctx context.Context, method string, params any, result any
 	}
 }
 
-// processInfo answers pane.process_info for a pane the session still holds.
 func (s *Client) processInfo(params any, result any) error {
 	if s.processErr != nil {
 		return s.processErr
@@ -228,7 +217,6 @@ func (s *Client) processInfo(params any, result any) error {
 	})
 }
 
-// rename applies a tab.rename to the stub session.
 func (s *Client) rename(params any) error {
 	if s.renameErr != nil {
 		return s.renameErr

--- a/internal/herdr/protocol.go
+++ b/internal/herdr/protocol.go
@@ -23,7 +23,6 @@ type frame struct {
 	Error  *APIError       `json:"error"`
 }
 
-// APIError is an error returned by Herdr for a request.
 type APIError struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
@@ -61,16 +60,13 @@ const (
 	MethodTabRename       = "tab.rename"
 )
 
-// PaneTarget names the pane a request applies to.
 type PaneTarget struct {
 	PaneID string `json:"pane_id"`
 }
 
-// TabRenameParams are the parameters of tab.rename.
 type TabRenameParams struct {
 	TabID string `json:"tab_id"`
 	Label string `json:"label"`
 }
 
-// emptyParams is the parameter object for methods that take none.
 type emptyParams struct{}

--- a/internal/herdr/session.go
+++ b/internal/herdr/session.go
@@ -108,12 +108,10 @@ type Snapshot struct {
 	Panes []PaneInfo `json:"panes"`
 }
 
-// snapshotResult wraps the snapshot in the method's result object.
 type snapshotResult struct {
 	Snapshot Snapshot `json:"snapshot"`
 }
 
-// processInfoResult wraps what pane.process_info answers.
 type processInfoResult struct {
 	ProcessInfo PaneProcessInfo `json:"process_info"`
 }

--- a/internal/resolver/agent.go
+++ b/internal/resolver/agent.go
@@ -9,7 +9,6 @@ type Agent struct{}
 
 var _ Source = Agent{}
 
-// NewAgent builds the source.
 func NewAgent() Agent { return Agent{} }
 
 func (Agent) Name() string    { return "agent" }

--- a/internal/resolver/position_test.go
+++ b/internal/resolver/position_test.go
@@ -14,7 +14,6 @@ func numberedCWD(maxLength int) *Numbered {
 	return NewNumbered(New(maxLength, NewCWD()), maxLength)
 }
 
-// atPosition builds a one-pane tab sitting at a position in its workspace.
 func atPosition(position int, dir string) state.TabState {
 	tab := tabWithCWD(dir)
 	tab.Position = position

--- a/internal/resolver/process.go
+++ b/internal/resolver/process.go
@@ -107,7 +107,6 @@ type Process struct{}
 
 var _ Source = Process{}
 
-// NewProcess builds the source.
 func NewProcess() Process { return Process{} }
 
 func (Process) Name() string    { return "process" }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -79,14 +79,12 @@ type Source interface {
 	Resolve(pane *state.PaneState) (Parts, bool)
 }
 
-// Decision is the outcome of resolving a tab.
 type Decision struct {
 	Name       string
 	Confidence int
 	Reason     string
 }
 
-// TitleResolver produces a title for a tab.
 type TitleResolver interface {
 	Resolve(tab state.TabState) Decision
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
 
-// tabWithCWD builds a one-pane tab whose pane sits in dir.
 func tabWithCWD(dir string) state.TabState {
 	return state.TabState{
 		ID: "wE:t1",

--- a/internal/resolver/ssh.go
+++ b/internal/resolver/ssh.go
@@ -29,7 +29,6 @@ type SSH struct{}
 
 var _ Source = SSH{}
 
-// NewSSH builds the source.
 func NewSSH() SSH { return SSH{} }
 
 func (SSH) Name() string    { return "ssh" }

--- a/internal/resolver/terminal.go
+++ b/internal/resolver/terminal.go
@@ -9,7 +9,6 @@ type TerminalTitle struct{}
 
 var _ Source = TerminalTitle{}
 
-// NewTerminalTitle builds the source.
 func NewTerminalTitle() TerminalTitle { return TerminalTitle{} }
 
 func (TerminalTitle) Name() string    { return "terminal_title" }

--- a/internal/resolver/terminal_test.go
+++ b/internal/resolver/terminal_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
 
-// tabWithPane builds a one-pane tab from a pane the test set up.
 func tabWithPane(pane *state.PaneState) state.TabState {
 	pane.ID = "wE:p1"
 	_ = pane

--- a/internal/resolver/transcript.go
+++ b/internal/resolver/transcript.go
@@ -9,7 +9,6 @@ type Transcript struct{}
 
 var _ Source = Transcript{}
 
-// NewTranscript builds the source.
 func NewTranscript() Transcript { return Transcript{} }
 
 func (Transcript) Name() string    { return "transcript" }

--- a/internal/state/changes.go
+++ b/internal/state/changes.go
@@ -31,7 +31,6 @@ type paneChange struct {
 	readAt    time.Time
 }
 
-// NewChanges returns an empty history.
 func NewChanges() *Changes {
 	return &Changes{
 		panes: make(map[string]paneChange),

--- a/internal/state/manual.go
+++ b/internal/state/manual.go
@@ -115,7 +115,6 @@ func (m *Manual) Observe(s Sighting) bool {
 		return false
 	case known:
 		if s.Current == previous {
-			// Nothing happened to this tab.
 			return false
 		}
 	case !m.settled:

--- a/internal/state/tab.go
+++ b/internal/state/tab.go
@@ -147,8 +147,6 @@ type TabState struct {
 	Panes []*PaneState
 }
 
-// TabFrom builds tab state from what a read returned. Position is the tab's
-// place in its workspace, counted from one.
 func TabFrom(info herdr.TabInfo, workspaceName string, position int, panes []*PaneState) TabState {
 	ordered := slices.Clone(panes)
 	slices.SortFunc(ordered, func(a, b *PaneState) int { return strings.Compare(a.ID, b.ID) })


### PR DESCRIPTION
## What

Forty-five comment lines removed across 23 files — every one that told the reader what the identifier in front of them already said: `NewSSH builds the source`, `SetTab adds or replaces a tab`, `RenameTab sets a tab's label`, and the like.

Two were doing worse than nothing:

- the comment over `CloseTab` also spoke for `ClosePane`, from a place a reader of `ClosePane` never looks;
- the one over `TabFrom` repeated the contract already stated on `TabState.Position`, the field it fills.

## What stayed

Everything that says *why*: the measured constants (`processRefresh`, `DefaultPoll`, `DefaultBranchMaxLength`), the Herdr protocol facts, the swallowed errors that explain themselves, and the cases that look unhandled and are not (`case arg == "-"` in the ssh parser).

`scripts/` is untouched — those are docstrings, and each carries more than its signature.

## Checks

`make check` — fmt, vet, lint (0 issues) and `go test -race ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ux5ZqEBaLG51tTBZ7d2pDt