### PR TITLE
fix(herdr): name a pane after the directory in front of it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,12 @@ listed here** (`make probe-*`, `scripts/probe.py`).
 - **A tab label is one line.** `tab.rename` accepts a newline and stores it
   verbatim — no error, no stripping — but the tab bar renders a single line, so
   a two-line label is not available. Herdr exposes no tab-bar height setting.
+- **`PaneInfo.cwd` is the pane's own shell, not what the user is typing into.**
+  A subshell moves `foreground_cwd` and leaves `cwd` behind: probed with
+  `chezmoi cd`, which runs `$SHELL` in the source directory, the pane reported
+  `cwd: ~/Work/global-sso` and `foreground_cwd: ~/.local/share/chezmoi` for as
+  long as that subshell lived. A pane's directory is `foreground_cwd` with
+  `cwd` behind it.
 - `PaneInfo` carries no foreground process name; that needs `pane.process_info`,
   one request per pane at 0.11 ms — cheaper than the snapshot, but one per pane:
   on an eight-pane session the reads measured 0.17 ms each against a 1.35 ms

--- a/docs/architecture/herdr-socket-api.md
+++ b/docs/architecture/herdr-socket-api.md
@@ -118,6 +118,14 @@ reads, so this section describes Herdr rather than those types.
 - **Pane revisions are monotonic per pane.** That is how one poll tells which
   panes moved since the last, and it is the whole basis of
   `internal/state/changes.go`.
+- **`PaneInfo.cwd` is the pane's own shell, not what the user is typing into.**
+  A subshell moves `foreground_cwd` and leaves `cwd` behind: probed with
+  `chezmoi cd`, which runs `$SHELL` in the source directory, the pane reported
+  `cwd: ~/Work/global-sso` and `foreground_cwd: ~/.local/share/chezmoi` for as
+  long as that subshell lived, while `pane.process_info` listed the subshell
+  alone. Both fields are null when Herdr cannot read one, so a pane's directory
+  is `foreground_cwd` with `cwd` behind it — see
+  [title resolution](./title-resolution.md).
 - **`PaneInfo` carries no foreground process name.** Only `pane.process_info`
   answers that, and nothing announces that a command started.
 - **`PaneInfo.title` is the agent's own title**, not the terminal's. Herdr left

--- a/docs/architecture/title-resolution.md
+++ b/docs/architecture/title-resolution.md
@@ -234,11 +234,19 @@ printed beside `prod-01` reads as that machine's.
 
 ### Working directory and the fallback
 
-The basename of the pane's directory, which is normally the project name. The
-shell's own `cwd` is preferred over `foreground_cwd`, which follows whatever is
-running right now. Directories that say nothing — the home directory, the
-filesystem root, a relative path — yield nothing, and a tab left with no name at
-all becomes `Shell`.
+The basename of the pane's directory, which is normally the project name.
+`foreground_cwd` is preferred over the shell's own `cwd`, with `cwd` behind it
+for the panes Herdr reports no foreground directory for. `cwd` is the pane's
+shell, and a subshell leaves it behind in the directory that shell was started
+from: `chezmoi cd` runs `$SHELL` in the source directory, and the pane keeps
+reporting the old `cwd` for as long as the subshell lives — the tab would go on
+naming a project the user has left. The foreground process follows what is
+running right now, which is the point: what is running right now is what the
+pane is showing.
+
+Directories that say nothing — the home directory, the filesystem root, a
+relative path — yield nothing, and a tab left with no name at all becomes
+`Shell`.
 
 ## The workspace is not repeated
 

--- a/internal/herdr/session.go
+++ b/internal/herdr/session.go
@@ -75,14 +75,15 @@ func (s *AgentSessionInfo) IDFor(agent string) (string, bool) {
 	return s.Value, true
 }
 
-// Dir is the directory a pane speaks for. The shell's own is preferred over
-// the foreground process's, which follows whatever is running right now.
+// Dir is the directory a pane speaks for. The foreground process's is
+// preferred: cwd is the pane's own shell, and a subshell leaves it behind in
+// the directory that shell was started from — see docs/architecture.
 func (p PaneInfo) Dir() string {
-	if p.CWD != "" {
-		return p.CWD
+	if p.ForegroundCWD != "" {
+		return p.ForegroundCWD
 	}
 
-	return p.ForegroundCWD
+	return p.CWD
 }
 
 // PaneProcessInfoProcess is one process running in a pane. Herdr reports more

--- a/internal/state/tab_test.go
+++ b/internal/state/tab_test.go
@@ -205,20 +205,20 @@ func TestAgentIsActiveOnANilPane(t *testing.T) {
 	}
 }
 
-func TestPaneFromPrefersTheShellsDirectory(t *testing.T) {
-	// foreground_cwd follows whatever is running right now, so it only speaks
-	// when the shell's own directory is missing.
+func TestPaneFromPrefersTheForegroundDirectory(t *testing.T) {
+	// A subshell — `chezmoi cd`, `nix develop` — moves the foreground process
+	// and leaves the pane's own shell where it was started.
 	both := PaneFrom(herdr.PaneInfo{
-		PaneID: "wE:p1", CWD: "/work/dashboard", ForegroundCWD: "/tmp",
+		PaneID: "wE:p1", CWD: "/work/dashboard", ForegroundCWD: "/work/chezmoi",
 	}, time.Time{})
-	if both.Dir != "/work/dashboard" {
-		t.Errorf("dir = %q, want the shell's own", both.Dir)
+	if both.Dir != "/work/chezmoi" {
+		t.Errorf("dir = %q, want the foreground process's", both.Dir)
 	}
 
-	foreground := PaneFrom(herdr.PaneInfo{
-		PaneID: "wE:p1", ForegroundCWD: "/work/api",
+	shell := PaneFrom(herdr.PaneInfo{
+		PaneID: "wE:p1", CWD: "/work/api",
 	}, time.Time{})
-	if foreground.Dir != "/work/api" {
-		t.Errorf("dir = %q, want the foreground process's", foreground.Dir)
+	if shell.Dir != "/work/api" {
+		t.Errorf("dir = %q, want the shell's own", shell.Dir)
 	}
 }


### PR DESCRIPTION
## The bug

Entering a subshell left the tab naming the project the user had walked away from. `chezmoi cd` runs `\$SHELL` in the source directory, and the tab kept saying `1 · global-sso` while the pane was sitting in `~/.local/share/chezmoi`.

## Why

Herdr reports two directories per pane, and they part company under a subshell. Probed directly against 0.8.2:

```
wM:p1  cwd= ~/Work/global-sso   foreground_cwd= ~/.local/share/chezmoi
```

`cwd` is the pane's own shell — the process behind `shell_pid` — so it stays in the directory that shell was started from for as long as the subshell lives. `pane.process_info` listed the subshell alone, so no source below the working directory had anything to say either.

`PaneInfo.Dir()` preferred `cwd`, falling back to `foreground_cwd` only when `cwd` was empty. The preference is now the other way round.

## Why this is safe for agent panes

The worry with `foreground_cwd` is a title that flickers while a command runs somewhere else. It does not: `foreground_cwd` is the leader of the foreground process group, so a `cd` inside a command an agent spawned does not move it. Probed against a live Claude Code pane — running `cd /private/tmp` in a subprocess left the snapshot reporting the project directory.

A subshell, by contrast, *is* the foreground process group, which is exactly the case that was broken.

## Verified

Resolved the live session with the new binary without calling `tab.rename`:

```
wM:t1  now="1 · global-sso"  would="1 · chezmoi"  dir=~/.local/share/chezmoi
```

No other tab changed. `make check` green.

## Also

The probe is recorded in `CLAUDE.md` and `docs/architecture/herdr-socket-api.md`, and `docs/architecture/title-resolution.md` now states the preference and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEDqkH6FbKj41gKyw3FrWZ