### PR TITLE
feat: make the agent title a configurable format string

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ restarts**, with the same `herdr server stop` the install needs.
 | `HERDR_AUTO_TITLE_POSITION`    | `true`                                    | Put each tab's position in front of its title                              |
 | `HERDR_AUTO_TITLE_MANUAL_FILE` | `manual-names.json`, next to `config.env` | Where tabs you renamed by hand are remembered; empty keeps them in memory  |
 | `HERDR_AUTO_TITLE_TRANSCRIPT`  | `true`                                    | Read an agent's own session transcript when it has not titled its terminal |
+| `HERDR_AUTO_TITLE_AGENT_FORMAT` | `{agent} › {activity}`                   | How an agent pane's title reads. `{agent}` is the agent, `{activity}` the work. Drop `{agent}` (say `{activity}`) for a terminal whose own tab HUD already names the agent. Must keep `{activity}` |
 
 ## Documentation
 

--- a/cmd/herdr-auto-title/main.go
+++ b/cmd/herdr-auto-title/main.go
@@ -47,7 +47,7 @@ func run() error {
 		return err
 	}
 
-	chain := resolver.Default(cfg.MaxLength, cfg.BranchMax)
+	chain := resolver.Default(cfg.MaxLength, cfg.BranchMax, cfg.AgentFormat)
 
 	var titles resolver.TitleResolver = chain
 	if cfg.ShowPosition {

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -9,7 +9,7 @@ generated: { by: claude-code/opus-5, at: 2026-08-26T14:14:17+03:00 }
 
 # Configuration
 
-Every setting Auto Title has is one of seven `HERDR_AUTO_TITLE_*` variables,
+Every setting Auto Title has is one of eight `HERDR_AUTO_TITLE_*` variables,
 read in `internal/app/config.go`. They can be set in the environment, or written
 into a file that is loaded into the environment before anything reads it.
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -37,7 +37,7 @@ func testResolver(t *testing.T) resolver.TitleResolver {
 	t.Helper()
 	t.Setenv("HOME", filepath.Join(t.TempDir(), "home"))
 
-	return resolver.Default(resolver.DefaultMaxLength, resolver.DefaultBranchMaxLength)
+	return resolver.Default(resolver.DefaultMaxLength, resolver.DefaultBranchMaxLength, resolver.DefaultAgentFormat)
 }
 
 // harness runs an App against a stubbed Herdr session.

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -18,13 +19,14 @@ import (
 // Environment variables Auto Title reads. The configuration file holds the
 // same names; see docs/architecture/configuration.md.
 const (
-	EnvDebug      = "HERDR_AUTO_TITLE_DEBUG"
-	EnvPoll       = "HERDR_AUTO_TITLE_POLL_MS"
-	EnvMaxLength  = "HERDR_AUTO_TITLE_MAX_LENGTH"
-	EnvBranchMax  = "HERDR_AUTO_TITLE_BRANCH_MAX"
-	EnvPosition   = "HERDR_AUTO_TITLE_POSITION"
-	EnvManual     = "HERDR_AUTO_TITLE_MANUAL_FILE"
-	EnvTranscript = "HERDR_AUTO_TITLE_TRANSCRIPT"
+	EnvDebug       = "HERDR_AUTO_TITLE_DEBUG"
+	EnvPoll        = "HERDR_AUTO_TITLE_POLL_MS"
+	EnvMaxLength   = "HERDR_AUTO_TITLE_MAX_LENGTH"
+	EnvBranchMax   = "HERDR_AUTO_TITLE_BRANCH_MAX"
+	EnvPosition    = "HERDR_AUTO_TITLE_POSITION"
+	EnvManual      = "HERDR_AUTO_TITLE_MANUAL_FILE"
+	EnvTranscript  = "HERDR_AUTO_TITLE_TRANSCRIPT"
+	EnvAgentFormat = "HERDR_AUTO_TITLE_AGENT_FORMAT"
 )
 
 // ConfigFile is the configuration file, read from the same directory the
@@ -56,6 +58,12 @@ type Config struct {
 	// when the agent has not titled its terminal. It reads what the user has
 	// been saying to that agent, so it can be turned off.
 	ReadTranscripts bool
+	// AgentFormat shapes how an agent pane's title joins the agent's name to
+	// its activity. `{agent}` is the agent's name, `{activity}` is the work, so
+	// the default `{agent} › {activity}` reads `claude › <activity>`. Dropping
+	// `{agent}` (say `{activity}`) leaves the activity on its own, which suits
+	// a terminal whose own tab HUD already names the agent.
+	AgentFormat string
 }
 
 // LoadConfig reads configuration from the configuration file and the
@@ -74,6 +82,7 @@ func LoadConfig() (Config, []string) {
 		ShowPosition:    true,
 		ManualPath:      state.DefaultManualPath(),
 		ReadTranscripts: true,
+		AgentFormat:     resolver.DefaultAgentFormat,
 	}
 
 	cfg.Debug = fromEnv(&warnings, EnvDebug, cfg.Debug, boolean)
@@ -83,6 +92,7 @@ func LoadConfig() (Config, []string) {
 	cfg.BranchMax = fromEnv(&warnings, EnvBranchMax, cfg.BranchMax, countOrNone)
 	cfg.ShowPosition = fromEnv(&warnings, EnvPosition, cfg.ShowPosition, boolean)
 	cfg.ReadTranscripts = fromEnv(&warnings, EnvTranscript, cfg.ReadTranscripts, boolean)
+	cfg.AgentFormat = fromEnv(&warnings, EnvAgentFormat, cfg.AgentFormat, agentFormat)
 	// A path needs neither parsing nor checking, so it does not go through
 	// fromEnv: any string the user set is the path they meant, and setting it
 	// to none of it asks for locks that do not outlive the process.
@@ -149,6 +159,7 @@ var (
 	errNotNumber   = errors.New("is not a number")
 	errNotPositive = errors.New("must be positive")
 	errNegative    = errors.New("cannot be negative")
+	errNoActivity  = errors.New("must contain {activity}")
 )
 
 func boolean(raw string) (bool, error) {
@@ -158,6 +169,17 @@ func boolean(raw string) (bool, error) {
 	}
 
 	return value, nil
+}
+
+// agentFormat keeps the title template a user can shape, but only once it still
+// carries the agent's work: a format without {activity} would drop what the
+// title is for, so it is rejected and the default kept.
+func agentFormat(raw string) (string, error) {
+	if !strings.Contains(raw, "{activity}") {
+		return "", errNoActivity
+	}
+
+	return raw, nil
 }
 
 // count reads a number that must be positive. Zero would stop the plugin doing

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -22,7 +22,7 @@ func isolate(t *testing.T) {
 	// isolate anything until it is out of the way.
 	t.Setenv("XDG_CONFIG_HOME", "")
 
-	for _, name := range []string{EnvDebug, EnvPoll, EnvMaxLength, EnvBranchMax, EnvPosition, EnvManual, EnvTranscript} {
+	for _, name := range []string{EnvDebug, EnvPoll, EnvMaxLength, EnvBranchMax, EnvPosition, EnvManual, EnvTranscript, EnvAgentFormat} {
 		// Setenv first for its cleanup, which then also undoes what the
 		// configuration file sets; an empty variable is not an absent one.
 		t.Setenv(name, "")
@@ -74,6 +74,41 @@ func TestLoadConfigDefaults(t *testing.T) {
 
 	if !cfg.ShowPosition {
 		t.Error("positions are off by default")
+	}
+
+	if cfg.AgentFormat != resolver.DefaultAgentFormat {
+		t.Errorf("agent format = %q, want the default %q", cfg.AgentFormat, resolver.DefaultAgentFormat)
+	}
+}
+
+func TestLoadConfigTakesTheAgentFormat(t *testing.T) {
+	isolate(t)
+	t.Setenv(EnvAgentFormat, "{activity}")
+
+	cfg, warnings := LoadConfig()
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want none", warnings)
+	}
+
+	if cfg.AgentFormat != "{activity}" {
+		t.Errorf("agent format = %q, want the one set", cfg.AgentFormat)
+	}
+}
+
+func TestAnAgentFormatWithoutActivityIsRejected(t *testing.T) {
+	// The format is the whole of what a title says an agent is doing, so one
+	// that drops {activity} is a mistake worth reporting, not a title worth
+	// showing. The default is kept.
+	isolate(t)
+	t.Setenv(EnvAgentFormat, "{agent}")
+
+	cfg, warnings := LoadConfig()
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want one", warnings)
+	}
+
+	if cfg.AgentFormat != resolver.DefaultAgentFormat {
+		t.Errorf("agent format = %q, want the default %q", cfg.AgentFormat, resolver.DefaultAgentFormat)
 	}
 }
 

--- a/internal/resolver/agent.go
+++ b/internal/resolver/agent.go
@@ -5,19 +5,19 @@ import "github.com/kryptamine/herdr-auto-title/internal/state"
 // Agent derives the activity from what the pane's agent says it is working on,
 // which outranks every other source. Many agents leave the field empty and fall
 // through to TerminalTitle instead.
-type Agent struct{}
+type Agent struct{ agentFormat string }
 
 var _ Source = Agent{}
 
-func NewAgent() Agent { return Agent{} }
+func NewAgent(agentFormat string) Agent { return Agent{agentFormat: agentFormat} }
 
 func (Agent) Name() string    { return "agent" }
 func (Agent) Confidence() int { return ConfidenceAgent }
 
-func (Agent) Resolve(pane *state.PaneState) (Parts, bool) {
+func (a Agent) Resolve(pane *state.PaneState) (Parts, bool) {
 	if !pane.HasAgent() {
 		return Parts{}, false
 	}
 
-	return activityFrom(pane, pane.AgentTitle)
+	return activityFrom(pane, pane.AgentTitle, a.agentFormat)
 }

--- a/internal/resolver/agent_kind_test.go
+++ b/internal/resolver/agent_kind_test.go
@@ -1,0 +1,67 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/kryptamine/herdr-auto-title/internal/herdr"
+	"github.com/kryptamine/herdr-auto-title/internal/state"
+)
+
+// agentPane is a working agent that has titled its own work, the case the
+// agent format shapes.
+func agentPane() *state.PaneState {
+	return &state.PaneState{
+		Dir:         "/Users/dev/work/dashboard",
+		Agent:       "claude",
+		AgentStatus: herdr.AgentStatusWorking,
+		AgentTitle:  "Implement OAuth scopes",
+	}
+}
+
+func TestDefaultFormatKeepsTheAgentPrefix(t *testing.T) {
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(agentPane()))
+
+	if want := "dashboard › claude › Implement OAuth scopes"; got.Name != want {
+		t.Errorf("name = %q, want %q", got.Name, want)
+	}
+}
+
+func TestFormatWithoutAgentDropsThePrefix(t *testing.T) {
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, "{activity}").Resolve(tabWithPane(agentPane()))
+
+	if want := "dashboard › Implement OAuth scopes"; got.Name != want {
+		t.Errorf("name = %q, want %q", got.Name, want)
+	}
+
+	// The activity still comes from the agent; only the `claude ›` is gone.
+	if got.Reason != "agent" {
+		t.Errorf("reason = %q, want agent", got.Reason)
+	}
+}
+
+func TestFormatCanReorderAndRestyleTheParts(t *testing.T) {
+	pane := agentPane()
+	pane.AgentTitle = "Fix bug"
+
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, "{activity} ({agent})").Resolve(tabWithPane(pane))
+
+	if want := "dashboard › Fix bug (claude)"; got.Name != want {
+		t.Errorf("name = %q, want %q", got.Name, want)
+	}
+}
+
+func TestTheFormatDoesNotTouchANonAgentPane(t *testing.T) {
+	// A plain editor pane keeps the built-in separator whatever the agent
+	// format says: the format is for agent panes only.
+	pane := &state.PaneState{
+		Dir:           "/Users/dev/work/dashboard",
+		TerminalTitle: "auth.provider.ts - Nvim",
+		Processes:     running("nvim"),
+	}
+
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, "{activity}").Resolve(tabWithPane(pane))
+
+	if want := "dashboard › nvim › auth.provider.ts"; got.Name != want {
+		t.Errorf("name = %q, want %q", got.Name, want)
+	}
+}

--- a/internal/resolver/agent_test.go
+++ b/internal/resolver/agent_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAgentTitleBeatsEverySourceBelowIt(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Claude Code",
 		Agent:         "claude",
@@ -30,7 +30,7 @@ func TestAgentTitleBeatsEverySourceBelowIt(t *testing.T) {
 }
 
 func TestAgentTitleOutranksAMeaningfulTerminalTitle(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Fix OAuth redirect",
 		Agent:         "claude",
@@ -51,6 +51,7 @@ func TestGenericAgentNameFallsThrough(t *testing.T) {
 			got := Default(
 				DefaultMaxLength,
 				DefaultBranchMaxLength,
+				DefaultAgentFormat,
 			).Resolve(tabWithPane(&state.PaneState{
 				Dir:           "/Users/dev/work/dashboard",
 				TerminalTitle: "Fix OAuth redirect",
@@ -82,11 +83,11 @@ func TestAgentEchoingItsOwnNameIsNotAgentContext(t *testing.T) {
 		AgentTitle:   "Acme Bot",
 	}
 
-	if _, ok := NewAgent().Resolve(pane); ok {
+	if _, ok := NewAgent(DefaultAgentFormat).Resolve(pane); ok {
 		t.Error("the agent source claimed an agent naming itself")
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 	if want := "dashboard › acme-bot"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -108,15 +109,15 @@ func TestAnEchoedAgentNameIsDeclinedWhateverReportsIt(t *testing.T) {
 		AgentTopic:    "acme-bot",
 	}
 
-	if _, ok := NewTerminalTitle().Resolve(pane); ok {
+	if _, ok := NewTerminalTitle(DefaultAgentFormat).Resolve(pane); ok {
 		t.Error("the terminal title source claimed an agent naming itself")
 	}
 
-	if _, ok := NewTranscript().Resolve(pane); ok {
+	if _, ok := NewTranscript(DefaultAgentFormat).Resolve(pane); ok {
 		t.Error("the transcript source claimed an agent naming itself")
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 	if want := "dashboard › acme-bot"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -125,7 +126,7 @@ func TestAnEchoedAgentNameIsDeclinedWhateverReportsIt(t *testing.T) {
 func TestAgentTitleWithoutAnAgentIsIgnored(t *testing.T) {
 	// Herdr leaves the title on a pane whose agent it no longer recognizes;
 	// without an agent it is not agent context.
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		Dir:        "/Users/dev/work/dashboard",
 		AgentTitle: "Implement OAuth scopes",
 	}))
@@ -136,7 +137,7 @@ func TestAgentTitleWithoutAnAgentIsIgnored(t *testing.T) {
 }
 
 func TestAgentTitleWithNoDirectoryStandsAlone(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		Agent:       "claude",
 		AgentStatus: herdr.AgentStatusWorking,
 		AgentTitle:  "Implement OAuth scopes",
@@ -168,7 +169,7 @@ func TestContextAndActivityComeFromTheSamePane(t *testing.T) {
 		},
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tab)
 	if want := "dashboard › claude › Implement OAuth scopes"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}

--- a/internal/resolver/git_test.go
+++ b/internal/resolver/git_test.go
@@ -18,7 +18,7 @@ func repoPane(branch, defaultBranch string) *state.PaneState {
 }
 
 func resolveRepoPane(pane *state.PaneState) string {
-	return Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane)).Name
+	return Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane)).Name
 }
 
 func TestTheBranchQualifiesTheDirectory(t *testing.T) {
@@ -122,14 +122,14 @@ func TestTheBranchSurvivesTheWorkspaceItRepeats(t *testing.T) {
 	tab := tabWithPane(repoPane("feat/oauth", "main"))
 	tab.WorkspaceName = "dashboard"
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab).Name
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tab).Name
 	if got != "feat/oauth" {
 		t.Errorf("title %q, want the branch alone", got)
 	}
 }
 
 func TestABranchWidthOfZeroLeavesBranchesOut(t *testing.T) {
-	got := Default(DefaultMaxLength, 0).Resolve(tabWithPane(repoPane("feat/oauth", "main"))).Name
+	got := Default(DefaultMaxLength, 0, DefaultAgentFormat).Resolve(tabWithPane(repoPane("feat/oauth", "main"))).Name
 	if got != "dashboard" {
 		t.Errorf("title %q, want no branch at all", got)
 	}
@@ -157,7 +157,7 @@ func TestABranchStandsWhereTheDirectorySaysNothing(t *testing.T) {
 func TestTheBranchIsCreditedLikeAContext(t *testing.T) {
 	// The reason a tab carries a name is the source that named the work, and a
 	// branch is not work: it answers for the title only when nothing else does.
-	resolver := Default(DefaultMaxLength, DefaultBranchMaxLength)
+	resolver := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat)
 
 	pane := repoPane("feat/oauth", "main")
 

--- a/internal/resolver/process.go
+++ b/internal/resolver/process.go
@@ -100,22 +100,60 @@ func stripKind(detail, kind string) string {
 	return strings.Trim(trimmed, " -–—|:"+separatorRune)
 }
 
+// formatAgent joins an agent pane's name to its activity through the user's
+// format: {agent} is the name, {activity} is the work. The default
+// `{agent} › {activity}` reproduces what a title has always shown.
+//
+// The substituted values are already sanitized at their source, so this only
+// fills the format; Format sanitizes the assembled title as a whole, which is
+// what collapses and trims a separator that a substituted-empty field left
+// dangling — `{agent} › {activity}` with no activity reads `claude`, not
+// `claude ›`.
+func formatAgent(format, agent, activity string) string {
+	detail := stripKind(activity, agent)
+
+	// With neither a name nor an activity there is nothing to name. A Process
+	// names an agent pane that has no activity to report, and keeps it only
+	// when the format still shows the agent; without {agent} it falls through
+	// to a lower source rather than showing the pane empty.
+	if detail == "" && (agent == "" || !strings.Contains(format, "{agent}")) {
+		return ""
+	}
+
+	return strings.NewReplacer(
+		"{agent}", agent,
+		"{activity}", detail,
+	).Replace(format)
+}
+
 // Process names a pane after the program running in it when nothing has said
 // what that program is doing: an editor with no file open still reads
 // `dashboard › nvim`.
-type Process struct{}
+type Process struct{ agentFormat string }
 
 var _ Source = Process{}
 
-func NewProcess() Process { return Process{} }
+func NewProcess(agentFormat string) Process { return Process{agentFormat: agentFormat} }
 
 func (Process) Name() string    { return "process" }
 func (Process) Confidence() int { return ConfidenceProcess }
 
-func (Process) Resolve(pane *state.PaneState) (Parts, bool) {
+func (p Process) Resolve(pane *state.PaneState) (Parts, bool) {
 	kind := paneKind(pane)
 	if kind == "" {
 		return Parts{}, false
+	}
+
+	// An agent pane named here has no activity to report, so the format decides
+	// whether the agent's name alone still names the tab. A format without
+	// {agent} leaves nothing, and the pane falls through to a lower source.
+	if pane.HasAgent() {
+		name := formatAgent(p.agentFormat, kind, "")
+		if name == "" {
+			return Parts{}, false
+		}
+
+		return Parts{Activity: name}, true
 	}
 
 	return Parts{Activity: kind}, true

--- a/internal/resolver/process_test.go
+++ b/internal/resolver/process_test.go
@@ -24,7 +24,7 @@ func TestTheKindQualifiesTheTitle(t *testing.T) {
 		Processes:     running("nvim"),
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 	if want := "dashboard › nvim › auth.provider.ts"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -38,7 +38,7 @@ func TestAKindWithNothingToAddStandsAlone(t *testing.T) {
 		Processes:     running("nvim"),
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 	if want := "dashboard › nvim"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -47,7 +47,7 @@ func TestAKindWithNothingToAddStandsAlone(t *testing.T) {
 func TestAKindWithNoTitleAtAllStillNamesThePane(t *testing.T) {
 	pane := &state.PaneState{Dir: "/Users/dev/work/dashboard", Processes: running("htop")}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 	if want := "dashboard › htop"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -102,6 +102,7 @@ func TestARemoteSessionIsNotNamedTwice(t *testing.T) {
 	if got := Default(
 		DefaultMaxLength,
 		DefaultBranchMaxLength,
+		DefaultAgentFormat,
 	).Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
 		t.Errorf("name = %q, want ssh › prod-01", got.Name)
 	}
@@ -133,7 +134,7 @@ func TestAProjectNeverTakesAColon(t *testing.T) {
 		Processes:     running("esbuild", "node", "node"),
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 	if want := "self-care-portal › yarn dev"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -154,7 +155,7 @@ func TestAnAgentIsItsOwnKind(t *testing.T) {
 		t.Errorf("paneKind = %q, want claude", got)
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 	if want := "dashboard › claude › Git email configuration"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -169,7 +170,7 @@ func TestAStartingAgentIsNamedByItsKindAlone(t *testing.T) {
 		Agent:         "claude",
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 	if want := "dashboard › claude"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -181,6 +182,7 @@ func TestAPaneWithoutAnAgentIsNotNamedAfterOne(t *testing.T) {
 	if got := Default(
 		DefaultMaxLength,
 		DefaultBranchMaxLength,
+		DefaultAgentFormat,
 	).Resolve(tabWithPane(pane)); got.Name != "dashboard" {
 		t.Errorf("name = %q, want dashboard", got.Name)
 	}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -17,6 +17,12 @@ const DefaultMaxLength = 50
 // GenericFallback names a tab whose context tells us nothing.
 const GenericFallback = "Shell"
 
+// DefaultAgentFormat joins an agent pane's name to its activity, and reproduces
+// what Auto Title has always shown: `claude › <activity>`. `{agent}` is the
+// agent's name, `{activity}` is the work; a format without `{agent}` drops the
+// prefix.
+const DefaultAgentFormat = "{agent}" + Separator + "{activity}"
+
 // Confidence levels form the resolution ladder, and the resolver orders itself
 // by them. A source never overrides a field a higher one already supplied. The
 // gaps are what make room for the next source.
@@ -44,7 +50,7 @@ type Parts struct {
 // activityFrom turns an untrusted value into the activity of a title, bound to
 // the kind of program the pane is running. No limit is applied: truncation
 // belongs to the assembled name.
-func activityFrom(pane *state.PaneState, value string) (Parts, bool) {
+func activityFrom(pane *state.PaneState, value, agentFormat string) (Parts, bool) {
 	activity, ok := Meaningful(Sanitize(value, 0))
 	if !ok {
 		return Parts{}, false
@@ -54,7 +60,12 @@ func activityFrom(pane *state.PaneState, value string) (Parts, bool) {
 		return Parts{}, false
 	}
 
-	return Parts{Activity: qualify(activity, paneKind(pane))}, true
+	kind := paneKind(pane)
+	if pane.HasAgent() {
+		return Parts{Activity: formatAgent(agentFormat, kind, activity)}, true
+	}
+
+	return Parts{Activity: qualify(activity, kind)}, true
 }
 
 // echoesAgentName reports an activity that is no more than the agent's own
@@ -114,12 +125,12 @@ func New(maxLength int, sources ...Source) *Deterministic {
 
 // Default builds the resolver Auto Title ships with, so the binary and the
 // tests cannot drift apart on what the chain contains.
-func Default(maxLength, branchMax int) *Deterministic {
+func Default(maxLength, branchMax int, agentFormat string) *Deterministic {
 	return New(maxLength,
-		NewAgent(),
-		NewTerminalTitle(),
-		NewTranscript(),
-		NewProcess(),
+		NewAgent(agentFormat),
+		NewTerminalTitle(agentFormat),
+		NewTranscript(agentFormat),
+		NewProcess(agentFormat),
 		NewSSH(),
 		NewGit(branchMax),
 		NewCWD(),

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -184,7 +184,7 @@ func TestATabDoesNotRepeatItsWorkspace(t *testing.T) {
 	})
 	tab.WorkspaceName = "dashboard"
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tab)
 	if got.Name != "Fix OAuth redirect" {
 		t.Errorf("name = %q, want %q", got.Name, "Fix OAuth redirect")
 	}
@@ -196,7 +196,7 @@ func TestATabWithNothingElseKeepsItsContext(t *testing.T) {
 	tab := tabWithPane(&state.PaneState{Dir: "/Users/dev/work/dashboard"})
 	tab.WorkspaceName = "dashboard"
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tab)
 	if got.Name != "dashboard" {
 		t.Errorf("name = %q, want dashboard", got.Name)
 	}
@@ -211,7 +211,7 @@ func TestADifferentWorkspaceIsNotDropped(t *testing.T) {
 	})
 	tab.WorkspaceName = "api"
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tab)
 	if want := "dashboard › Fix OAuth redirect"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -224,7 +224,7 @@ func TestAWorkspaceWithoutAName(t *testing.T) {
 		TerminalTitle: "Fix OAuth redirect",
 	})
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tab)
 	if want := "dashboard › Fix OAuth redirect"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -234,7 +234,7 @@ func TestTheShippedChainIsAWellFormedLadder(t *testing.T) {
 	// Confidences used to be repeated in every result a source returned, and
 	// the chain's order was a second, unchecked statement of the same ladder.
 	// Now the numbers are the only statement, so they have to hold up.
-	chain := Default(DefaultMaxLength, DefaultBranchMaxLength)
+	chain := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat)
 
 	seen := make(map[int]string, len(chain.sources))
 	previous := 0
@@ -288,7 +288,7 @@ func TestSourcesAreOrderedByConfidenceNotByArgument(t *testing.T) {
 }
 
 func TestTheShippedChainResolvesATabWithNoPanes(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(state.TabState{ID: "wE:t1"})
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(state.TabState{ID: "wE:t1"})
 	if got.Name != GenericFallback {
 		t.Errorf("name = %q, want %q", got.Name, GenericFallback)
 	}

--- a/internal/resolver/ssh_test.go
+++ b/internal/resolver/ssh_test.go
@@ -64,7 +64,7 @@ func TestTheHostBecomesTheContext(t *testing.T) {
 func TestTheTabIsNamedAfterTheMarkedHost(t *testing.T) {
 	pane := sshPane("ssh", "root@prod-01")
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 	if want := "ssh › prod-01"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -85,6 +85,7 @@ func TestTheHostOutranksTheWorkingDirectory(t *testing.T) {
 	if got := Default(
 		DefaultMaxLength,
 		DefaultBranchMaxLength,
+		DefaultAgentFormat,
 	).Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
 		t.Errorf("name = %q, want %q", got.Name, "ssh › prod-01")
 	}
@@ -97,7 +98,7 @@ func TestAnUnreadableDestinationStillMarksTheTabRemote(t *testing.T) {
 	for _, argv := range [][]string{nil, {"ssh"}, {"ssh", "-p", "2222"}, {"ssh", "-"}} {
 		pane := sshPane(argv...)
 
-		got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+		got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 		if want := "ssh"; got.Name != want {
 			t.Errorf("argv %v → %q, want %q", argv, got.Name, want)
 		}
@@ -111,7 +112,7 @@ func TestAnUnreadableDestinationKeepsTheMarkUnderARemoteTitle(t *testing.T) {
 	pane := sshPane()
 	pane.TerminalTitle = "Restart the queue workers"
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 	if want := "ssh › Restart the queue workers"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -126,7 +127,7 @@ func TestAPaneWithoutSSHIsUnaffected(t *testing.T) {
 		},
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 	if strings.Contains(strings.ToLower(got.Name), "ssh") {
 		t.Errorf("name = %q, want nothing about ssh", got.Name)
 	}
@@ -147,6 +148,7 @@ func TestSSHIsFoundAmongOtherProcesses(t *testing.T) {
 	if got := Default(
 		DefaultMaxLength,
 		DefaultBranchMaxLength,
+		DefaultAgentFormat,
 	).Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
 		t.Errorf("name = %q, want %q", got.Name, "ssh › prod-01")
 	}
@@ -159,7 +161,7 @@ func TestTheMarkSurvivesARemoteTitle(t *testing.T) {
 	pane := sshPane("ssh", "prod-01")
 	pane.TerminalTitle = "Restart the queue workers"
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 	if want := "ssh › prod-01 › Restart the queue workers"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -169,7 +171,7 @@ func TestHostsFromArgvAreSanitized(t *testing.T) {
 	// argv is terminal-derived input like any other.
 	pane := sshPane("ssh", "root@prod\x1b[31m-01")
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(pane))
 	if strings.ContainsRune(got.Name, '\x1b') {
 		t.Errorf("name = %q, still carries an escape", got.Name)
 	}

--- a/internal/resolver/terminal.go
+++ b/internal/resolver/terminal.go
@@ -5,16 +5,18 @@ import "github.com/kryptamine/herdr-auto-title/internal/state"
 // TerminalTitle derives the activity from the pane's terminal title: a title a
 // program went out of its way to set usually says what is happening. A lone
 // program in the pane qualifies it, `nvim › auth.provider.ts`.
-type TerminalTitle struct{}
+type TerminalTitle struct{ agentFormat string }
 
 var _ Source = TerminalTitle{}
 
-func NewTerminalTitle() TerminalTitle { return TerminalTitle{} }
+func NewTerminalTitle(agentFormat string) TerminalTitle {
+	return TerminalTitle{agentFormat: agentFormat}
+}
 
 func (TerminalTitle) Name() string    { return "terminal_title" }
 func (TerminalTitle) Confidence() int { return ConfidenceTerminalTitle }
 
-func (TerminalTitle) Resolve(pane *state.PaneState) (Parts, bool) {
+func (t TerminalTitle) Resolve(pane *state.PaneState) (Parts, bool) {
 	// Herdr strips escapes and decorative prefixes for us; the raw field is
 	// only a fallback for when it has not.
 	title := pane.TerminalTitle
@@ -22,5 +24,5 @@ func (TerminalTitle) Resolve(pane *state.PaneState) (Parts, bool) {
 		title = pane.TerminalTitleRaw
 	}
 
-	return activityFrom(pane, title)
+	return activityFrom(pane, title, t.agentFormat)
 }

--- a/internal/resolver/terminal_test.go
+++ b/internal/resolver/terminal_test.go
@@ -19,7 +19,7 @@ func tabWithPane(pane *state.PaneState) state.TabState {
 }
 
 func TestTerminalTitleBeatsTheWorkingDirectory(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Fix OAuth redirect",
 	}))
@@ -44,6 +44,7 @@ func TestGenericTerminalTitleFallsThrough(t *testing.T) {
 			got := Default(
 				DefaultMaxLength,
 				DefaultBranchMaxLength,
+				DefaultAgentFormat,
 			).Resolve(tabWithPane(&state.PaneState{
 				Dir:           "/Users/dev/work/dashboard",
 				TerminalTitle: title,
@@ -61,7 +62,7 @@ func TestGenericTerminalTitleFallsThrough(t *testing.T) {
 }
 
 func TestTerminalTitleFallsBackToTheRawField(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		Dir:              "/Users/dev/work/dashboard",
 		TerminalTitleRaw: "\x1b[32m✳ Fix OAuth redirect\x1b[0m",
 	}))
@@ -73,7 +74,7 @@ func TestTerminalTitleFallsBackToTheRawField(t *testing.T) {
 }
 
 func TestStrippedTerminalTitleWinsOverTheRawOne(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		Dir:              "/Users/dev/work/dashboard",
 		TerminalTitle:    "Fix OAuth redirect",
 		TerminalTitleRaw: "◐ Fix OAuth redirect",
@@ -85,7 +86,7 @@ func TestStrippedTerminalTitleWinsOverTheRawOne(t *testing.T) {
 }
 
 func TestTerminalTitleIsSanitized(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "\x1b[31mFix OAuth\nredirect\x1b[0m\t",
 	}))
@@ -96,7 +97,7 @@ func TestTerminalTitleIsSanitized(t *testing.T) {
 }
 
 func TestLongTerminalTitleIsTruncatedAsAWhole(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: strings.Repeat("long ", 40),
 	}))
@@ -111,7 +112,7 @@ func TestLongTerminalTitleIsTruncatedAsAWhole(t *testing.T) {
 }
 
 func TestTerminalTitleWithoutAWorkingDirectory(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		TerminalTitle: "Fix OAuth redirect",
 	}))
 
@@ -122,7 +123,7 @@ func TestTerminalTitleWithoutAWorkingDirectory(t *testing.T) {
 }
 
 func TestTerminalTitleRepeatingTheContextIsDropped(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Dashboard",
 	}))
@@ -133,7 +134,7 @@ func TestTerminalTitleRepeatingTheContextIsDropped(t *testing.T) {
 }
 
 func TestTerminalTitleWithNothingElse(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		TerminalTitle: "zsh",
 	}))
 
@@ -168,7 +169,7 @@ func TestEditorTitleKeepsTheFileAndDropsThePath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.title, func(t *testing.T) {
-			got := Default(wide, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+			got := Default(wide, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 				Dir:           "/Users/dev/Work/herdr-auto-title",
 				TerminalTitle: tc.title,
 			}))

--- a/internal/resolver/transcript.go
+++ b/internal/resolver/transcript.go
@@ -5,19 +5,19 @@ import "github.com/kryptamine/herdr-auto-title/internal/state"
 // Transcript derives the activity from what the agent's own session says it is
 // about. It sits below TerminalTitle because an agent that titles its window
 // has already said the same thing, sooner; this answers when it has not.
-type Transcript struct{}
+type Transcript struct{ agentFormat string }
 
 var _ Source = Transcript{}
 
-func NewTranscript() Transcript { return Transcript{} }
+func NewTranscript(agentFormat string) Transcript { return Transcript{agentFormat: agentFormat} }
 
 func (Transcript) Name() string    { return "transcript" }
 func (Transcript) Confidence() int { return ConfidenceTranscript }
 
-func (Transcript) Resolve(pane *state.PaneState) (Parts, bool) {
+func (t Transcript) Resolve(pane *state.PaneState) (Parts, bool) {
 	if !pane.HasAgent() {
 		return Parts{}, false
 	}
 
-	return activityFrom(pane, pane.AgentTopic)
+	return activityFrom(pane, pane.AgentTopic, t.agentFormat)
 }

--- a/internal/resolver/transcript_test.go
+++ b/internal/resolver/transcript_test.go
@@ -10,7 +10,7 @@ import (
 func TestATopicNamesATabTheTerminalTitleCannot(t *testing.T) {
 	// The session that motivated the source: the agent never titled its
 	// terminal, so without the transcript the tab is just `claude`.
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Claude Code",
 		Agent:         "claude",
@@ -33,7 +33,7 @@ func TestATopicNamesATabTheTerminalTitleCannot(t *testing.T) {
 
 func TestATerminalTitleOutranksTheTranscript(t *testing.T) {
 	// Both say what the session is about, and the agent says it sooner.
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Fix OAuth redirect",
 		Agent:         "claude",
@@ -53,7 +53,7 @@ func TestATerminalTitleOutranksTheTranscript(t *testing.T) {
 func TestATopicWithoutAnAgentIsIgnored(t *testing.T) {
 	// A pane whose agent Herdr no longer recognizes keeps whatever was read of
 	// its session, and that is no longer what the pane is doing.
-	if _, ok := NewTranscript().Resolve(&state.PaneState{
+	if _, ok := NewTranscript(DefaultAgentFormat).Resolve(&state.PaneState{
 		Dir:        "/Users/dev/work/dashboard",
 		AgentTopic: "grill-me",
 	}); ok {
@@ -62,7 +62,7 @@ func TestATopicWithoutAnAgentIsIgnored(t *testing.T) {
 }
 
 func TestATopicThatNamesTheAgentFallsThrough(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := Default(DefaultMaxLength, DefaultBranchMaxLength, DefaultAgentFormat).Resolve(tabWithPane(&state.PaneState{
 		Dir:         "/Users/dev/work/dashboard",
 		Agent:       "claude",
 		AgentStatus: "idle",


### PR DESCRIPTION
## What

Adds `HERDR_AUTO_TITLE_AGENT_FORMAT` — a format string for how an agent pane's title reads. Default `{agent} › {activity}` reproduces the current behavior exactly.

- `{agent}` — the agent name (e.g. `claude`)
- `{activity}` — the work

Examples:
- `{activity}` — drop the agent prefix (for a terminal whose own tab HUD already names the agent)
- `{activity} ({agent})` — reorder

A format missing `{activity}` is rejected with a warning and the default kept.

## Why

The agent name is not always wanted in the tab title — some terminals/HUDs already show which agent a pane holds, making `claude ›` redundant. A format string lets each user decide, without a new boolean per preference.

## Notes

- Default preserves existing behavior.
- Agent-panes only; non-agent titles are untouched.
- Tests + README/configuration docs included; `go test ./...`, `go vet`, `gofmt` clean.
- Commit history has a few steps (boolean → format string → trim); happy to squash to a single commit on request.