### PR TITLE
fix(state): name a pane after its foreground process's directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,14 +155,32 @@ listed here** (`make probe-*`, `scripts/probe.py`).
   A subshell moves `foreground_cwd` and leaves `cwd` behind: probed with
   `chezmoi cd`, which runs `$SHELL` in the source directory, the pane reported
   `cwd: ~/Work/global-sso` and `foreground_cwd: ~/.local/share/chezmoi` for as
-  long as that subshell lived. A pane's directory is `foreground_cwd` with
-  `cwd` behind it.
+  long as that subshell lived. Neither field is the pane's directory on its own
+  — see the next two.
+- **`foreground_cwd` is the deepest descendant's directory**, not the foreground
+  process's own: a pane running `python3` that had spawned `sleep` in `/tmp`
+  reported `foreground_cwd: /private/tmp` while `cwd` stayed on the pane's
+  directory. Anything a program starts elsewhere takes it with it: an agent
+  whose MCP server sits in `/tmp` reported that as the pane's.
+- **A pane's directory is its foreground process's own `cwd`**, which only
+  `pane.process_info` reports. Measured on a live session: an agent pane held
+  `cwd: ~/Work/herdr-auto-title` (the shell, left behind) and
+  `foreground_cwd: ~/Work/self-care-portal` (an MCP server), while the agent
+  process itself was in `~/Work/self-care-portal` — the project the user was
+  working in. The snapshot's pair is the fallback for a pane nothing was read
+  for.
+- **`foreground_processes` is the pane's foreground process group**, by the
+  group id `pane.process_info` reports and the pane's controlling terminal. An
+  agent's MCP servers are in it; a descendant started in a group of its own
+  without a terminal, as Claude Code starts the commands it runs, is not.
 - `PaneInfo` carries no foreground process name; that needs `pane.process_info`,
   one request per pane at 0.11 ms — cheaper than the snapshot, but one per pane:
   on an eight-pane session the reads measured 0.17 ms each against a 1.35 ms
   snapshot, so making one every poll cost as much again as the snapshot itself.
   Its `foreground_processes` lists the pane's foreground process *and its
-  descendants*, each with `name` and a nullable `argv`.
+  descendants*, deepest first, each with `pid`, `name`, `argv0`, a nullable
+  `argv`, `cmdline` and `cwd`; the pane's entry carries `shell_pid` and
+  `foreground_process_group_id`.
 - Pane revisions are monotonic, which is how a poll tells which panes drew.
 - **A revision does not track what is running in the pane.** Measured over ten
   minutes of a live eight-pane session: the foreground processes changed nine

--- a/docs/architecture/herdr-socket-api.md
+++ b/docs/architecture/herdr-socket-api.md
@@ -123,9 +123,36 @@ reads, so this section describes Herdr rather than those types.
   `chezmoi cd`, which runs `$SHELL` in the source directory, the pane reported
   `cwd: ~/Work/global-sso` and `foreground_cwd: ~/.local/share/chezmoi` for as
   long as that subshell lived, while `pane.process_info` listed the subshell
-  alone. Both fields are null when Herdr cannot read one, so a pane's directory
-  is `foreground_cwd` with `cwd` behind it — see
+  alone. Both fields are null when Herdr cannot read one, and neither is the
+  pane's directory on its own — see the two facts below and
   [title resolution](./title-resolution.md).
+- **`foreground_cwd` is the deepest descendant's, not the foreground process's
+  own.** Probed with a pane in `~/Library/Application Support/herdr-auto-title`
+  running `python3` that had spawned `sleep` in `/tmp`: `cwd` reported the
+  pane's directory, `foreground_cwd` reported `/private/tmp`, and
+  `pane.process_info` listed the child first and its parent second. Anything a
+  program starts elsewhere takes the pane's directory with it.
+- **A pane's directory is the `cwd` of its own foreground process**, which only
+  `pane.process_info` reports. Probed across the four panes of a live session:
+  in every one the last entry of `foreground_processes` was the process whose
+  `pid` equals `foreground_process_group_id`, and its `cwd` was the directory
+  the pane was working in. One pane disagreed with both snapshot fields at once
+  — `cwd: ~/Work/herdr-auto-title` (the shell it was started from) against
+  `foreground_cwd: ~/Work/self-care-portal` (an MCP server), with the agent
+  itself in `~/Work/self-care-portal`. Auto Title reads it for the pane that
+  names the tab and keeps the snapshot's pair behind it — see
+  [title resolution](./title-resolution.md).
+- **`foreground_processes` is the pane's foreground process group.** Every
+  process it listed shared the group id `pane.process_info` reports as
+  `foreground_process_group_id` and the pane's controlling terminal; a
+  descendant started in a group of its own without a terminal — which is how
+  Claude Code runs the commands it is asked to run — was absent from the list
+  while it ran. An agent's MCP servers are in it.
+- **`pane.process_info` reports more per process than a name.** Each entry
+  carries `pid`, `argv0`, `cmdline` and `cwd` beside `name` and `argv`, and the
+  pane's entry carries `shell_pid` and `foreground_process_group_id`. Auto
+  Title reads the name, the arguments and the directory; the rest is listed
+  here so a future change need not probe again.
 - **`PaneInfo` carries no foreground process name.** Only `pane.process_info`
   answers that, and nothing announces that a command started.
 - **`PaneInfo.title` is the agent's own title**, not the terminal's. Herdr left

--- a/docs/architecture/title-resolution.md
+++ b/docs/architecture/title-resolution.md
@@ -244,6 +244,20 @@ naming a project the user has left. The foreground process follows what is
 running right now, which is the point: what is running right now is what the
 pane is showing.
 
+Both of those are the snapshot's guess, and the pane a tab is named from does
+better: `pane.process_info` reports each foreground process with the directory
+it is itself in, deepest first, so the last entry is the pane's own foreground
+process and its directory is the pane's. That is what the poll reads, and the
+snapshot's pair stays behind it for the panes nothing is read for.
+
+The difference is what an agent spawns. `foreground_cwd` is the deepest
+descendant's, and an agent's descendants are its own machinery: an MCP server
+started as `uv run --directory ~/gimp-mcp` is a foreground process of the pane,
+so a tab holding that agent was named after the server's directory. Reading the
+agent's own directory instead names the project it is working in — which is not
+the shell's `cwd` either, because that shell was left behind when the user
+moved on.
+
 Directories that say nothing — the home directory, the filesystem root, a
 relative path — yield nothing, and a tab left with no name at all becomes
 `Shell`.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -414,6 +414,37 @@ func TestAgentContextNamesTheTab(t *testing.T) {
 	}
 }
 
+func TestAnAgentPaneIsNamedAfterTheAgentsOwnDirectory(t *testing.T) {
+	// Both directories the snapshot carries are a descendant's: the agent moved
+	// on to another project, and its MCP server sits in a third place.
+	client := herdrtest.New(
+		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		[]herdr.PaneInfo{{
+			PaneID: "wE:p1", TabID: "wE:t1", Focused: true,
+			CWD:           "/Users/dev/work/dashboard",
+			ForegroundCWD: "/private/tmp",
+			Agent:         "claude",
+			AgentStatus:   herdr.AgentStatusWorking,
+			Title:         "Implement OAuth scopes",
+		}},
+	)
+	client.SetProcesses(
+		"wE:p1",
+		herdr.PaneProcessInfoProcess{Name: "fff-mcp", CWD: "/private/tmp"},
+		herdr.PaneProcessInfoProcess{
+			Name: "claude",
+			CWD:  "/Users/dev/work/self-care-portal",
+		},
+	)
+
+	h := startWith(t, client)
+
+	want := "self-care-portal › claude › Implement OAuth scopes"
+	if got := h.awaitRenames(1)[0].Label; got != want {
+		t.Errorf("rename = %q, want %q", got, want)
+	}
+}
+
 func TestARemoteSessionIsNamedAfterItsHost(t *testing.T) {
 	// What is running in a pane is not in the snapshot, so this exercises the
 	// extra read the poll makes for the pane that names the tab.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1049,3 +1049,39 @@ func TestAPollPastItsDeadlineStopsReadingTheFilesystem(t *testing.T) {
 		t.Errorf("checkout = %+v, want a poll past its deadline to read nothing", got)
 	}
 }
+
+func TestAPaneIsReadFromItsForegroundProcessesDirectory(t *testing.T) {
+	// Both directories the snapshot carries point at a server the agent spawned
+	// elsewhere, so a checkout read from either finds no repository at all.
+	repo := repoAt(t, "feat/oauth")
+	elsewhere := t.TempDir()
+
+	pane := herdr.PaneInfo{
+		PaneID: "wE:p1", TabID: "wE:t1", Agent: "claude",
+		CWD: elsewhere, ForegroundCWD: elsewhere,
+	}
+
+	app := New(testConfig(), discardLogger(), testResolver(t))
+	client := herdrtest.New([]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}}, []herdr.PaneInfo{pane})
+	client.SetProcesses(
+		"wE:p1",
+		herdr.PaneProcessInfoProcess{Name: "gimp-mcp", CWD: elsewhere},
+		herdr.PaneProcessInfoProcess{Name: "claude", CWD: repo},
+	)
+
+	tabs := app.tabsIn(herdr.Snapshot{
+		Tabs:  []herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		Panes: []herdr.PaneInfo{pane},
+	})
+
+	read := tabs[0].Panes[0]
+	app.readInto(context.Background(), client, read, make(checkoutMemo))
+
+	if read.Dir != repo {
+		t.Errorf("dir = %q, want the agent's own %q", read.Dir, repo)
+	}
+
+	if got := read.Git.Branch; got != "feat/oauth" {
+		t.Errorf("branch = %q, want the checkout of the directory the pane is in", got)
+	}
+}

--- a/internal/app/reads.go
+++ b/internal/app/reads.go
@@ -63,13 +63,14 @@ func (a *App) readInto(
 		return
 	}
 
-	// What a pane is running settles which directory it speaks for, and the
-	// reads below are of that directory, so this one comes first.
-	pane.ReadProcesses(a.processesIn(ctx, client, pane.ID))
+	processes := a.processesIn(ctx, client, pane.ID)
+	dir := state.PaneDir(processes, pane.Dir)
 
 	pane.Read(state.Reads{
-		Git:   a.checkoutIn(ctx, pane.Dir, checkouts),
-		Topic: a.topicIn(ctx, pane),
+		Processes: processes,
+		Dir:       dir,
+		Git:       a.checkoutIn(ctx, dir, checkouts),
+		Topic:     a.topicIn(ctx, pane, dir),
 	})
 }
 
@@ -138,7 +139,7 @@ func (m checkoutMemo) read(dir string) git.Checkout {
 // topicIn reports what the session the pane's agent is holding says it is
 // about. Only Claude Code's transcripts are understood, and only Herdr's
 // integration hook says which session a pane holds.
-func (a *App) topicIn(ctx context.Context, pane *state.PaneState) string {
+func (a *App) topicIn(ctx context.Context, pane *state.PaneState, dir string) string {
 	if !a.cfg.ReadTranscripts || spentPoll(ctx) {
 		return ""
 	}
@@ -148,7 +149,7 @@ func (a *App) topicIn(ctx context.Context, pane *state.PaneState) string {
 		return ""
 	}
 
-	return a.topics.Topic(sessionID, pane.Dir).Text()
+	return a.topics.Topic(sessionID, dir).Text()
 }
 
 // spentPoll reports that this poll is past its deadline, in which case the tab

--- a/internal/app/reads.go
+++ b/internal/app/reads.go
@@ -63,10 +63,13 @@ func (a *App) readInto(
 		return
 	}
 
+	// What a pane is running settles which directory it speaks for, and the
+	// reads below are of that directory, so this one comes first.
+	pane.ReadProcesses(a.processesIn(ctx, client, pane.ID))
+
 	pane.Read(state.Reads{
-		Processes: a.processesIn(ctx, client, pane.ID),
-		Git:       a.checkoutIn(ctx, pane.Dir, checkouts),
-		Topic:     a.topicIn(ctx, pane),
+		Git:   a.checkoutIn(ctx, pane.Dir, checkouts),
+		Topic: a.topicIn(ctx, pane),
 	})
 }
 

--- a/internal/herdr/session.go
+++ b/internal/herdr/session.go
@@ -75,28 +75,18 @@ func (s *AgentSessionInfo) IDFor(agent string) (string, bool) {
 	return s.Value, true
 }
 
-// Dir is the directory a pane speaks for. The foreground process's is
-// preferred: cwd is the pane's own shell, and a subshell leaves it behind in
-// the directory that shell was started from — see docs/architecture.
-func (p PaneInfo) Dir() string {
-	if p.ForegroundCWD != "" {
-		return p.ForegroundCWD
-	}
-
-	return p.CWD
-}
-
-// PaneProcessInfoProcess is one process running in a pane. Herdr reports more
-// about each — its pid, its working directory, the joined command line — but a
-// title is derived from the name and the arguments alone.
+// PaneProcessInfoProcess is one process running in a pane. Herdr reports its
+// pid and the joined command line too; a title is derived from the name, the
+// arguments and the directory the process itself is in.
 type PaneProcessInfoProcess struct {
 	Name string   `json:"name"`
 	Argv []string `json:"argv"`
+	CWD  string   `json:"cwd"`
 }
 
 // PaneProcessInfo is what pane.process_info answers. ForegroundProcesses holds
-// the pane's foreground process and its descendants, so an editor that shelled
-// out lists both.
+// the pane's foreground process and its descendants, deepest first, so an
+// editor that shelled out lists both and the editor is last.
 type PaneProcessInfo struct {
 	ForegroundProcesses []PaneProcessInfoProcess `json:"foreground_processes"`
 }

--- a/internal/state/tab.go
+++ b/internal/state/tab.go
@@ -15,8 +15,8 @@ import (
 type PaneState struct {
 	ID string
 
-	// Dir is the directory this pane speaks for, already chosen between the
-	// shell's and the foreground process's.
+	// Dir is the directory this pane speaks for: its foreground process's own
+	// once ReadProcesses has run, and the snapshot's guess until then.
 	Dir string
 	// TerminalTitle is Herdr's cleaned title; TerminalTitleRaw still carries
 	// escapes and decorative prefixes and is only a fallback.
@@ -63,10 +63,20 @@ type Process struct {
 // carry: each field costs a request or a file of its own, which is why only
 // the pane that names its tab is read.
 type Reads struct {
-	Processes []herdr.PaneProcessInfoProcess
-	Git       git.Checkout
+	Git git.Checkout
 	// Topic is what the agent's own session says it is about.
 	Topic string
+}
+
+// paneDir is the directory a snapshot says a pane speaks for. A subshell leaves
+// cwd behind in the directory it was started from, so the foreground one is
+// preferred — but only ReadProcesses can say it exactly.
+func paneDir(info herdr.PaneInfo) string {
+	if info.ForegroundCWD != "" {
+		return info.ForegroundCWD
+	}
+
+	return info.CWD
 }
 
 // PaneFrom builds pane context from a snapshot entry and when a poll last saw
@@ -75,7 +85,7 @@ type Reads struct {
 func PaneFrom(info herdr.PaneInfo, changedAt time.Time) *PaneState {
 	return &PaneState{
 		ID:               info.PaneID,
-		Dir:              info.Dir(),
+		Dir:              paneDir(info),
 		TerminalTitle:    info.TerminalTitleStripped,
 		TerminalTitleRaw: info.TerminalTitle,
 		Agent:            info.Agent,
@@ -92,9 +102,21 @@ func PaneFrom(info herdr.PaneInfo, changedAt time.Time) *PaneState {
 // poll can leave it out: a tab is named from one pane, and every read behind
 // this costs a request or a file — see docs/architecture/poll-loop.md.
 func (p *PaneState) Read(reads Reads) {
-	p.Processes = processesFrom(reads.Processes)
 	p.Git = reads.Git
 	p.AgentTopic = reads.Topic
+}
+
+// ReadProcesses records what a pane is running, which is also what settles the
+// directory it speaks for: a snapshot reports the deepest descendant's, and a
+// server an agent spawned elsewhere would name the tab after itself.
+func (p *PaneState) ReadProcesses(processes []herdr.PaneProcessInfoProcess) {
+	p.Processes = processesFrom(processes)
+
+	// Deepest first, so the pane's own foreground process is last, and the
+	// directory it is in is the one the pane is working in.
+	if last := len(processes) - 1; last >= 0 && processes[last].CWD != "" {
+		p.Dir = processes[last].CWD
+	}
 }
 
 func processesFrom(processes []herdr.PaneProcessInfoProcess) []Process {

--- a/internal/state/tab.go
+++ b/internal/state/tab.go
@@ -16,7 +16,7 @@ type PaneState struct {
 	ID string
 
 	// Dir is the directory this pane speaks for: its foreground process's own
-	// once ReadProcesses has run, and the snapshot's guess until then.
+	// once a poll has read it, and the snapshot's guess until then.
 	Dir string
 	// TerminalTitle is Herdr's cleaned title; TerminalTitleRaw still carries
 	// escapes and decorative prefixes and is only a fallback.
@@ -63,15 +63,30 @@ type Process struct {
 // carry: each field costs a request or a file of its own, which is why only
 // the pane that names its tab is read.
 type Reads struct {
+	Processes []herdr.PaneProcessInfoProcess
+	// Dir is the directory the pane speaks for, which only what it is running
+	// says exactly — see PaneDir.
+	Dir string
 	Git git.Checkout
 	// Topic is what the agent's own session says it is about.
 	Topic string
 }
 
-// paneDir is the directory a snapshot says a pane speaks for. A subshell leaves
-// cwd behind in the directory it was started from, so the foreground one is
-// preferred — but only ReadProcesses can say it exactly.
-func paneDir(info herdr.PaneInfo) string {
+// PaneDir is the directory a pane speaks for, settled by what it is running:
+// the list is deepest first, so the pane's own foreground process is last and
+// the directory it is in is the pane's. A read saying nothing leaves guess.
+func PaneDir(processes []herdr.PaneProcessInfoProcess, guess string) string {
+	if last := len(processes) - 1; last >= 0 && processes[last].CWD != "" {
+		return processes[last].CWD
+	}
+
+	return guess
+}
+
+// snapshotDir is the directory a snapshot guesses a pane speaks for. A subshell
+// leaves cwd behind in the directory it was started from, so the foreground one
+// is preferred — but it is a descendant's, and only PaneDir is exact.
+func snapshotDir(info herdr.PaneInfo) string {
 	if info.ForegroundCWD != "" {
 		return info.ForegroundCWD
 	}
@@ -85,7 +100,7 @@ func paneDir(info herdr.PaneInfo) string {
 func PaneFrom(info herdr.PaneInfo, changedAt time.Time) *PaneState {
 	return &PaneState{
 		ID:               info.PaneID,
-		Dir:              paneDir(info),
+		Dir:              snapshotDir(info),
 		TerminalTitle:    info.TerminalTitleStripped,
 		TerminalTitleRaw: info.TerminalTitle,
 		Agent:            info.Agent,
@@ -102,21 +117,10 @@ func PaneFrom(info herdr.PaneInfo, changedAt time.Time) *PaneState {
 // poll can leave it out: a tab is named from one pane, and every read behind
 // this costs a request or a file — see docs/architecture/poll-loop.md.
 func (p *PaneState) Read(reads Reads) {
+	p.Processes = processesFrom(reads.Processes)
+	p.Dir = reads.Dir
 	p.Git = reads.Git
 	p.AgentTopic = reads.Topic
-}
-
-// ReadProcesses records what a pane is running, which is also what settles the
-// directory it speaks for: a snapshot reports the deepest descendant's, and a
-// server an agent spawned elsewhere would name the tab after itself.
-func (p *PaneState) ReadProcesses(processes []herdr.PaneProcessInfoProcess) {
-	p.Processes = processesFrom(processes)
-
-	// Deepest first, so the pane's own foreground process is last, and the
-	// directory it is in is the one the pane is working in.
-	if last := len(processes) - 1; last >= 0 && processes[last].CWD != "" {
-		p.Dir = processes[last].CWD
-	}
 }
 
 func processesFrom(processes []herdr.PaneProcessInfoProcess) []Process {

--- a/internal/state/tab_test.go
+++ b/internal/state/tab_test.go
@@ -222,3 +222,44 @@ func TestPaneFromPrefersTheForegroundDirectory(t *testing.T) {
 		t.Errorf("dir = %q, want the shell's own", shell.Dir)
 	}
 }
+
+func TestReadProcessesTakesTheForegroundProcessesOwnDirectory(t *testing.T) {
+	// A snapshot reports the deepest descendant's directory, which for an agent
+	// is a server it spawned. The process list is deepest first.
+	pane := PaneFrom(herdr.PaneInfo{
+		PaneID: "wE:p1", Agent: "claude",
+		CWD: "/work/dashboard", ForegroundCWD: "/opt/gimp-mcp",
+	}, time.Time{})
+
+	pane.ReadProcesses([]herdr.PaneProcessInfoProcess{
+		{Name: "gimp-mcp", CWD: "/opt/gimp-mcp"},
+		{Name: "claude", CWD: "/work/self-care-portal"},
+	})
+
+	if pane.Dir != "/work/self-care-portal" {
+		t.Errorf("dir = %q, want the foreground process's own", pane.Dir)
+	}
+
+	if len(pane.Processes) != 2 || pane.Processes[0].Name != "gimp-mcp" {
+		t.Errorf("processes = %+v, want both, deepest first", pane.Processes)
+	}
+}
+
+func TestReadProcessesKeepsTheSnapshotDirectoryWhenItLearnsNone(t *testing.T) {
+	pane := PaneFrom(
+		herdr.PaneInfo{PaneID: "wE:p1", CWD: "/work/api", ForegroundCWD: "/work/api"},
+		time.Time{},
+	)
+
+	pane.ReadProcesses(nil)
+
+	if pane.Dir != "/work/api" {
+		t.Errorf("dir = %q after an unread pane, want the snapshot's", pane.Dir)
+	}
+
+	pane.ReadProcesses([]herdr.PaneProcessInfoProcess{{Name: "nvim"}})
+
+	if pane.Dir != "/work/api" {
+		t.Errorf("dir = %q after a process with no directory, want the snapshot's", pane.Dir)
+	}
+}

--- a/internal/state/tab_test.go
+++ b/internal/state/tab_test.go
@@ -76,7 +76,7 @@ func TestPaneFromReadsAgentContext(t *testing.T) {
 		DisplayAgent:          "Claude Code",
 		AgentStatus:           herdr.AgentStatusWorking,
 	}, stamp)
-	pane.Read(Reads{Topic: "Rework the poll loop"})
+	pane.Read(Reads{Dir: pane.Dir, Topic: "Rework the poll loop"})
 
 	switch {
 	case pane.TerminalTitle != "Claude Code":
@@ -223,18 +223,19 @@ func TestPaneFromPrefersTheForegroundDirectory(t *testing.T) {
 	}
 }
 
-func TestReadProcessesTakesTheForegroundProcessesOwnDirectory(t *testing.T) {
+func TestPaneDirTakesTheForegroundProcessesOwnDirectory(t *testing.T) {
 	// A snapshot reports the deepest descendant's directory, which for an agent
 	// is a server it spawned. The process list is deepest first.
+	processes := []herdr.PaneProcessInfoProcess{
+		{Name: "gimp-mcp", CWD: "/opt/gimp-mcp"},
+		{Name: "claude", CWD: "/work/self-care-portal"},
+	}
+
 	pane := PaneFrom(herdr.PaneInfo{
 		PaneID: "wE:p1", Agent: "claude",
 		CWD: "/work/dashboard", ForegroundCWD: "/opt/gimp-mcp",
 	}, time.Time{})
-
-	pane.ReadProcesses([]herdr.PaneProcessInfoProcess{
-		{Name: "gimp-mcp", CWD: "/opt/gimp-mcp"},
-		{Name: "claude", CWD: "/work/self-care-portal"},
-	})
+	pane.Read(Reads{Processes: processes, Dir: PaneDir(processes, pane.Dir)})
 
 	if pane.Dir != "/work/self-care-portal" {
 		t.Errorf("dir = %q, want the foreground process's own", pane.Dir)
@@ -245,21 +246,13 @@ func TestReadProcessesTakesTheForegroundProcessesOwnDirectory(t *testing.T) {
 	}
 }
 
-func TestReadProcessesKeepsTheSnapshotDirectoryWhenItLearnsNone(t *testing.T) {
-	pane := PaneFrom(
-		herdr.PaneInfo{PaneID: "wE:p1", CWD: "/work/api", ForegroundCWD: "/work/api"},
-		time.Time{},
-	)
-
-	pane.ReadProcesses(nil)
-
-	if pane.Dir != "/work/api" {
-		t.Errorf("dir = %q after an unread pane, want the snapshot's", pane.Dir)
+func TestPaneDirKeepsTheSnapshotsGuessWhenItLearnsNone(t *testing.T) {
+	if dir := PaneDir(nil, "/work/api"); dir != "/work/api" {
+		t.Errorf("dir = %q for an unread pane, want the snapshot's", dir)
 	}
 
-	pane.ReadProcesses([]herdr.PaneProcessInfoProcess{{Name: "nvim"}})
-
-	if pane.Dir != "/work/api" {
-		t.Errorf("dir = %q after a process with no directory, want the snapshot's", pane.Dir)
+	nameOnly := []herdr.PaneProcessInfoProcess{{Name: "nvim"}}
+	if dir := PaneDir(nameOnly, "/work/api"); dir != "/work/api" {
+		t.Errorf("dir = %q for a process with no directory, want the snapshot's", dir)
 	}
 }


### PR DESCRIPTION
Closes #36.

## The bug

Every tab holding an agent was named after whatever that agent had
spawned. Herdr reports `foreground_cwd` as the **deepest descendant's**
directory, so an MCP server started as `uv run --directory ~/gimp-mcp`
named every tab that agent held — which is exactly the
`{POSITION} - gimp-mcp › claude ›` the issue reports.

## Why the obvious fix is also wrong

Reading `cwd` instead trades one wrong directory for another. `cwd` is
the pane's own shell, left behind the moment the user moves on: a live
pane reported `cwd: ~/Work/herdr-auto-title` beside
`foreground_cwd: ~/Work/self-care-portal` while the agent itself worked
in the latter. Naming from `cwd` loses the project altogether.

## What this does

Neither snapshot field is the pane's directory. `pane.process_info`
reports each foreground process with the directory it is itself in,
deepest first, so the last entry is the pane's own process and its `cwd`
is the answer — right for a subshell, for an agent, and for a build that
shells out. The poll already reads that list for the pane a tab is named
from, so this costs no extra request.

The snapshot's `foreground_cwd`/`cwd` pair stays behind it as the
fallback for panes nothing is read for.

The second commit is a restructuring of the first, not a separate
change: settling the directory in a `ReadProcesses` of its own made the
order of two mutating calls a contract that nothing but a comment held —
swapping them left the checkout and transcript reads on the snapshot's
guess, and the whole suite still passed. The directory is now a pure
function of what the pane runs (`state.PaneDir`), held in a local, and
`Read` fills the pane in one assignment again.

## Not in scope

The `claude ›` half of the issue is #35, which adds
`HERDR_AUTO_TITLE_AGENT_FORMAT`. This PR is the directory half.

## Verification

- `make check` green (fmt, vet, golangci-lint, `go test -race`).
- Probed against Herdr 0.8.2, protocol 20; what the probes taught is
  recorded in `CLAUDE.md` and `docs/architecture/herdr-socket-api.md`.
- `TestAPaneIsReadFromItsForegroundProcessesDirectory` pins the checkout
  to the directory the processes settled on, and fails on the
  arrangement the second commit replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpFUhoFoNUEP1vAmn7VYVt

