### PR TITLE
docs: state the comment rule in Go terms and apply it

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,0 +1,110 @@
+---
+description: How to write comments, and what never to comment
+---
+
+# Comments
+
+Go, and this repository's Go. Comments here are in English, like everything
+else written into the repository, whatever language the request was made in.
+
+## Rules
+
+- These rules cover every kind of comment: doc comments on packages, types,
+  functions, methods, fields and constants, and inline ones inside a function.
+- Comment only where it is genuinely needed: a declaration or a block whose
+  intent is not obvious at a glance. Obvious code gets none, exported or not —
+  `NewChanges` returning a `*Changes` needs no doc comment, and a comment that
+  only expands the identifier's name is worse than silence.
+- **A comment is at most three lines.** A hard cap. Anything longer is
+  explaining something the code cannot hold, and that explanation belongs in
+  [docs/architecture](../../docs/architecture/) with one line here pointing at it.
+- A doc comment starts with the name it documents and reads as a sentence:
+  `// paneKind names what a pane is running, or "" when that cannot be said.`
+  Inline comments inside a function need neither the name nor a full sentence.
+- One package comment per package, on the file named after it.
+- Explain the gist of the thing the comment sits on: what it does, plus the why
+  when that is not obvious. Never who calls it or when it runs — call sites
+  move and the comment then lies.
+- Never record provenance: which probe, which issue, which measurement session,
+  which commit. That is what `git log`, `CLAUDE.md` and `docs/architecture`
+  are for. A *measured value* is worth stating; the session that measured it is
+  not.
+- Never justify code somewhere else. A contract is stated where it is relied
+  on, never where a caller might one day lean on it.
+- Keep a comment that stops a reader "fixing" the code and breaking it: a
+  measured constant, a constraint the Herdr API imposes, an ordering that
+  matters, a case that looks unhandled and is not.
+- Plain language, plain words. If a sentence needs a second read, rewrite it
+  shorter.
+- Do not restate a line the code already states (`// increment the counter`
+  above `counter++`).
+- A `//nolint` names its linter and says why in the same line; `nolintlint`
+  rejects it otherwise.
+- In tests, a comment says what the case protects — the behaviour that would
+  otherwise be lost — never what the assertion does.
+- A field, method or constant deleted takes its comment with it.
+
+## Examples
+
+Bad, restates the code and names the caller:
+
+```go
+// Observe is called by App.poll on every tick.
+// It stores the panes from the snapshot.
+func (c *Changes) Observe(panes []herdr.PaneInfo) { ... }
+```
+
+Good, what it does and the why the signature cannot state:
+
+```go
+// Observe records a poll: panes whose revision moved changed just now and are
+// no longer described by what was read of them, and panes the session no
+// longer holds are forgotten.
+func (c *Changes) Observe(panes []herdr.PaneInfo) { ... }
+```
+
+Bad, a rationale essay with its provenance:
+
+```go
+// This constant exists because when the poll loop started reusing process
+// reads it turned out that a pane's revision does not move for every change
+// in what runs there. Over a ten-minute probe of a live eight-pane session on
+// Herdr 0.8.2 the foreground processes changed nine times while the revision
+// moved only four, so a pane running a build kept the name of whatever it
+// started with until it happened to draw, and the read now expires on its own.
+const processRefresh = 2 * time.Second
+```
+
+Good, the same thing in three lines, with the paragraph left in the docs:
+
+```go
+// processRefresh is how long a process read is reused for. A pane's revision
+// cannot carry this alone — measured, it moved for only four of nine process
+// changes — so see docs/architecture/poll-loop.md before raising it.
+const processRefresh = 2 * time.Second
+```
+
+Good, a why the code cannot state:
+
+```go
+// Herdr labels an unnamed tab with its position, and tab.rename stores an
+// empty label verbatim, so both spellings mean "nobody named this tab".
+if label == "" || label == position {
+```
+
+Good, none at all:
+
+```go
+func NewChanges() *Changes {
+	return &Changes{
+		panes: make(map[string]paneChange),
+		now:   time.Now,
+	}
+}
+```
+
+## Comment pass
+
+Write the code first. As the last step before reporting, check the comments
+this change added or touched against the rules above. Edit comments only, never
+code.

--- a/.claude/skills/validate-agent-work/SKILL.md
+++ b/.claude/skills/validate-agent-work/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: validate-agent-work
+description: Use when finishing any change to this repository, or when the user says "validate", "check my work", "run checks", or "verify changes". Also use automatically after adding a feature, fixing a bug, or editing Go, Python or documentation here.
+---
+
+# Validate Agent Work
+
+The rules live in [CLAUDE.md](../../../CLAUDE.md) and
+[CONTRIBUTING.md](../../../CONTRIBUTING.md); this is the order to check them in
+before handing work back.
+
+## Steps
+
+1. **See what changed** — the branch against `main`, and whatever is not
+   committed yet:
+
+   ```bash
+   git diff --name-only main...HEAD
+   git status --short
+   ```
+
+   Stage nothing: every check below runs over the whole module, and the index
+   is the user's to decide.
+
+2. **Run the gate:**
+
+   ```bash
+   make check
+   ```
+
+   `fmt` runs first and rewrites files, so re-read one before editing it again.
+
+3. **Comment pass** — the `## Comment pass` in
+   [`.claude/rules/comments.md`](../../rules/comments.md), over the comments
+   this change added or touched.
+
+4. **Read the diff against the mandatory rules in CLAUDE.md** — the language,
+   commit, type, script and comment rules, and the "Working here" list. The
+   linter checks none of them. Two need a search rather than a read: a field,
+   method or constant added without a reader in the same change, and a probe
+   whose finding has not reached both `CLAUDE.md` and
+   `docs/architecture/herdr-socket-api.md`.
+
+5. **Check nothing was left running:**
+
+   ```bash
+   make ps
+   ```
+
+6. **Fix and re-run** — fix what a step found, then run that step again to
+   confirm it. If a failure is not yours to fix, say so rather than working
+   around it.
+
+7. **Report** — always say what happened:
+
+   - Clean: a brief confirmation.
+   - Found and fixed, one line each:
+
+     ```
+     Validation found and fixed 3 issues:
+     - golangci-lint: unused parameter in resolver.qualify
+     - Comments: dropped a caller note in app/reads.go
+     - Type rule: removed PaneInfo.Cols, which nothing read
+     ```
+
+   - Still broken: what is wrong and why you could not fix it.
+
+`make check` is the whole gate on this machine, but CI also builds and tests on
+the Go floor `go.mod` names and on macOS — see CONTRIBUTING's "Pull requests".
+The user should never be surprised by a failure that could have been caught
+here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## What this changes
+
+<!--
+One paragraph. The diff already says what; say why the change is the one
+worth making. If it settles something about Herdr's API, say what was
+probed.
+-->
+
+Closes #
+
+## How it was checked
+
+<!--
+`make check` is the gate, but say what you looked at beyond it: a live
+session, a pane arranged to reproduce the bug, a probe under `scripts/`.
+-->
+
+## Before merging
+
+- [ ] `make check` is green locally.
+- [ ] One logical change per commit, Conventional Commits, no co-author
+      trailer. **PRs are rebased, never squashed or merged**, so the commit
+      messages are what lands in the history and in the changelog.
+- [ ] Tests land with the behaviour they cover.
+- [ ] `CHANGELOG.md`, the tags and the version in `herdr-plugin.toml` are
+      untouched — they belong to release-please.
+- [ ] A probe that taught something new is recorded in `CLAUDE.md` and in
+      `docs/architecture/herdr-socket-api.md`.
+- [ ] This pull request is one thing.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,8 +31,8 @@ type App struct {
 	failures failureLog
 }
 
-// New builds the application. The connection is supplied to Run, so the same
-// App can be driven by a real socket or by a stub in tests.
+// New builds the application. The client belongs to Run rather than to the
+// App, so one App can be driven by any connection.
 func New(cfg Config, log *slog.Logger, titles resolver.TitleResolver) *App {
 	return &App{
 		cfg:     cfg,
@@ -115,10 +115,9 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 			continue
 		}
 
-		// The reads happen here rather than during assembly: they are what a
-		// poll spends, and this is where it is known they will be used. The
-		// resolver picks the same pane again, which the choice being made from
-		// state alone is what guarantees.
+		// Read here rather than during assembly: the reads are what a poll
+		// spends, and only a tab that will be renamed is worth them. The
+		// resolver picks the same pane, because the choice is made from state.
 		a.readInto(ctx, client, state.SelectContextPane(tab), checkouts)
 
 		decision := a.titles.Resolve(tab)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -758,11 +758,9 @@ func TestAPaneThatCannotBeReadIsAskedAgain(t *testing.T) {
 	h := startWith(t, client)
 	h.awaitPolls(3)
 
-	// The tab is already named from the snapshot alone; the second rename is
-	// the one that could only come from a process read that happened again.
-	// The processes go in before the error is cleared: between the two calls a
-	// poll can read an empty pane successfully, and that answer is reused for
-	// processRefresh, which outlasts what this test is willing to wait.
+	// The tab is already named from the snapshot alone; the second rename can
+	// only come from a process read that happened again. The processes go in
+	// before the error clears: an empty read between the two would be reused.
 	client.SetProcesses("wE:p1", herdr.PaneProcessInfoProcess{Name: "nvim"})
 	client.SetProcessError(nil)
 

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -84,8 +84,8 @@ func LoadConfig() (Config, []string) {
 	cfg.ShowPosition = fromEnv(&warnings, EnvPosition, cfg.ShowPosition, boolean)
 	cfg.ReadTranscripts = fromEnv(&warnings, EnvTranscript, cfg.ReadTranscripts, boolean)
 	// A path needs neither parsing nor checking, so it does not go through
-	// fromEnv: any string the user set is the path they meant, and setting it
-	// to none of it asks for locks that do not outlive the process.
+	// fromEnv: any string the user set is the path they meant, and an empty
+	// one asks for locks that do not outlive the process.
 	if raw, set := os.LookupEnv(EnvManual); set {
 		cfg.ManualPath = raw
 	}
@@ -123,8 +123,8 @@ func configPath() string {
 }
 
 // fromEnv returns what the environment says name is, or fallback when it says
-// nothing usable. Nothing here fails: a typo must not stop the plugin starting,
-// which is why it warns instead, and is the only place a warning is worded.
+// nothing usable. Nothing here fails: a typo must not stop the plugin
+// starting, so it warns instead.
 func fromEnv[T any](warnings *[]string, name string, fallback T, convert converter[T]) T {
 	raw := os.Getenv(name)
 	if raw == "" {
@@ -172,8 +172,6 @@ func countOrNone(raw string) (int, error) {
 	return atLeast(raw, 0, errNegative)
 }
 
-// atLeast reads a number that may not fall below lowest, which is the whole of
-// what separates one count from the other.
 func atLeast(raw string, lowest int, tooSmall error) (int, error) {
 	value, err := strconv.Atoi(raw)
 	if err != nil {

--- a/internal/app/reads.go
+++ b/internal/app/reads.go
@@ -152,9 +152,9 @@ func (a *App) topicIn(ctx context.Context, pane *state.PaneState, dir string) st
 	return a.topics.Topic(sessionID, dir).Text()
 }
 
-// spentPoll reports that this poll is past its deadline, in which case the tab
-// loop will discard it. The reads it guards go to the filesystem, which takes
-// no context, so the only way to bound them is not to start them.
+// spentPoll reports that this poll is past its deadline. The reads it guards
+// go to the filesystem, which takes no context, so the only way to bound them
+// is not to start them.
 func spentPoll(ctx context.Context) bool {
 	return ctx.Err() != nil
 }

--- a/internal/claude/transcript.go
+++ b/internal/claude/transcript.go
@@ -23,8 +23,8 @@ const Agent = "claude"
 // catch-up on a session first seen mid-flight, not the steady state.
 const maxScan = 2 << 20
 
-// maxOpening bounds what an opening prompt contributes. A title is 50 columns;
-// the rest is only carried so the truncation can happen against the tab bar.
+// maxOpening bounds what an opening prompt contributes. It is generous because
+// the cut that matters is made later, against the width of the tab bar.
 const maxOpening = 200
 
 // locateRetry is how long a session whose transcript was not found is left
@@ -141,8 +141,8 @@ func (r *Reader) find(session *transcript, sessionID, dir string) bool {
 	return true
 }
 
-// Retain forgets every session but these, which is how the sessions a run has
-// outlived are let go.
+// Retain forgets every session but these, so a pane that closed takes its
+// transcript with it.
 func (r *Reader) Retain(sessionIDs []string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -10,8 +10,8 @@ import (
 	"sync/atomic"
 )
 
-// socketPathEnv names the environment variable holding the path to the Herdr
-// socket. The path is never hard-coded.
+// socketPathEnv is where Herdr names the socket it made for this session. The
+// path is never hard-coded.
 const socketPathEnv = "HERDR_SOCKET_PATH"
 
 // Client is the subset of the Herdr socket API that Auto Title uses.

--- a/internal/herdr/session.go
+++ b/internal/herdr/session.go
@@ -8,9 +8,6 @@ const (
 	AgentStatusBlocked = "blocked"
 )
 
-// Wire types carry only the fields Auto Title reads: a field nothing uses makes
-// the type claim a dependency the code does not have.
-
 // WorkspaceInfo describes a workspace. Its label is what Herdr shows above the
 // tabs, and it is usually the project every tab in it belongs to.
 type WorkspaceInfo struct {

--- a/internal/resolver/process.go
+++ b/internal/resolver/process.go
@@ -18,9 +18,9 @@ var shellNames = map[string]struct{}{
 // process names a pane: a build tool is `esbuild` and five `node`s.
 func paneKind(pane *state.PaneState) string {
 	if pane.HasAgent() {
-		// An agent's name is in the generic table, because an agent naming
-		// itself is not a report of its work. As a kind it is exactly right:
-		// it names the program, which is all a kind ever does.
+		// An agent naming itself is not a report of its work, which is why the
+		// name is generic as an activity. As a kind it names the program,
+		// which is all a kind ever does.
 		return Sanitize(pane.Agent, 0)
 	}
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -112,8 +112,8 @@ func New(maxLength int, sources ...Source) *Deterministic {
 	return &Deterministic{sources: ordered, maxLength: maxLength}
 }
 
-// Default builds the resolver Auto Title ships with, so the binary and the
-// tests cannot drift apart on what the chain contains.
+// Default builds the chain Auto Title ships with, so nothing else has to list
+// what it contains.
 func Default(maxLength, branchMax int) *Deterministic {
 	return New(maxLength,
 		NewAgent(),

--- a/internal/resolver/sanitize.go
+++ b/internal/resolver/sanitize.go
@@ -23,8 +23,8 @@ const zeroWidthJoiner = '\u200d'
 // left dangling by truncation says a part was lost without saying which.
 const trimmable = " " + separatorRune
 
-// escape opens every sequence ansiRe matches, which is what makes finding none
-// of it enough to skip that pass.
+// escape opens every sequence ansiRe matches, so a value without it needs no
+// ANSI pass at all.
 const escape = '\x1b'
 
 var (

--- a/internal/state/manual.go
+++ b/internal/state/manual.go
@@ -85,8 +85,8 @@ type Sighting struct {
 }
 
 // SightingFrom is what a poll saw of a tab, given the name the resolver chose
-// for it. What Herdr calls an unclaimed tab is derived here rather than by the
-// caller: it is the tab's own position, which is this package's to know.
+// for it. What Herdr calls an unclaimed tab is its position, which is this
+// package's to know.
 func SightingFrom(tab TabState, desired string) Sighting {
 	return Sighting{
 		TabID:   tab.ID,

--- a/internal/state/tab.go
+++ b/internal/state/tab.go
@@ -163,10 +163,9 @@ type TabState struct {
 	CurrentName string
 	// WorkspaceName is the label Herdr shows above this tab.
 	WorkspaceName string
-	// Position is the tab's place in its workspace, counted from one, which is
-	// both the key that switches to it and the label Herdr gives it while it
-	// is unnamed. Not TabInfo.number, which is a counter that never repeats —
-	// see docs/architecture/herdr-socket-api.md.
+	// Position is the tab's place in its workspace, counted from one: the key
+	// that switches to it, and the label Herdr gives it while it is unnamed.
+	// Not TabInfo.number — see docs/architecture/herdr-socket-api.md.
 	Position int
 	// Panes are ordered by ID, which is what makes every traversal of them
 	// yield the same answer from the same session.
@@ -209,9 +208,9 @@ func SelectContextPane(tab TabState) *PaneState {
 	return mostRecent(panes, nil)
 }
 
-// mostRecent returns the last-changed pane of an ID-ordered slice that keep
-// accepts, or nil when it accepts none. A nil keep takes every pane; the
-// strict comparison keeps the lowest ID when timestamps tie.
+// mostRecent returns the last-changed pane keep accepts, or nil when it
+// accepts none. A nil keep takes every pane. Panes arrive ordered by ID, and
+// the strict comparison keeps the lowest of them when timestamps tie.
 func mostRecent(panes []*PaneState, keep func(*PaneState) bool) *PaneState {
 	var best *PaneState
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,5 +1,5 @@
 // Tooling only. This module exists so the linter's dependency tree stays out
-// of the plugin's: the main module keeps one dependency and builds on Go 1.24,
+// of the plugin's: the main module keeps two dependencies and builds on Go 1.24,
 // which is what Herdr needs at install time.
 module github.com/kryptamine/herdr-auto-title/tools
 


### PR DESCRIPTION
## What this changes

The comment rule existed in `CLAUDE.md` but nothing said what it meant for Go
specifically, so the comments in the tree had drifted into the two shapes the
rule is meant to stop: restating what a well-named identifier already says, and
justifying code somewhere else. `.claude/rules/comments.md` states the rule in
Go terms — doc comments, inline comments, tests, `//nolint` — with worked
examples of what to keep and what to delete, and the pass over `internal/`
brings the existing comments in line with it. No behaviour changes: the Go diff
is comments only.

The rest is the tooling around that. A pull request template so a PR states its
why and its checks, and a `validate-agent-work` skill so the gate before
reporting is the same every time. The dependency count in the `tools/go.mod`
note was wrong and is corrected.

## How it was checked

`make check` is green locally: `golangci-lint` reports 0 issues and
`go test -race ./...` passes across every package. The Go changes touch no
statement, so the diff itself is the check — `git diff origin/main...HEAD --
internal/` is comment lines only.

## Before merging

- [x] `make check` is green locally.
- [x] One logical change per commit, Conventional Commits, no co-author
      trailer. **PRs are rebased, never squashed or merged**, so the commit
      messages are what lands in the history and in the changelog.
- [x] Tests land with the behaviour they cover. No behaviour changed; the one
      test comment touched says what its case protects.
- [x] `CHANGELOG.md`, the tags and the version in `herdr-plugin.toml` are
      untouched — they belong to release-please.
- [x] A probe that taught something new is recorded in `CLAUDE.md` and in
      `docs/architecture/herdr-socket-api.md`. Nothing was probed here.
- [x] This pull request is one thing: the comment rule and the pass it asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhyurWvVFevWBo1AmNby
