### PR TITLE
docs: fold the comment rule into a pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,27 +56,13 @@ library.
 
 ## Comment rule (mandatory)
 
-**A comment is at most three lines.** That is a hard cap, in every language in
-the repository. It is not a style preference: a comment long enough to need a
-fourth line is explaining something the code cannot hold, and that explanation
-belongs in [docs/architecture](docs/architecture/) where it can be read by
-someone who is not already staring at the function.
+**A comment is at most three lines**, in every language in the repository, and
+it says what is surprising rather than what is visible. A decision that needs a
+paragraph goes in [docs/architecture](docs/architecture/), with one line in the
+code pointing at it.
 
-Comment what is **surprising**, never what is visible:
-
-- **Delete it** if it restates the code, names what a well-named identifier
-  already names, or records where a value came from (which schema, which
-  ticket, which measurement session). Provenance is what `git log` and
-  `docs/architecture` are for.
-- **Delete it** if it justifies code somewhere else. A comment belongs to the
-  thing it is attached to, so a contract is stated where it is relied on, never
-  where a caller might one day lean on it.
-- **Keep it** if a reader would otherwise "fix" the code and break it: a
-  measured constant, a constraint the API imposes, an ordering that matters, a
-  case that looks unhandled and is not.
-
-When a decision genuinely needs a paragraph, write the paragraph in
-`docs/architecture` and leave one line in the code pointing at it.
+The rule in full, in Go terms and with worked examples of what to keep and what
+to delete, is in [.claude/rules/comments.md](.claude/rules/comments.md).
 
 ## Commands
 


### PR DESCRIPTION
## What this changes

The comment rule was stated three times: here in `CLAUDE.md`, in
`CONTRIBUTING.md` for people, and in full in `.claude/rules/comments.md`, which
loads alongside `CLAUDE.md`. Three copies of one rule drift, and then it is not
clear which is the rule. What stays in `CLAUDE.md` is the cap, its scope across
every language in the repository, and a pointer to the full text — which is
what the rule itself prescribes for a decision that needs a paragraph.

Kept deliberately: "in every language in the repository". The rules file opens
with "Go, and this repository's Go", so dropping the section outright would
have quietly stopped the cap applying to `scripts/`.

## How it was checked

`make check` is green. Documentation only — no Go file is touched. The claim
that nothing is lost is checkable by reading `.claude/rules/comments.md` and
`CONTRIBUTING.md:54-56` against the deleted lines.

## Before merging

- [x] `make check` is green locally.
- [x] One logical change per commit, Conventional Commits, no co-author
      trailer. **PRs are rebased, never squashed or merged**, so the commit
      messages are what lands in the history and in the changelog.
- [x] Tests land with the behaviour they cover. No behaviour changed.
- [x] `CHANGELOG.md`, the tags and the version in `herdr-plugin.toml` are
      untouched — they belong to release-please.
- [x] A probe that taught something new is recorded. Nothing was probed here.
- [x] This pull request is one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
