### PR TITLE
chore(lint): check the rules the repository only stated

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,24 +8,70 @@ run:
 linters:
   default: standard
   enable:
-    - copyloopvar # loop-variable copies made redundant by Go 1.22
-    - errorlint   # errors compared with == and formatted with %v
-    - gocritic    # a grab-bag of correctness and style checks
-    - misspell    # typos, in a repository that is mostly prose
-    - modernize   # idioms superseded by newer Go versions
-    - nakedret    # naked returns far from their signature
-    - nolintlint  # a //nolint must name its linter and say why
-    - recvcheck   # a type mixing pointer and value receivers
-    - sloglint    # log/slog used the way it is meant to be
-    - thelper     # test helpers that forget t.Helper()
-    - unconvert   # conversions that convert nothing
-    - unparam     # parameters and results that are always the same
-    - wsl_v5      # statements that belong together cuddled, the rest spaced
+    - bidichk         # bidirectional runes that make source read as it is not
+    - containedctx    # a context.Context smuggled inside a struct
+    - contextcheck    # a function that drops the context it was handed
+    - copyloopvar     # loop-variable copies made redundant by Go 1.22
+    - depguard        # the dependency floor, below
+    - durationcheck   # a duration multiplied by a duration
+    - errorlint       # errors compared with == and formatted with %v
+    - fatcontext      # a context rebuilt on every turn of a loop
+    - forbidigo       # the calls named below
+    - forcetypeassert # a type assertion that panics instead of reporting
+    - gocritic        # a grab-bag of correctness and style checks
+    - godot           # a comment that stops without a full stop
+    - gosec           # the usual security mistakes
+    - misspell        # typos, in a repository that is mostly prose
+    - modernize       # idioms superseded by newer Go versions
+    - musttag         # a struct reaching encoding/json without tags
+    - nakedret        # naked returns far from their signature
+    - nilerr          # nil returned although the error was not
+    - nilnil          # a nil result and a nil error together
+    - noctx           # a call made without the context it could take
+    - nolintlint      # a //nolint must name its linter and say why
+    - recvcheck       # a type mixing pointer and value receivers
+    - sloglint        # log/slog used the way it is meant to be
+    - thelper         # test helpers that forget t.Helper()
+    - unconvert       # conversions that convert nothing
+    - unparam         # parameters and results that are always the same
+    - usetesting      # what the testing package now does itself
+    - wsl_v5          # statements that belong together cuddled, the rest spaced
   disable:
     # Silence is a decision here, not an oversight: writing the manual-name
     # file and closing a socket both fail quietly on purpose, and each place
     # says so. See internal/state/manual.go and internal/herdr/client.go.
     - errcheck
+
+  settings:
+    depguard:
+      rules:
+        everywhere:
+          # Herdr needs Go 1.24 and builds the plugin at install time, so a
+          # third-party import has to be a decision rather than an accident.
+          list-mode: strict
+          allow:
+            - $gostd
+            - github.com/kryptamine/herdr-auto-title
+            - github.com/rivo/uniseg
+            - github.com/joho/godotenv
+          deny:
+            - pkg: os/exec
+              desc: renames go over the socket API, never through a shell
+    forbidigo:
+      analyze-types: true
+      forbid:
+        - pattern: ^exec\.Command(Context)?$
+          msg: a terminal-derived value must never reach a shell
+
+  exclusions:
+    rules:
+      # A test writes fixtures into its own temporary directory and closes a
+      # listener it owns; neither is the file permission or missing context
+      # these two are looking for.
+      - path: _test\.go
+        linters:
+          - gosec
+          - noctx
 
 formatters:
   enable:

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -187,7 +187,7 @@ func rebasingBranch(gitDir string) (string, bool) {
 // readRef returns the first line of a ref file, or false when there is nothing
 // to read. Reading is bounded: these files hold one line.
 func readRef(path string) (string, bool) {
-	file, err := os.Open(path)
+	file, err := os.Open(path) //nolint:gosec // path is a .git file this package located itself
 	if err != nil {
 		return "", false
 	}

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -37,7 +37,9 @@ type testServer struct {
 func newTestServer(t *testing.T, reply func(incoming) string) *testServer {
 	t.Helper()
 
-	// Unix socket paths are short; keep well clear of the platform limit.
+	// t.TempDir() names the directory after the test, which measured 122 bytes
+	// here — past the 104 a socket's sun_path holds.
+	//nolint:usetesting // t.TempDir() overruns sun_path, as measured above
 	dir, err := os.MkdirTemp("", "at")
 	if err != nil {
 		t.Fatalf("temp dir: %v", err)

--- a/internal/state/manual.go
+++ b/internal/state/manual.go
@@ -181,7 +181,7 @@ func (m *Manual) saveLocked() {
 		return
 	}
 
-	if os.MkdirAll(filepath.Dir(m.path), 0o755) != nil {
+	if os.MkdirAll(filepath.Dir(m.path), 0o700) != nil {
 		return
 	}
 
@@ -192,7 +192,7 @@ func (m *Manual) saveLocked() {
 	}
 
 	tmp := m.path + ".tmp"
-	if os.WriteFile(tmp, raw, 0o644) != nil {
+	if os.WriteFile(tmp, raw, 0o600) != nil {
 		return
 	}
 

--- a/internal/state/manual.go
+++ b/internal/state/manual.go
@@ -40,7 +40,7 @@ func LoadManual(path string) *Manual {
 		locked: make(map[string]string),
 	}
 
-	raw, err := os.ReadFile(path)
+	raw, err := os.ReadFile(path) //nolint:gosec // the path is configured, never terminal-derived
 	if err != nil {
 		return m
 	}


### PR DESCRIPTION
## What this changes

Four rules in `CLAUDE.md` are marked mandatory and the linter enforced none of
them. Two now are:

- **`depguard`** pins the dependency floor to the standard library, `uniseg`
  and `godotenv`. Herdr builds this plugin from source at install time, so a
  third-party import is a decision, not something that slips through review.
- **`forbidigo` + `depguard`** ban `os/exec`. "Never pass a terminal-derived
  value to a shell" was prose; it is a check now.

Both were verified to fire, not merely to stay quiet: a throwaway file calling
`exec.Command` was rejected by each, then deleted. Worth knowing — `forbidigo`
stayed silent when the calling function was itself dead code, while `depguard`
caught the import in every arrangement, which is the argument for keeping both.

The rest of the set reports nothing on today's code and exists to guard what
comes next. Chosen for what this repository actually does rather than for
completeness: `musttag` because the whole plugin is Herdr's wire objects and a
struct reaching `encoding/json` without tags fails silently; `fatcontext`,
`contextcheck` and `containedctx` because the poll loop runs on deadlines and
loops over tabs; `durationcheck` because there is duration arithmetic;
`bidichk` because a project that sanitizes untrusted terminal text should not
leave its own source open to the same trick; `godot`, which the comments here
already satisfy.

Deliberately not enabled: `paralleltest` (50 hits, all asking for `t.Parallel()`
on tests that drive one poll loop against a shared stub under `-race` — that is
a behaviour change, not a lint fix), `goconst` (50 hits, all test fixtures like
a pane id used 88 times; constants would make those tests harder to read), and
`gochecknoglobals` (~20 hits, every compiled regexp, lookup table and
`var _ Source = Git{}` assertion).

`gosec` found four things in non-test code. Two are the point of the function
holding them and carry a `//nolint` saying so. The other two were real, and are
the first commit: the manual lock file was written world-readable in a
world-traversable directory, and nothing but this plugin ever reads it.

## How it was checked

`make check` is green, and green at **each** commit separately — the
permissions fix does not depend on the linter change, which matters where PRs
are rebased.

`usetesting` asked for `t.TempDir()` in `newTestServer` and that advice was
measured and rejected: `t.TempDir()` names the directory after the test, giving
a 122-byte path here against the 104 bytes a Unix socket's `sun_path` holds —
`net.Listen` fails with `bind: invalid argument`. Worse, it would depend on the
length of the test function's name: 36 characters overruns, 30 does not. CI runs
macOS, so this would have landed as an intermittent failure. The existing
`os.MkdirTemp` stays, and the comment now records the measurement.

## Before merging

- [x] `make check` is green locally.
- [x] One logical change per commit, Conventional Commits, no co-author
      trailer. **PRs are rebased, never squashed or merged**, so the commit
      messages are what lands in the history and in the changelog.
- [x] Tests land with the behaviour they cover. The permissions change alters
      no observable behaviour; the existing manual-rename tests cover the file.
- [x] `CHANGELOG.md`, the tags and the version in `herdr-plugin.toml` are
      untouched — they belong to release-please.
- [x] A probe that taught something new is recorded. Nothing about Herdr's API
      was probed here.
- [x] This pull request is one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
