### PR TITLE
docs: add a security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ What the plugin does and how to install it are in the
 - Small fixes go straight to a PR: a typo, an obvious bug, a dependency bump.
 - If an issue rests on something false about Herdr's API, say so on the issue
   and correct it rather than working around it in silence.
-- Anything with security consequences: open an issue naming what is affected,
-  and leave the exploit out of it.
+- Anything with security consequences goes to the address in
+  [SECURITY.md](SECURITY.md), not to an issue.
 
 ## Getting set up
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Supported versions
+
+Auto Title is pre-1.0 — a fix lands on `main` and goes out in the next release
+rather than as a patch to an older tag. Only the newest release is supported.
+
+| Version | Supported |
+|---------|-----------|
+| 0.3.x   | ✅        |
+| < 0.3   | ❌        |
+
+## Reporting a vulnerability
+
+Email **satretdinovalexander@gmail.com** with `herdr-auto-title` in the
+subject. Do not open a public issue for anything exploitable: an issue is the
+right place once a fix is out, not before.
+
+Include what makes it reproducible:
+
+- the plugin version (the `version` field in `herdr-plugin.toml`), your Herdr
+  version and your OS;
+- what an attacker controls (a directory name, a terminal title, a file an
+  agent wrote) and what that gets them;
+- the shortest sequence that shows it.
+
+You get an acknowledgement within 72 hours and an assessment within a week.
+This is a one-person project, so a fix takes as long as it takes, but you will
+hear where it stands. Tell me whether you plan to disclose it and when, and the
+release is timed to that. You get credit in the release notes unless you would
+rather not be named.
+
+## Scope
+
+Auto Title polls a local Herdr session over a Unix socket and renames tabs. It
+starts no subprocess, and that socket is the only thing it talks to. Every
+value that reaches a tab title comes from terminal output and is treated as
+hostile; [docs/architecture/sanitization.md](docs/architecture/sanitization.md)
+says what is stripped and what is rejected.
+
+Worth reporting:
+
+- a terminal-derived value reaching a shell, a subprocess or a path;
+- an escape, control or format character that survives `Sanitize` into a tab
+  label, or a label that forges structure the session does not have;
+- a read escaping Claude Code's `projects` directory: a session id arrives over
+  the socket and becomes part of a transcript path;
+- a crash or an unbounded read a pane can trigger on its own.
+
+Not this project's to fix:
+
+- vulnerabilities in Herdr itself, which go to [herdr.dev](https://herdr.dev);
+- anything that presupposes an attacker who already runs code as you. Whoever
+  reaches the Herdr socket owns the session with or without this plugin;
+- a title that is wrong or unhelpful. That is a bug, so open an issue.


### PR DESCRIPTION
## What this changes

`CONTRIBUTING.md` sent anything with security consequences into a public issue — the one place an exploitable finding must not land — and GitHub had no policy to point a reporter at, so the repository showed no security section at all. `SECURITY.md` gives that a private address, and the contributing line now points there instead of at an issue.

The scope section is written against what the plugin actually is: a local reader of terminal output that starts no subprocess and speaks to no external service. It names the findings that matter here — a terminal-derived value reaching a shell or a path, an escape or format character surviving `Sanitize`, a read escaping Claude Code's `projects` directory when a session id from the socket becomes part of a transcript path — and sends Herdr's own bugs to Herdr and a merely ugly title to an issue. Nothing about the API was probed for this.

Alongside the file, Dependabot alerts, Dependabot security updates, secret scanning and push protection are now on for the repository. Private vulnerability reporting is deliberately left off: the policy names one channel, and GitHub's button would offer a second one that contradicts it.

## How it was checked

`make check` is green. Beyond it: every claim in the file was checked against the code rather than assumed — the transcript root and the session-id pattern in `internal/claude/transcript.go`, and the "no subprocess" claim across the tree. `make ps` shows only the user's own installed plugin. No Go code changed.

## Before merging

- [x] `make check` is green locally.
- [x] One logical change per commit, Conventional Commits, no co-author trailer. **PRs are rebased, never squashed or merged**, so the commit messages are what lands in the history and in the changelog.
- [x] Tests land with the behaviour they cover. *(documentation only)*
- [x] `CHANGELOG.md`, the tags and the version in `herdr-plugin.toml` are untouched — they belong to release-please.
- [x] A probe that taught something new is recorded in `CLAUDE.md` and in `docs/architecture/herdr-socket-api.md`. *(no probe here)*
- [x] This pull request is one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMRLRtH8rEAmGjN7oEGaCq