### PR TITLE
fix(resolver): leave a tunnel-only ssh out of the tab's context

### DIFF
--- a/internal/resolver/ssh.go
+++ b/internal/resolver/ssh.go
@@ -51,15 +51,49 @@ func (SSH) Resolve(pane *state.PaneState) (Parts, bool) {
 	return Parts{Context: qualify(host, sshKind)}, true
 }
 
-// sshArgs finds an ssh process in the pane and returns its arguments.
+// sshArgs finds an ssh process in the pane and returns its arguments. A
+// tunnel (`ssh -N`) runs no remote shell, so it says nothing about where the
+// pane's work is; an MCP server or a database client behind an agent keeps one.
 func sshArgs(pane *state.PaneState) ([]string, bool) {
 	for _, process := range pane.Processes {
-		if strings.EqualFold(process.Name, "ssh") {
+		if strings.EqualFold(process.Name, "ssh") && !sshIsTunnel(process.Args) {
 			return process.Args, true
 		}
 	}
 
 	return nil, false
+}
+
+// sshIsTunnel reports whether argv carries -N before the destination, alone
+// or in a cluster such as -NT or -fN. A letter that takes a value ends the
+// cluster: -pN is a port. Anything after the destination is the remote command.
+func sshIsTunnel(args []string) bool {
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		if arg == "-" {
+			continue
+		}
+
+		if len(arg) < 2 || arg[0] != '-' {
+			return false
+		}
+
+		for j := 1; j < len(arg); j++ {
+			if _, takesValue := sshFlagsWithValue[arg[j]]; takesValue {
+				if j == len(arg)-1 {
+					i++
+				}
+
+				break
+			}
+
+			if arg[j] == 'N' {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // sshHost extracts the destination: the first argument that is not an option or

--- a/internal/resolver/ssh.go
+++ b/internal/resolver/ssh.go
@@ -52,8 +52,7 @@ func (SSH) Resolve(pane *state.PaneState) (Parts, bool) {
 }
 
 // sshArgs finds an ssh process in the pane and returns its arguments. A
-// tunnel (`ssh -N`) runs no remote shell, so it says nothing about where the
-// pane's work is; an MCP server or a database client behind an agent keeps one.
+// tunnel (`ssh -N`) runs no remote shell and is skipped.
 func sshArgs(pane *state.PaneState) ([]string, bool) {
 	for _, process := range pane.Processes {
 		if strings.EqualFold(process.Name, "ssh") && !sshIsTunnel(process.Args) {
@@ -64,9 +63,7 @@ func sshArgs(pane *state.PaneState) ([]string, bool) {
 	return nil, false
 }
 
-// sshIsTunnel reports whether argv carries -N before the destination, alone
-// or in a cluster such as -NT or -fN. A letter that takes a value ends the
-// cluster: -pN is a port. Anything after the destination is the remote command.
+// sshIsTunnel reports whether -N appears before the destination; -pN is a port.
 func sshIsTunnel(args []string) bool {
 	for i := 1; i < len(args); i++ {
 		arg := args[i]

--- a/internal/resolver/ssh_test.go
+++ b/internal/resolver/ssh_test.go
@@ -118,9 +118,6 @@ func TestAnUnreadableDestinationKeepsTheMarkUnderARemoteTitle(t *testing.T) {
 }
 
 func TestATunnelDoesNotMarkTheTabRemote(t *testing.T) {
-	// `ssh -N` forwards ports and runs no remote shell: an MCP server or a
-	// database client behind an agent keeps one open, and the pane's work is
-	// still local. Alone, clustered, or beside options that take a value.
 	for _, argv := range [][]string{
 		{"ssh", "-N", "-L", "5432:db:5432", "bastion"},
 		{"ssh", "-N", "-T", "-o", "BatchMode=yes", "-L", "5432:db:5432", "bastion"},
@@ -138,8 +135,6 @@ func TestATunnelDoesNotMarkTheTabRemote(t *testing.T) {
 }
 
 func TestAValueSpelledNIsNotTheTunnelSwitch(t *testing.T) {
-	// -pN reads N as the port and -o N=... as an option, and past the
-	// destination -N is part of the remote command; none is the switch.
 	for _, argv := range [][]string{
 		{"ssh", "-pN", "prod-01"},
 		{"ssh", "-o", "N=1", "prod-01"},

--- a/internal/resolver/ssh_test.go
+++ b/internal/resolver/ssh_test.go
@@ -117,6 +117,41 @@ func TestAnUnreadableDestinationKeepsTheMarkUnderARemoteTitle(t *testing.T) {
 	}
 }
 
+func TestATunnelDoesNotMarkTheTabRemote(t *testing.T) {
+	// `ssh -N` forwards ports and runs no remote shell: an MCP server or a
+	// database client behind an agent keeps one open, and the pane's work is
+	// still local. Alone, clustered, or beside options that take a value.
+	for _, argv := range [][]string{
+		{"ssh", "-N", "-L", "5432:db:5432", "bastion"},
+		{"ssh", "-N", "-T", "-o", "BatchMode=yes", "-L", "5432:db:5432", "bastion"},
+		{"ssh", "-NT", "bastion"},
+		{"ssh", "-fN", "bastion"},
+		{"ssh", "-p", "2222", "-N", "bastion"},
+	} {
+		pane := sshPane(argv...)
+
+		got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+		if strings.Contains(strings.ToLower(got.Name), "ssh") {
+			t.Errorf("argv %v → %q, want nothing about ssh", argv, got.Name)
+		}
+	}
+}
+
+func TestAValueSpelledNIsNotTheTunnelSwitch(t *testing.T) {
+	// -pN reads N as the port and -o N=... as an option, and past the
+	// destination -N is part of the remote command; none is the switch.
+	for _, argv := range [][]string{
+		{"ssh", "-pN", "prod-01"},
+		{"ssh", "-o", "N=1", "prod-01"},
+		{"ssh", "prod-01", "-N"},
+		{"ssh", "prod-01", "--", "-N"},
+	} {
+		if sshIsTunnel(argv) {
+			t.Errorf("argv %v read as a tunnel", argv)
+		}
+	}
+}
+
 func TestAPaneWithoutSSHIsUnaffected(t *testing.T) {
 	pane := &state.PaneState{
 		Dir: "/Users/dev/work/dashboard",


### PR DESCRIPTION
## Problem

A Claude Code pane whose MCP server opens an `ssh -N -L <port>:db:<port> bastion` port forward gets named `3 · ssh › bastion › claude › <topic>`. Herdr reports the tunnel among the pane's foreground processes (it is a descendant of the agent), and the `ssh` resolver takes the first `ssh` it finds as a remote session.

```
claude
 └─ node <mcp server>
     └─ ssh -N -T -o BatchMode=yes -L 5432:db:5432 bastion
```

## Change

`sshArgs` skips an ssh whose options carry `-N` before the destination, alone or in a cluster (`-NT`, `-fN`). A tunnel runs no remote shell, so the pane's work is still local and the other resolvers name it. A value spelled `N` (`-pN`, `-o N=1`) and a `-N` after the destination (part of the remote command) are not the switch.

Tests cover both sides. `go vet` and `go test -race ./...` pass; `make check` needs Go 1.26 for `tools/`, which I do not have locally.