### PR TITLE
feat: let the agent name be turned off in a tab title

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ transcript in its own format, so **only Claude Code is read so far**. Any other
 agent's tab is named from its terminal title, exactly as before, and
 `HERDR_AUTO_TITLE_TRANSCRIPT=false` stops Auto Title reading transcripts at all.
 
+If your terminal already shows which agent holds a pane, the name in the tab is
+saying it twice: `HERDR_AUTO_TITLE_AGENT_NAME=false` leaves it out, and
+`dashboard › claude › Implement OAuth scopes` becomes
+`dashboard › Implement OAuth scopes`. It goes everywhere, including the tabs
+where the name was all there was — a pane whose agent has reported nothing then
+reads as its directory, `dashboard`, in place of `claude`.
+
 ## What your tabs will be called
 
 ```
@@ -124,6 +131,7 @@ restarts**, with the same `herdr server stop` the install needs.
 | `HERDR_AUTO_TITLE_POSITION`    | `true`                                    | Put each tab's position in front of its title                              |
 | `HERDR_AUTO_TITLE_MANUAL_FILE` | `manual-names.json`, next to `config.env` | Where tabs you renamed by hand are remembered; empty keeps them in memory  |
 | `HERDR_AUTO_TITLE_TRANSCRIPT`  | `true`                                    | Read an agent's own session transcript when it has not titled its terminal |
+| `HERDR_AUTO_TITLE_AGENT_NAME`  | `true`                                    | Put the agent's name in front of what an agent pane is doing               |
 
 ## Documentation
 

--- a/cmd/herdr-auto-title/main.go
+++ b/cmd/herdr-auto-title/main.go
@@ -47,7 +47,11 @@ func run() error {
 		return err
 	}
 
-	chain := resolver.Default(cfg.MaxLength, cfg.BranchMax)
+	chain := resolver.Default(resolver.Options{
+		MaxLength:     cfg.MaxLength,
+		BranchMax:     cfg.BranchMax,
+		HideAgentName: !cfg.ShowAgentName,
+	})
 
 	var titles resolver.TitleResolver = chain
 	if cfg.ShowPosition {

--- a/config.env.example
+++ b/config.env.example
@@ -28,3 +28,7 @@
 
 # Read an agent's own session transcript when it has not titled its terminal.
 #HERDR_AUTO_TITLE_TRANSCRIPT=true
+
+# Put the agent's name in front of what an agent pane is doing. Turned off, a
+# pane whose agent has reported nothing is named after its directory instead.
+#HERDR_AUTO_TITLE_AGENT_NAME=true

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -9,7 +9,7 @@ generated: { by: claude-code/opus-5, at: 2026-08-26T14:14:17+03:00 }
 
 # Configuration
 
-Every setting Auto Title has is one of seven `HERDR_AUTO_TITLE_*` variables,
+Every setting Auto Title has is one of eight `HERDR_AUTO_TITLE_*` variables,
 read in `internal/app/config.go`. They can be set in the environment, or written
 into a file that is loaded into the environment before anything reads it.
 

--- a/docs/architecture/title-resolution.md
+++ b/docs/architecture/title-resolution.md
@@ -22,13 +22,14 @@ distinction they cannot see. So every part shares one, `Separator`
 (`internal/resolver/sanitize.go`). The number in front is not a part of the
 title, and [carries a mark of its own](#the-position-is-not-a-part-of-the-title).
 
-Structurally a title is three fields, `Parts{Context, Branch, Activity}`
-(`internal/resolver/resolver.go`): *where* the user is and *what* they are
-doing. The branch belongs to the first of those — it qualifies the directory
-rather than standing beside it as a separate kind of thing. A fourth field,
-`Agent`, exists only between a source and the assembled title: an agent's name
-is held apart from its work because [the user decides whether it is
-shown](#the-agents-name-is-optional).
+Structurally a title is four fields, `Parts{Context, Branch, Agent, Activity}`
+(`internal/resolver/resolver.go`), formatted in that order: *where* the user is
+and *what* they are doing. The branch belongs to the first of those — it
+qualifies the directory rather than standing beside it as a separate kind of
+thing. The agent's name is a field rather than a prefix on the activity because
+[the user decides whether it is shown](#the-agents-name-is-optional), and
+because holding it apart is what lets the repetition check see the activity as
+it is.
 
 ## One pane speaks for the tab
 
@@ -153,8 +154,8 @@ What this source produces is a **kind** — the program, not the work.
 a kind a detail already carries, so `nvim › auth.provider.ts - Nvim` does not say
 the same thing twice. A kind with nothing left to add stands alone:
 `dashboard › nvim` for an editor with no file open. An agent is the one kind
-that is not bound here — only stripped — because binding it is a decision the
-whole title makes.
+that is not bound here — only stripped — because it is a field of its own, which
+the user can switch off.
 
 A mapping from command lines to friendlier names (`yarn dev` → `Dev`) was
 specified and is deliberately not built: the commands it would map are invisible
@@ -309,10 +310,10 @@ case is not hypothetical: an agent that never reports its work is ordinary, and
 `{agent}: {activity}` would leave `dashboard › claude:` in the tab bar. One bit
 was what was asked for, so one bit is what is stored.
 
-Because the name is held apart until the title is assembled, the repetition
-check sees the activity as it is. A tab whose agent titles its terminal after
-the project it was started in reads `dashboard › claude` rather than
-`dashboard › claude › dashboard`.
+Because the name is a field of its own rather than a prefix glued onto the
+activity, the repetition check sees the activity as it is. A tab whose agent
+titles its terminal after the project it was started in reads
+`dashboard › claude` rather than `dashboard › claude › dashboard`.
 
 ## The position is not a part of the title
 

--- a/docs/architecture/title-resolution.md
+++ b/docs/architecture/title-resolution.md
@@ -25,7 +25,10 @@ title, and [carries a mark of its own](#the-position-is-not-a-part-of-the-title)
 Structurally a title is three fields, `Parts{Context, Branch, Activity}`
 (`internal/resolver/resolver.go`): *where* the user is and *what* they are
 doing. The branch belongs to the first of those — it qualifies the directory
-rather than standing beside it as a separate kind of thing.
+rather than standing beside it as a separate kind of thing. A fourth field,
+`Agent`, exists only between a source and the assembled title: an agent's name
+is held apart from its work because [the user decides whether it is
+shown](#the-agents-name-is-optional).
 
 ## One pane speaks for the tab
 
@@ -85,7 +88,8 @@ terminal title instead. An agent that echoes its own name (`Claude Code`) is
 rejected as an activity — it is compared against the agent Herdr recognized in
 the pane rather than against a list — and reappears as a *kind*, so a tab reads
 `dashboard › claude` until there is something to report and
-`dashboard › claude › Implement OAuth scopes` after.
+`dashboard › claude › Implement OAuth scopes` after. That name can be [turned
+off](#the-agents-name-is-optional).
 
 ### Terminal title
 
@@ -148,7 +152,9 @@ What this source produces is a **kind** — the program, not the work.
 `qualify` binds a kind to whatever a higher source found, and `stripKind` drops
 a kind a detail already carries, so `nvim › auth.provider.ts - Nvim` does not say
 the same thing twice. A kind with nothing left to add stands alone:
-`dashboard › nvim` for an editor with no file open.
+`dashboard › nvim` for an editor with no file open. An agent is the one kind
+that is not bound here — only stripped — because binding it is a decision the
+whole title makes.
 
 A mapping from command lines to friendlier names (`yarn dev` → `Dev`) was
 specified and is deliberately not built: the commands it would map are invisible
@@ -274,7 +280,39 @@ lost more than it saved — and only on an exact match, so a tab whose directory
 has left its workspace behind is exactly the one that keeps saying where it is.
 A branch counts as something remaining, and the match is against the directory
 alone, so a tab in the workspace of the repository it is in reads `feat/oauth ›
-nvim`: the half that repeats goes, the half that distinguishes stays.
+nvim`: the half that repeats goes, the half that distinguishes stays. An agent's
+name counts too, but only while it is going to be shown — which is why it is
+dropped before this runs rather than after.
+
+## The agent's name is optional
+
+`HERDR_AUTO_TITLE_AGENT_NAME=false` leaves the agent's name out of every title.
+Some terminals say which agent holds a pane on their own, and a name repeated in
+the tab costs columns the work could use.
+
+Off means off, including the case where the name is the entire title: a pane
+whose agent has reported nothing then reads as its directory, `dashboard`, or as
+the generic fallback where there is no directory either. Keeping the name for
+that one case would make the setting a rule with an exception, and the exception
+would have to be explained to everyone who set it.
+
+The name is still stripped from the *edges* of an activity that carries it,
+under either value, so an agent signing its terminal title cannot smuggle the
+name back in as text. Nothing looks for the name anywhere else in an activity: a
+repository called `claude-mcp` keeps its title.
+
+**It is a switch, not a format string.** A template — `{agent} › {activity}`,
+with the name dropped by leaving `{agent}` out — is the more general answer, and
+it costs a grammar to parse, validate and document, plus a rule for the
+separator a placeholder leaves dangling when it resolves to nothing. That last
+case is not hypothetical: an agent that never reports its work is ordinary, and
+`{agent}: {activity}` would leave `dashboard › claude:` in the tab bar. One bit
+was what was asked for, so one bit is what is stored.
+
+Because the name is held apart until the title is assembled, the repetition
+check sees the activity as it is. A tab whose agent titles its terminal after
+the project it was started in reads `dashboard › claude` rather than
+`dashboard › claude › dashboard`.
 
 ## The position is not a part of the title
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -37,7 +37,10 @@ func testResolver(t *testing.T) resolver.TitleResolver {
 	t.Helper()
 	t.Setenv("HOME", filepath.Join(t.TempDir(), "home"))
 
-	return resolver.Default(resolver.DefaultMaxLength, resolver.DefaultBranchMaxLength)
+	return resolver.Default(resolver.Options{
+		MaxLength: resolver.DefaultMaxLength,
+		BranchMax: resolver.DefaultBranchMaxLength,
+	})
 }
 
 // harness runs an App against a stubbed Herdr session.

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -25,6 +25,7 @@ const (
 	EnvPosition   = "HERDR_AUTO_TITLE_POSITION"
 	EnvManual     = "HERDR_AUTO_TITLE_MANUAL_FILE"
 	EnvTranscript = "HERDR_AUTO_TITLE_TRANSCRIPT"
+	EnvAgentName  = "HERDR_AUTO_TITLE_AGENT_NAME"
 )
 
 // ConfigFile is the configuration file, read from the same directory the
@@ -56,6 +57,10 @@ type Config struct {
 	// when the agent has not titled its terminal. It reads what the user has
 	// been saying to that agent, so it can be turned off.
 	ReadTranscripts bool
+	// ShowAgentName puts the name of the agent running in a pane in front of
+	// what it is working on. Turned off, a pane whose agent has said nothing
+	// is named like any other pane in that directory.
+	ShowAgentName bool
 }
 
 // LoadConfig reads configuration from the configuration file and the
@@ -74,6 +79,7 @@ func LoadConfig() (Config, []string) {
 		ShowPosition:    true,
 		ManualPath:      state.DefaultManualPath(),
 		ReadTranscripts: true,
+		ShowAgentName:   true,
 	}
 
 	cfg.Debug = fromEnv(&warnings, EnvDebug, cfg.Debug, boolean)
@@ -83,6 +89,7 @@ func LoadConfig() (Config, []string) {
 	cfg.BranchMax = fromEnv(&warnings, EnvBranchMax, cfg.BranchMax, countOrNone)
 	cfg.ShowPosition = fromEnv(&warnings, EnvPosition, cfg.ShowPosition, boolean)
 	cfg.ReadTranscripts = fromEnv(&warnings, EnvTranscript, cfg.ReadTranscripts, boolean)
+	cfg.ShowAgentName = fromEnv(&warnings, EnvAgentName, cfg.ShowAgentName, boolean)
 	// A path needs neither parsing nor checking, so it does not go through
 	// fromEnv: any string the user set is the path they meant, and an empty
 	// one asks for locks that do not outlive the process.

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -22,7 +22,12 @@ func isolate(t *testing.T) {
 	// isolate anything until it is out of the way.
 	t.Setenv("XDG_CONFIG_HOME", "")
 
-	for _, name := range []string{EnvDebug, EnvPoll, EnvMaxLength, EnvBranchMax, EnvPosition, EnvManual, EnvTranscript} {
+	names := []string{
+		EnvDebug, EnvPoll, EnvMaxLength, EnvBranchMax,
+		EnvPosition, EnvManual, EnvTranscript, EnvAgentName,
+	}
+
+	for _, name := range names {
 		// Setenv first for its cleanup, which then also undoes what the
 		// configuration file sets; an empty variable is not an absent one.
 		t.Setenv(name, "")
@@ -75,6 +80,10 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if !cfg.ShowPosition {
 		t.Error("positions are off by default")
 	}
+
+	if !cfg.ShowAgentName {
+		t.Error("agent names are off by default")
+	}
 }
 
 func TestLoadConfigTurnsPositionsOff(t *testing.T) {
@@ -88,6 +97,20 @@ func TestLoadConfigTurnsPositionsOff(t *testing.T) {
 
 	if cfg.ShowPosition {
 		t.Error("positions are on despite being disabled")
+	}
+}
+
+func TestLoadConfigTurnsTheAgentNameOff(t *testing.T) {
+	isolate(t)
+	t.Setenv(EnvAgentName, "false")
+
+	cfg, warnings := LoadConfig()
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want none", warnings)
+	}
+
+	if cfg.ShowAgentName {
+		t.Error("agent names are shown despite being disabled")
 	}
 }
 
@@ -208,6 +231,7 @@ HERDR_AUTO_TITLE_MAX_LENGTH=32
 HERDR_AUTO_TITLE_BRANCH_MAX=0
 HERDR_AUTO_TITLE_POSITION=false
 HERDR_AUTO_TITLE_TRANSCRIPT=false
+HERDR_AUTO_TITLE_AGENT_NAME=false
 HERDR_AUTO_TITLE_MANUAL_FILE=/tmp/names.json
 `)
 
@@ -238,6 +262,10 @@ HERDR_AUTO_TITLE_MANUAL_FILE=/tmp/names.json
 
 	if cfg.ReadTranscripts {
 		t.Error("transcripts are read despite the file turning them off")
+	}
+
+	if cfg.ShowAgentName {
+		t.Error("agent names are shown despite the file turning them off")
 	}
 
 	if cfg.ManualPath != "/tmp/names.json" {

--- a/internal/resolver/agent_test.go
+++ b/internal/resolver/agent_test.go
@@ -186,3 +186,87 @@ func TestAnAgentTabDoesNotRepeatItsOwnDirectory(t *testing.T) {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
 }
+
+func hiddenAgentChain() *Deterministic {
+	return Default(Options{
+		MaxLength:     DefaultMaxLength,
+		BranchMax:     DefaultBranchMaxLength,
+		HideAgentName: true,
+	})
+}
+
+func TestAHiddenAgentNameLeavesTheWorkAlone(t *testing.T) {
+	got := hiddenAgentChain().Resolve(tabWithPane(&state.PaneState{
+		Dir:         "/Users/dev/work/dashboard",
+		Agent:       "claude",
+		AgentStatus: herdr.AgentStatusWorking,
+		AgentTitle:  "Implement OAuth scopes",
+	}))
+
+	if want := "dashboard › Implement OAuth scopes"; got.Name != want {
+		t.Errorf("name = %q, want %q", got.Name, want)
+	}
+}
+
+func TestAHiddenAgentNameIsAlsoStrippedFromTheWork(t *testing.T) {
+	// An agent that signs its terminal title must not smuggle its name back in
+	// as text once the name itself is turned off.
+	got := hiddenAgentChain().Resolve(tabWithPane(&state.PaneState{
+		Dir:           "/Users/dev/work/dashboard",
+		TerminalTitle: "Claude — Implement OAuth scopes",
+		Agent:         "claude",
+		AgentStatus:   herdr.AgentStatusWorking,
+	}))
+
+	if want := "dashboard › Implement OAuth scopes"; got.Name != want {
+		t.Errorf("name = %q, want %q", got.Name, want)
+	}
+}
+
+func TestASilentAgentHiddenLeavesTheTabToItsDirectory(t *testing.T) {
+	// The name is the whole title of a pane whose agent has reported nothing,
+	// so turning it off has to leave that tab named like any other.
+	pane := &state.PaneState{
+		Dir:         "/Users/dev/work/dashboard",
+		Agent:       "claude",
+		AgentStatus: herdr.AgentStatusWorking,
+	}
+
+	if got := defaultChain().Resolve(tabWithPane(pane)); got.Name != "dashboard › claude" {
+		t.Errorf("name = %q, want dashboard › claude", got.Name)
+	}
+
+	if got := hiddenAgentChain().Resolve(tabWithPane(pane)); got.Name != "dashboard" {
+		t.Errorf("name = %q, want dashboard", got.Name)
+	}
+}
+
+func TestASilentAgentHiddenWithNoDirectoryFallsBack(t *testing.T) {
+	got := hiddenAgentChain().Resolve(tabWithPane(&state.PaneState{
+		Agent:       "claude",
+		AgentStatus: herdr.AgentStatusWorking,
+	}))
+
+	if got.Name != GenericFallback {
+		t.Errorf("name = %q, want %q", got.Name, GenericFallback)
+	}
+}
+
+func TestAHiddenAgentNameKeepsAWorkspaceDirectory(t *testing.T) {
+	// The workspace is dropped only when something else is left to read, and a
+	// name that is about to be hidden is not something else.
+	tab := tabWithPane(&state.PaneState{
+		Dir:         "/Users/dev/work/dashboard",
+		Agent:       "claude",
+		AgentStatus: herdr.AgentStatusWorking,
+	})
+	tab.WorkspaceName = "dashboard"
+
+	if got := defaultChain().Resolve(tab); got.Name != "claude" {
+		t.Errorf("name = %q, want claude", got.Name)
+	}
+
+	if got := hiddenAgentChain().Resolve(tab); got.Name != "dashboard" {
+		t.Errorf("name = %q, want dashboard", got.Name)
+	}
+}

--- a/internal/resolver/agent_test.go
+++ b/internal/resolver/agent_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAgentTitleBeatsEverySourceBelowIt(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Claude Code",
 		Agent:         "claude",
@@ -30,7 +30,7 @@ func TestAgentTitleBeatsEverySourceBelowIt(t *testing.T) {
 }
 
 func TestAgentTitleOutranksAMeaningfulTerminalTitle(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Fix OAuth redirect",
 		Agent:         "claude",
@@ -48,10 +48,7 @@ func TestGenericAgentNameFallsThrough(t *testing.T) {
 	// topic then arrives through the terminal title instead.
 	for _, title := range []string{"Claude", "Claude Code", "Agent", "Coding Agent", ""} {
 		t.Run(title, func(t *testing.T) {
-			got := Default(
-				DefaultMaxLength,
-				DefaultBranchMaxLength,
-			).Resolve(tabWithPane(&state.PaneState{
+			got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 				Dir:           "/Users/dev/work/dashboard",
 				TerminalTitle: "Fix OAuth redirect",
 				Agent:         "claude",
@@ -86,7 +83,7 @@ func TestAgentEchoingItsOwnNameIsNotAgentContext(t *testing.T) {
 		t.Error("the agent source claimed an agent naming itself")
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := defaultChain().Resolve(tabWithPane(pane))
 	if want := "dashboard › acme-bot"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -116,7 +113,7 @@ func TestAnEchoedAgentNameIsDeclinedWhateverReportsIt(t *testing.T) {
 		t.Error("the transcript source claimed an agent naming itself")
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := defaultChain().Resolve(tabWithPane(pane))
 	if want := "dashboard › acme-bot"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -125,7 +122,7 @@ func TestAnEchoedAgentNameIsDeclinedWhateverReportsIt(t *testing.T) {
 func TestAgentTitleWithoutAnAgentIsIgnored(t *testing.T) {
 	// Herdr leaves the title on a pane whose agent it no longer recognizes;
 	// without an agent it is not agent context.
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		Dir:        "/Users/dev/work/dashboard",
 		AgentTitle: "Implement OAuth scopes",
 	}))
@@ -136,7 +133,7 @@ func TestAgentTitleWithoutAnAgentIsIgnored(t *testing.T) {
 }
 
 func TestAgentTitleWithNoDirectoryStandsAlone(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		Agent:       "claude",
 		AgentStatus: herdr.AgentStatusWorking,
 		AgentTitle:  "Implement OAuth scopes",
@@ -168,7 +165,7 @@ func TestContextAndActivityComeFromTheSamePane(t *testing.T) {
 		},
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
+	got := defaultChain().Resolve(tab)
 	if want := "dashboard › claude › Implement OAuth scopes"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}

--- a/internal/resolver/agent_test.go
+++ b/internal/resolver/agent_test.go
@@ -170,3 +170,19 @@ func TestContextAndActivityComeFromTheSamePane(t *testing.T) {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
 }
+
+func TestAnAgentTabDoesNotRepeatItsOwnDirectory(t *testing.T) {
+	// Claude Code titles its terminal after the project it was started in, so
+	// the activity says what the context already does. The agent's name in
+	// front of it must not hide that.
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
+		Dir:           "/Users/dev/work/dashboard",
+		TerminalTitle: "dashboard",
+		Agent:         "claude",
+		AgentStatus:   herdr.AgentStatusWorking,
+	}))
+
+	if want := "dashboard › claude"; got.Name != want {
+		t.Errorf("name = %q, want %q", got.Name, want)
+	}
+}

--- a/internal/resolver/git_test.go
+++ b/internal/resolver/git_test.go
@@ -129,7 +129,10 @@ func TestTheBranchSurvivesTheWorkspaceItRepeats(t *testing.T) {
 }
 
 func TestABranchWidthOfZeroLeavesBranchesOut(t *testing.T) {
-	got := Default(DefaultMaxLength, 0).Resolve(tabWithPane(repoPane("feat/oauth", "main"))).Name
+	got := Default(
+		Options{MaxLength: DefaultMaxLength},
+	).Resolve(tabWithPane(repoPane("feat/oauth", "main"))).
+		Name
 	if got != "dashboard" {
 		t.Errorf("title %q, want no branch at all", got)
 	}

--- a/internal/resolver/git_test.go
+++ b/internal/resolver/git_test.go
@@ -18,7 +18,7 @@ func repoPane(branch, defaultBranch string) *state.PaneState {
 }
 
 func resolveRepoPane(pane *state.PaneState) string {
-	return Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane)).Name
+	return defaultChain().Resolve(tabWithPane(pane)).Name
 }
 
 func TestTheBranchQualifiesTheDirectory(t *testing.T) {
@@ -122,7 +122,7 @@ func TestTheBranchSurvivesTheWorkspaceItRepeats(t *testing.T) {
 	tab := tabWithPane(repoPane("feat/oauth", "main"))
 	tab.WorkspaceName = "dashboard"
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab).Name
+	got := defaultChain().Resolve(tab).Name
 	if got != "feat/oauth" {
 		t.Errorf("title %q, want the branch alone", got)
 	}
@@ -157,7 +157,7 @@ func TestABranchStandsWhereTheDirectorySaysNothing(t *testing.T) {
 func TestTheBranchIsCreditedLikeAContext(t *testing.T) {
 	// The reason a tab carries a name is the source that named the work, and a
 	// branch is not work: it answers for the title only when nothing else does.
-	resolver := Default(DefaultMaxLength, DefaultBranchMaxLength)
+	resolver := defaultChain()
 
 	pane := repoPane("feat/oauth", "main")
 

--- a/internal/resolver/position_test.go
+++ b/internal/resolver/position_test.go
@@ -11,7 +11,7 @@ import (
 
 // numberedCWD names a tab after its directory and puts its position in front.
 func numberedCWD(maxLength int) *Numbered {
-	return NewNumbered(New(maxLength, NewCWD()), maxLength)
+	return NewNumbered(New(Options{MaxLength: maxLength}, NewCWD()), maxLength)
 }
 
 func atPosition(position int, dir string) state.TabState {
@@ -82,7 +82,7 @@ func TestAPositionWithNoRoomIsDropped(t *testing.T) {
 func TestNumberedWithoutAWidthTakesTheDefault(t *testing.T) {
 	// Zero means "no bound" to Sanitize but would leave no room at all here,
 	// so every tab would quietly lose the position instead.
-	got := NewNumbered(New(0, NewCWD()), 0).Resolve(atPosition(2, "/Users/dev/work/api"))
+	got := NewNumbered(New(Options{}, NewCWD()), 0).Resolve(atPosition(2, "/Users/dev/work/api"))
 	if got.Name != "2 · api" {
 		t.Errorf("name = %q, want the position kept", got.Name)
 	}

--- a/internal/resolver/process.go
+++ b/internal/resolver/process.go
@@ -118,9 +118,5 @@ func (Process) Resolve(pane *state.PaneState) (Parts, bool) {
 		return Parts{}, false
 	}
 
-	if pane.HasAgent() {
-		return Parts{Agent: kind}, true
-	}
-
-	return Parts{Activity: kind}, true
+	return partsFrom(pane, kind, ""), true
 }

--- a/internal/resolver/process.go
+++ b/internal/resolver/process.go
@@ -118,5 +118,9 @@ func (Process) Resolve(pane *state.PaneState) (Parts, bool) {
 		return Parts{}, false
 	}
 
+	if pane.HasAgent() {
+		return Parts{Agent: kind}, true
+	}
+
 	return Parts{Activity: kind}, true
 }

--- a/internal/resolver/process_test.go
+++ b/internal/resolver/process_test.go
@@ -24,7 +24,7 @@ func TestTheKindQualifiesTheTitle(t *testing.T) {
 		Processes:     running("nvim"),
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := defaultChain().Resolve(tabWithPane(pane))
 	if want := "dashboard › nvim › auth.provider.ts"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -38,7 +38,7 @@ func TestAKindWithNothingToAddStandsAlone(t *testing.T) {
 		Processes:     running("nvim"),
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := defaultChain().Resolve(tabWithPane(pane))
 	if want := "dashboard › nvim"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -47,7 +47,7 @@ func TestAKindWithNothingToAddStandsAlone(t *testing.T) {
 func TestAKindWithNoTitleAtAllStillNamesThePane(t *testing.T) {
 	pane := &state.PaneState{Dir: "/Users/dev/work/dashboard", Processes: running("htop")}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := defaultChain().Resolve(tabWithPane(pane))
 	if want := "dashboard › htop"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -99,10 +99,7 @@ func TestARemoteSessionIsNotNamedTwice(t *testing.T) {
 		t.Errorf("paneKind = %q, want empty", got)
 	}
 
-	if got := Default(
-		DefaultMaxLength,
-		DefaultBranchMaxLength,
-	).Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
+	if got := defaultChain().Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
 		t.Errorf("name = %q, want ssh › prod-01", got.Name)
 	}
 }
@@ -133,7 +130,7 @@ func TestAProjectNeverTakesAColon(t *testing.T) {
 		Processes:     running("esbuild", "node", "node"),
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := defaultChain().Resolve(tabWithPane(pane))
 	if want := "self-care-portal › yarn dev"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -154,7 +151,7 @@ func TestAnAgentIsItsOwnKind(t *testing.T) {
 		t.Errorf("paneKind = %q, want claude", got)
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := defaultChain().Resolve(tabWithPane(pane))
 	if want := "dashboard › claude › Git email configuration"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -169,7 +166,7 @@ func TestAStartingAgentIsNamedByItsKindAlone(t *testing.T) {
 		Agent:         "claude",
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := defaultChain().Resolve(tabWithPane(pane))
 	if want := "dashboard › claude"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -178,10 +175,7 @@ func TestAStartingAgentIsNamedByItsKindAlone(t *testing.T) {
 func TestAPaneWithoutAnAgentIsNotNamedAfterOne(t *testing.T) {
 	pane := &state.PaneState{Dir: "/Users/dev/work/dashboard", TerminalTitle: "Claude Code"}
 
-	if got := Default(
-		DefaultMaxLength,
-		DefaultBranchMaxLength,
-	).Resolve(tabWithPane(pane)); got.Name != "dashboard" {
+	if got := defaultChain().Resolve(tabWithPane(pane)); got.Name != "dashboard" {
 		t.Errorf("name = %q, want dashboard", got.Name)
 	}
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -59,15 +59,18 @@ func activityFrom(pane *state.PaneState, value string) (Parts, bool) {
 		return Parts{}, false
 	}
 
-	kind := paneKind(pane)
+	return partsFrom(pane, paneKind(pane), activity), true
+}
+
+// partsFrom places a pane's kind: an agent's name is a field of its own, any
+// other kind qualifies the activity. An agent's activity is stripped of the
+// name whether or not it is shown, so it cannot come back as text.
+func partsFrom(pane *state.PaneState, kind, activity string) Parts {
 	if pane.HasAgent() {
-		// The kind is stripped from the activity here rather than at the join,
-		// so an activity that carried the agent's name is rid of it however the
-		// name itself is treated.
-		return Parts{Agent: kind, Activity: stripKind(activity, kind)}, true
+		return Parts{Agent: kind, Activity: stripKind(activity, kind)}
 	}
 
-	return Parts{Activity: qualify(activity, kind)}, true
+	return Parts{Activity: qualify(activity, kind)}
 }
 
 // echoesAgentName reports an activity that is no more than the agent's own

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -32,15 +32,16 @@ const (
 )
 
 // Parts are the components a source contributes to a title, formatted as
-// "<context> › <branch> › <activity>". A source may supply any of them.
+// "<context> › <branch> › <agent> › <activity>". A source may supply any of
+// them.
 type Parts struct {
 	Context string
 	// Branch qualifies the context rather than standing on its own: a branch
 	// is part of where the user is, not of what they are doing.
 	Branch string
-	// Agent names the agent running in the pane. It is kept apart from the
-	// activity because whether the two are joined belongs to the title as a
-	// whole, not to the source that read them.
+	// Agent names the agent running in the pane. It stands apart from the
+	// activity because the user can turn it off, which is a decision the whole
+	// title makes rather than the source that read it.
 	Agent    string
 	Activity string
 }
@@ -67,24 +68,6 @@ func activityFrom(pane *state.PaneState, value string) (Parts, bool) {
 	}
 
 	return Parts{Activity: qualify(activity, kind)}, true
-}
-
-// withAgentName puts the agent's name in front of the work it reported. An
-// agent that has reported nothing leaves its name standing as the activity,
-// which is what names a tab that is only known to hold an agent.
-func withAgentName(parts Parts) Parts {
-	if parts.Agent == "" {
-		return parts
-	}
-
-	activity := parts.Agent
-	if parts.Activity != "" {
-		activity += Separator + parts.Activity
-	}
-
-	parts.Agent, parts.Activity = "", activity
-
-	return parts
 }
 
 // echoesAgentName reports an activity that is no more than the agent's own
@@ -171,9 +154,8 @@ func Default(opts Options) *Deterministic {
 	return d
 }
 
-// Resolve names a tab in four steps: ask the sources what they see, drop the
-// parts that only repeat something already on screen, put the agent's name
-// back in front of its work, and assemble the rest.
+// Resolve names a tab in three steps: ask the sources what they see, drop the
+// parts that only repeat something already on screen, and assemble the rest.
 func (d *Deterministic) Resolve(tab state.TabState) Decision {
 	found := d.collect(state.SelectContextPane(tab))
 
@@ -187,7 +169,7 @@ func (d *Deterministic) Resolve(tab state.TabState) Decision {
 
 	parts = withoutRepetition(parts, tab.WorkspaceName)
 
-	name := Format(withAgentName(parts), d.maxLength)
+	name := Format(parts, d.maxLength)
 	if name == "" {
 		return Decision{
 			Name:       GenericFallback,

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -37,7 +37,11 @@ type Parts struct {
 	Context string
 	// Branch qualifies the context rather than standing on its own: a branch
 	// is part of where the user is, not of what they are doing.
-	Branch   string
+	Branch string
+	// Agent names the agent running in the pane. It is kept apart from the
+	// activity because whether the two are joined belongs to the title as a
+	// whole, not to the source that read them.
+	Agent    string
 	Activity string
 }
 
@@ -54,7 +58,33 @@ func activityFrom(pane *state.PaneState, value string) (Parts, bool) {
 		return Parts{}, false
 	}
 
-	return Parts{Activity: qualify(activity, paneKind(pane))}, true
+	kind := paneKind(pane)
+	if pane.HasAgent() {
+		// The kind is stripped from the activity here rather than at the join,
+		// so an activity that carried the agent's name is rid of it however the
+		// name itself is treated.
+		return Parts{Agent: kind, Activity: stripKind(activity, kind)}, true
+	}
+
+	return Parts{Activity: qualify(activity, kind)}, true
+}
+
+// withAgentName puts the agent's name in front of the work it reported. An
+// agent that has reported nothing leaves its name standing as the activity,
+// which is what names a tab that is only known to hold an agent.
+func withAgentName(parts Parts) Parts {
+	if parts.Agent == "" {
+		return parts
+	}
+
+	activity := parts.Agent
+	if parts.Activity != "" {
+		activity += Separator + parts.Activity
+	}
+
+	parts.Agent, parts.Activity = "", activity
+
+	return parts
 }
 
 // echoesAgentName reports an activity that is no more than the agent's own
@@ -126,13 +156,14 @@ func Default(maxLength, branchMax int) *Deterministic {
 	)
 }
 
-// Resolve names a tab in three steps: ask the sources what they see, drop the
-// parts that only repeat something already on screen, and assemble the rest.
+// Resolve names a tab in four steps: ask the sources what they see, drop the
+// parts that only repeat something already on screen, put the agent's name
+// back in front of its work, and assemble the rest.
 func (d *Deterministic) Resolve(tab state.TabState) Decision {
 	found := d.collect(state.SelectContextPane(tab))
-	found.parts = withoutRepetition(found.parts, tab.WorkspaceName)
+	parts := withoutRepetition(found.parts, tab.WorkspaceName)
 
-	name := Format(found.parts, d.maxLength)
+	name := Format(withAgentName(parts), d.maxLength)
 	if name == "" {
 		return Decision{
 			Name:       GenericFallback,
@@ -183,11 +214,18 @@ func (d *Deterministic) collect(pane *state.PaneState) collected {
 // take fills whatever this source supplies and nothing already has.
 func (c *collected) take(source Source, parts Parts) {
 	// The activity is what a title is about, so its source answers for the
-	// title whenever one turns up. A context and a branch are credited only
-	// while no activity has been found.
+	// title whenever one turns up. Every other part is credited only while
+	// nothing has been.
 	if c.parts.Activity == "" && parts.Activity != "" {
 		c.parts.Activity = parts.Activity
 		c.credit(source)
+	}
+
+	if c.parts.Agent == "" && parts.Agent != "" {
+		c.parts.Agent = parts.Agent
+		if c.reason == "" {
+			c.credit(source)
+		}
 	}
 
 	if c.parts.Branch == "" && parts.Branch != "" {
@@ -210,11 +248,11 @@ func (c *collected) credit(source Source) {
 	c.confidence = source.Confidence()
 }
 
-// complete stops the walk once both halves of a title are answered. The branch
-// is not required: a tab outside a repository has none, and waiting for one
-// would only walk sources that have already been outranked.
+// complete stops the walk once both halves of a title are answered, an agent's
+// name counting as the activity half. The branch is not required: a tab outside
+// a repository has none, and waiting for one only walks outranked sources.
 func (c *collected) complete() bool {
-	return c.parts.Context != "" && c.parts.Activity != ""
+	return c.parts.Context != "" && (c.parts.Activity != "" || c.parts.Agent != "")
 }
 
 // withoutRepetition drops the parts of a title that only say again what the
@@ -233,9 +271,10 @@ func withoutRepetition(parts Parts, workspace string) Parts {
 	}
 
 	// Herdr shows the workspace above its tabs, so repeating it wastes half the
-	// width. Dropped only when something else remains — the branch counts,
-	// which is what keeps `feat/oauth › nvim` from losing where it is.
-	if (parts.Activity != "" || parts.Branch != "") && strings.EqualFold(parts.Context, workspace) {
+	// width. Dropped only when something else remains: a branch counts, and so
+	// does an agent's name, which by here is gone if it is not to be shown.
+	if (parts.Activity != "" || parts.Branch != "" || parts.Agent != "") &&
+		strings.EqualFold(parts.Context, workspace) {
 		parts.Context = ""
 	}
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -119,10 +119,22 @@ type TitleResolver interface {
 	Resolve(tab state.TabState) Decision
 }
 
+// Options are the settings a title is assembled under, as opposed to the ones
+// a single source reads.
+type Options struct {
+	MaxLength int
+	BranchMax int
+	// HideAgentName leaves the agent's name out of a title. It is stated this
+	// way round so that the zero value keeps the name, which is what a resolver
+	// built without options wants.
+	HideAgentName bool
+}
+
 // Deterministic resolves titles from a fixed priority list of sources.
 type Deterministic struct {
-	sources   []Source
-	maxLength int
+	sources       []Source
+	maxLength     int
+	hideAgentName bool
 }
 
 var _ TitleResolver = (*Deterministic)(nil)
@@ -144,16 +156,19 @@ func New(maxLength int, sources ...Source) *Deterministic {
 
 // Default builds the chain Auto Title ships with, so nothing else has to list
 // what it contains.
-func Default(maxLength, branchMax int) *Deterministic {
-	return New(maxLength,
+func Default(opts Options) *Deterministic {
+	d := New(opts.MaxLength,
 		NewAgent(),
 		NewTerminalTitle(),
 		NewTranscript(),
 		NewProcess(),
 		NewSSH(),
-		NewGit(branchMax),
+		NewGit(opts.BranchMax),
 		NewCWD(),
 	)
+	d.hideAgentName = opts.HideAgentName
+
+	return d
 }
 
 // Resolve names a tab in four steps: ask the sources what they see, drop the
@@ -161,7 +176,16 @@ func Default(maxLength, branchMax int) *Deterministic {
 // back in front of its work, and assemble the rest.
 func (d *Deterministic) Resolve(tab state.TabState) Decision {
 	found := d.collect(state.SelectContextPane(tab))
-	parts := withoutRepetition(found.parts, tab.WorkspaceName)
+
+	parts := found.parts
+	if d.hideAgentName {
+		// Dropped before the repetition check, so a tab left with nothing but
+		// its directory keeps it rather than losing it to a name it will not
+		// show.
+		parts.Agent = ""
+	}
+
+	parts = withoutRepetition(parts, tab.WorkspaceName)
 
 	name := Format(withAgentName(parts), d.maxLength)
 	if name == "" {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -127,9 +127,9 @@ var _ TitleResolver = (*Deterministic)(nil)
 
 // New builds a resolver from sources, ordering them by confidence rather than
 // by the order they are listed in. Equal confidences keep the order given.
-func New(maxLength int, sources ...Source) *Deterministic {
-	if maxLength <= 0 {
-		maxLength = DefaultMaxLength
+func New(opts Options, sources ...Source) *Deterministic {
+	if opts.MaxLength <= 0 {
+		opts.MaxLength = DefaultMaxLength
 	}
 
 	ordered := slices.Clone(sources)
@@ -137,13 +137,17 @@ func New(maxLength int, sources ...Source) *Deterministic {
 		return cmp.Compare(b.Confidence(), a.Confidence())
 	})
 
-	return &Deterministic{sources: ordered, maxLength: maxLength}
+	return &Deterministic{
+		sources:       ordered,
+		maxLength:     opts.MaxLength,
+		hideAgentName: opts.HideAgentName,
+	}
 }
 
 // Default builds the chain Auto Title ships with, so nothing else has to list
 // what it contains.
 func Default(opts Options) *Deterministic {
-	d := New(opts.MaxLength,
+	return New(opts,
 		NewAgent(),
 		NewTerminalTitle(),
 		NewTranscript(),
@@ -152,9 +156,6 @@ func Default(opts Options) *Deterministic {
 		NewGit(opts.BranchMax),
 		NewCWD(),
 	)
-	d.hideAgentName = opts.HideAgentName
-
-	return d
 }
 
 // Resolve names a tab in three steps: ask the sources what they see, drop the

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func defaultChain() *Deterministic {
-	return Default(DefaultMaxLength, DefaultBranchMaxLength)
+	return Default(Options{MaxLength: DefaultMaxLength, BranchMax: DefaultBranchMaxLength})
 }
 
 func tabWithCWD(dir string) state.TabState {

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
 
+func defaultChain() *Deterministic {
+	return Default(DefaultMaxLength, DefaultBranchMaxLength)
+}
+
 func tabWithCWD(dir string) state.TabState {
 	return state.TabState{
 		ID: "wE:t1",
@@ -184,7 +188,7 @@ func TestATabDoesNotRepeatItsWorkspace(t *testing.T) {
 	})
 	tab.WorkspaceName = "dashboard"
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
+	got := defaultChain().Resolve(tab)
 	if got.Name != "Fix OAuth redirect" {
 		t.Errorf("name = %q, want %q", got.Name, "Fix OAuth redirect")
 	}
@@ -196,7 +200,7 @@ func TestATabWithNothingElseKeepsItsContext(t *testing.T) {
 	tab := tabWithPane(&state.PaneState{Dir: "/Users/dev/work/dashboard"})
 	tab.WorkspaceName = "dashboard"
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
+	got := defaultChain().Resolve(tab)
 	if got.Name != "dashboard" {
 		t.Errorf("name = %q, want dashboard", got.Name)
 	}
@@ -211,7 +215,7 @@ func TestADifferentWorkspaceIsNotDropped(t *testing.T) {
 	})
 	tab.WorkspaceName = "api"
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
+	got := defaultChain().Resolve(tab)
 	if want := "dashboard › Fix OAuth redirect"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -224,7 +228,7 @@ func TestAWorkspaceWithoutAName(t *testing.T) {
 		TerminalTitle: "Fix OAuth redirect",
 	})
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tab)
+	got := defaultChain().Resolve(tab)
 	if want := "dashboard › Fix OAuth redirect"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -234,7 +238,7 @@ func TestTheShippedChainIsAWellFormedLadder(t *testing.T) {
 	// Confidences used to be repeated in every result a source returned, and
 	// the chain's order was a second, unchecked statement of the same ladder.
 	// Now the numbers are the only statement, so they have to hold up.
-	chain := Default(DefaultMaxLength, DefaultBranchMaxLength)
+	chain := defaultChain()
 
 	seen := make(map[int]string, len(chain.sources))
 	previous := 0
@@ -288,7 +292,7 @@ func TestSourcesAreOrderedByConfidenceNotByArgument(t *testing.T) {
 }
 
 func TestTheShippedChainResolvesATabWithNoPanes(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(state.TabState{ID: "wE:t1"})
+	got := defaultChain().Resolve(state.TabState{ID: "wE:t1"})
 	if got.Name != GenericFallback {
 		t.Errorf("name = %q, want %q", got.Name, GenericFallback)
 	}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -26,7 +26,7 @@ func tabWithCWD(dir string) state.TabState {
 func TestResolveFromCWD(t *testing.T) {
 	home := t.TempDir()
 	source := CWD{home: filepath.Clean(home)}
-	r := New(DefaultMaxLength, source)
+	r := New(Options{MaxLength: DefaultMaxLength}, source)
 
 	tests := []struct {
 		name       string
@@ -63,7 +63,7 @@ func TestResolveFromCWD(t *testing.T) {
 }
 
 func TestResolveNamesATabAfterItsDirectory(t *testing.T) {
-	r := New(DefaultMaxLength, NewCWD())
+	r := New(Options{MaxLength: DefaultMaxLength}, NewCWD())
 	tab := state.TabState{
 		ID: "wE:t1",
 		Panes: []*state.PaneState{
@@ -77,7 +77,7 @@ func TestResolveNamesATabAfterItsDirectory(t *testing.T) {
 }
 
 func TestResolveTabWithoutPanes(t *testing.T) {
-	r := New(DefaultMaxLength, NewCWD())
+	r := New(Options{MaxLength: DefaultMaxLength}, NewCWD())
 
 	got := r.Resolve(state.TabState{ID: "wE:t1"})
 	if got.Name != GenericFallback {
@@ -87,7 +87,7 @@ func TestResolveTabWithoutPanes(t *testing.T) {
 
 func TestResolveTruncatesToMaxLength(t *testing.T) {
 	long := strings.Repeat("x", 100)
-	r := New(10, NewCWD())
+	r := New(Options{MaxLength: 10}, NewCWD())
 
 	got := r.Resolve(tabWithCWD("/Users/dev/" + long))
 	if len([]rune(got.Name)) != 10 {
@@ -96,7 +96,7 @@ func TestResolveTruncatesToMaxLength(t *testing.T) {
 }
 
 func TestResolveIsDeterministic(t *testing.T) {
-	r := New(DefaultMaxLength, NewCWD())
+	r := New(Options{MaxLength: DefaultMaxLength}, NewCWD())
 	panes := []*state.PaneState{
 		{ID: "wE:p1", Dir: "/Users/dev/work/dashboard"},
 		{ID: "wE:p2", Dir: "/Users/dev/work/api"},
@@ -130,7 +130,7 @@ func (s higherSource) Resolve(*state.PaneState) (Parts, bool) {
 }
 
 func TestHigherPrioritySourceSuppliesActivity(t *testing.T) {
-	r := New(DefaultMaxLength,
+	r := New(Options{MaxLength: DefaultMaxLength},
 		higherSource{confidence: ConfidenceProcess, parts: Parts{Activity: "Tests"}, ok: true},
 		NewCWD(),
 	)
@@ -152,7 +152,7 @@ func TestHigherPrioritySourceSuppliesActivity(t *testing.T) {
 
 func TestHigherPrioritySourceOverridesContext(t *testing.T) {
 	r := New(
-		DefaultMaxLength,
+		Options{MaxLength: DefaultMaxLength},
 		higherSource{
 			confidence: ConfidenceSSH,
 			parts:      Parts{Context: "prod-01", Activity: "SSH"},
@@ -168,7 +168,7 @@ func TestHigherPrioritySourceOverridesContext(t *testing.T) {
 }
 
 func TestSourceThatDeclinesIsSkipped(t *testing.T) {
-	r := New(DefaultMaxLength,
+	r := New(Options{MaxLength: DefaultMaxLength},
 		higherSource{ok: false},
 		NewCWD(),
 	)
@@ -277,8 +277,8 @@ func TestSourcesAreOrderedByConfidenceNotByArgument(t *testing.T) {
 
 	tab := tabWithPane(&state.PaneState{})
 	for _, chain := range []*Deterministic{
-		New(DefaultMaxLength, high, low),
-		New(DefaultMaxLength, low, high),
+		New(Options{MaxLength: DefaultMaxLength}, high, low),
+		New(Options{MaxLength: DefaultMaxLength}, low, high),
 	} {
 		got := chain.Resolve(tab)
 		if got.Name != "high" {

--- a/internal/resolver/sanitize.go
+++ b/internal/resolver/sanitize.go
@@ -127,7 +127,7 @@ func splitAtWidth(s string, maxWidth int) (head, rest string) {
 func Format(parts Parts, maxLen int) string {
 	var b strings.Builder
 
-	for _, part := range []string{parts.Context, parts.Branch, parts.Activity} {
+	for _, part := range []string{parts.Context, parts.Branch, parts.Agent, parts.Activity} {
 		if part == "" {
 			continue
 		}

--- a/internal/resolver/sanitize_test.go
+++ b/internal/resolver/sanitize_test.go
@@ -110,6 +110,18 @@ func TestFormat(t *testing.T) {
 			Parts{Context: "dashboard", Activity: "Tests"},
 			"dashboard › Tests",
 		},
+		{
+			// The agent's name sits between where the user is and what the
+			// agent is doing, and holds that place with either neighbour gone.
+			"every part is joined in reading order",
+			Parts{Context: "dashboard", Branch: "feat/oauth", Agent: "claude", Activity: "Scopes"},
+			"dashboard › feat/oauth › claude › Scopes",
+		},
+		{
+			"an agent that reported nothing stands alone",
+			Parts{Context: "dashboard", Agent: "claude"},
+			"dashboard › claude",
+		},
 		{"context alone carries no separator", Parts{Context: "dashboard"}, "dashboard"},
 		{"activity alone carries no separator", Parts{Activity: "Tests"}, "Tests"},
 		{"nothing yields nothing", Parts{}, ""},

--- a/internal/resolver/ssh_test.go
+++ b/internal/resolver/ssh_test.go
@@ -64,7 +64,7 @@ func TestTheHostBecomesTheContext(t *testing.T) {
 func TestTheTabIsNamedAfterTheMarkedHost(t *testing.T) {
 	pane := sshPane("ssh", "root@prod-01")
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := defaultChain().Resolve(tabWithPane(pane))
 	if want := "ssh › prod-01"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -82,10 +82,7 @@ func TestTheHostOutranksTheWorkingDirectory(t *testing.T) {
 	// The local directory of a pane running ssh describes the wrong machine.
 	pane := sshPane("ssh", "prod-01")
 
-	if got := Default(
-		DefaultMaxLength,
-		DefaultBranchMaxLength,
-	).Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
+	if got := defaultChain().Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
 		t.Errorf("name = %q, want %q", got.Name, "ssh › prod-01")
 	}
 }
@@ -97,7 +94,7 @@ func TestAnUnreadableDestinationStillMarksTheTabRemote(t *testing.T) {
 	for _, argv := range [][]string{nil, {"ssh"}, {"ssh", "-p", "2222"}, {"ssh", "-"}} {
 		pane := sshPane(argv...)
 
-		got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+		got := defaultChain().Resolve(tabWithPane(pane))
 		if want := "ssh"; got.Name != want {
 			t.Errorf("argv %v → %q, want %q", argv, got.Name, want)
 		}
@@ -111,7 +108,7 @@ func TestAnUnreadableDestinationKeepsTheMarkUnderARemoteTitle(t *testing.T) {
 	pane := sshPane()
 	pane.TerminalTitle = "Restart the queue workers"
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := defaultChain().Resolve(tabWithPane(pane))
 	if want := "ssh › Restart the queue workers"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -127,7 +124,7 @@ func TestATunnelDoesNotMarkTheTabRemote(t *testing.T) {
 	} {
 		pane := sshPane(argv...)
 
-		got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+		got := defaultChain().Resolve(tabWithPane(pane))
 		if strings.Contains(strings.ToLower(got.Name), "ssh") {
 			t.Errorf("argv %v → %q, want nothing about ssh", argv, got.Name)
 		}
@@ -156,7 +153,7 @@ func TestAPaneWithoutSSHIsUnaffected(t *testing.T) {
 		},
 	}
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := defaultChain().Resolve(tabWithPane(pane))
 	if strings.Contains(strings.ToLower(got.Name), "ssh") {
 		t.Errorf("name = %q, want nothing about ssh", got.Name)
 	}
@@ -174,10 +171,7 @@ func TestSSHIsFoundAmongOtherProcesses(t *testing.T) {
 		},
 	}
 
-	if got := Default(
-		DefaultMaxLength,
-		DefaultBranchMaxLength,
-	).Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
+	if got := defaultChain().Resolve(tabWithPane(pane)); got.Name != "ssh › prod-01" {
 		t.Errorf("name = %q, want %q", got.Name, "ssh › prod-01")
 	}
 }
@@ -189,7 +183,7 @@ func TestTheMarkSurvivesARemoteTitle(t *testing.T) {
 	pane := sshPane("ssh", "prod-01")
 	pane.TerminalTitle = "Restart the queue workers"
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := defaultChain().Resolve(tabWithPane(pane))
 	if want := "ssh › prod-01 › Restart the queue workers"; got.Name != want {
 		t.Errorf("name = %q, want %q", got.Name, want)
 	}
@@ -199,7 +193,7 @@ func TestHostsFromArgvAreSanitized(t *testing.T) {
 	// argv is terminal-derived input like any other.
 	pane := sshPane("ssh", "root@prod\x1b[31m-01")
 
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(pane))
+	got := defaultChain().Resolve(tabWithPane(pane))
 	if strings.ContainsRune(got.Name, '\x1b') {
 		t.Errorf("name = %q, still carries an escape", got.Name)
 	}

--- a/internal/resolver/terminal_test.go
+++ b/internal/resolver/terminal_test.go
@@ -165,7 +165,9 @@ func TestEditorTitleKeepsTheFileAndDropsThePath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.title, func(t *testing.T) {
-			got := Default(wide, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+			got := Default(
+				Options{MaxLength: wide, BranchMax: DefaultBranchMaxLength},
+			).Resolve(tabWithPane(&state.PaneState{
 				Dir:           "/Users/dev/Work/herdr-auto-title",
 				TerminalTitle: tc.title,
 			}))

--- a/internal/resolver/terminal_test.go
+++ b/internal/resolver/terminal_test.go
@@ -19,7 +19,7 @@ func tabWithPane(pane *state.PaneState) state.TabState {
 }
 
 func TestTerminalTitleBeatsTheWorkingDirectory(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Fix OAuth redirect",
 	}))
@@ -41,10 +41,7 @@ func TestGenericTerminalTitleFallsThrough(t *testing.T) {
 	// Every one of these was observed on a live Herdr session.
 	for _, title := range []string{"zsh", "Claude Code", "node", "~", "~/W/dashboard", ""} {
 		t.Run(title, func(t *testing.T) {
-			got := Default(
-				DefaultMaxLength,
-				DefaultBranchMaxLength,
-			).Resolve(tabWithPane(&state.PaneState{
+			got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 				Dir:           "/Users/dev/work/dashboard",
 				TerminalTitle: title,
 			}))
@@ -61,7 +58,7 @@ func TestGenericTerminalTitleFallsThrough(t *testing.T) {
 }
 
 func TestTerminalTitleFallsBackToTheRawField(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		Dir:              "/Users/dev/work/dashboard",
 		TerminalTitleRaw: "\x1b[32m✳ Fix OAuth redirect\x1b[0m",
 	}))
@@ -73,7 +70,7 @@ func TestTerminalTitleFallsBackToTheRawField(t *testing.T) {
 }
 
 func TestStrippedTerminalTitleWinsOverTheRawOne(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		Dir:              "/Users/dev/work/dashboard",
 		TerminalTitle:    "Fix OAuth redirect",
 		TerminalTitleRaw: "◐ Fix OAuth redirect",
@@ -85,7 +82,7 @@ func TestStrippedTerminalTitleWinsOverTheRawOne(t *testing.T) {
 }
 
 func TestTerminalTitleIsSanitized(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "\x1b[31mFix OAuth\nredirect\x1b[0m\t",
 	}))
@@ -96,7 +93,7 @@ func TestTerminalTitleIsSanitized(t *testing.T) {
 }
 
 func TestLongTerminalTitleIsTruncatedAsAWhole(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: strings.Repeat("long ", 40),
 	}))
@@ -111,7 +108,7 @@ func TestLongTerminalTitleIsTruncatedAsAWhole(t *testing.T) {
 }
 
 func TestTerminalTitleWithoutAWorkingDirectory(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		TerminalTitle: "Fix OAuth redirect",
 	}))
 
@@ -122,7 +119,7 @@ func TestTerminalTitleWithoutAWorkingDirectory(t *testing.T) {
 }
 
 func TestTerminalTitleRepeatingTheContextIsDropped(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Dashboard",
 	}))
@@ -133,7 +130,7 @@ func TestTerminalTitleRepeatingTheContextIsDropped(t *testing.T) {
 }
 
 func TestTerminalTitleWithNothingElse(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		TerminalTitle: "zsh",
 	}))
 

--- a/internal/resolver/transcript_test.go
+++ b/internal/resolver/transcript_test.go
@@ -10,7 +10,7 @@ import (
 func TestATopicNamesATabTheTerminalTitleCannot(t *testing.T) {
 	// The session that motivated the source: the agent never titled its
 	// terminal, so without the transcript the tab is just `claude`.
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Claude Code",
 		Agent:         "claude",
@@ -33,7 +33,7 @@ func TestATopicNamesATabTheTerminalTitleCannot(t *testing.T) {
 
 func TestATerminalTitleOutranksTheTranscript(t *testing.T) {
 	// Both say what the session is about, and the agent says it sooner.
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		Dir:           "/Users/dev/work/dashboard",
 		TerminalTitle: "Fix OAuth redirect",
 		Agent:         "claude",
@@ -62,7 +62,7 @@ func TestATopicWithoutAnAgentIsIgnored(t *testing.T) {
 }
 
 func TestATopicThatNamesTheAgentFallsThrough(t *testing.T) {
-	got := Default(DefaultMaxLength, DefaultBranchMaxLength).Resolve(tabWithPane(&state.PaneState{
+	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
 		Dir:         "/Users/dev/work/dashboard",
 		Agent:       "claude",
 		AgentStatus: "idle",


### PR DESCRIPTION
## What this changes

An agent's name was joined to its work by the source that read it, which made
the name a fixed part of every agent tab and hid a repetition from the check
meant to catch it. Held apart until the title is assembled, the name becomes
something the title as a whole decides about: `HERDR_AUTO_TITLE_AGENT_NAME`
(default `true`, so nothing changes for anyone who does not set it) leaves it
out, and the repetition check now compares the activity as what it is, so a tab
whose agent titles its terminal after the project it was started in reads
`dashboard › claude` rather than `dashboard › claude › dashboard`.

Off means off, including where the name was the whole title: a pane whose agent
has reported nothing then reads as its directory, or as the generic fallback
where there is no directory either. Keeping the name for that one case would
make the setting a rule with an exception, and the exception would have to be
explained to everyone who set it. The name is still stripped from the *edges* of
an activity that carries it under either value, so an agent signing its terminal
title cannot smuggle it back in as text; nothing looks for the name elsewhere in
an activity, so a repository called `claude-mcp` keeps its title.

It is a switch rather than a format string. A template is the more general
answer and costs a grammar to parse, validate and document, plus a rule for the
separator a placeholder leaves dangling when it resolves to nothing — not
hypothetical, since an agent that never reports its work is ordinary and
`{agent}: {activity}` would leave `dashboard › claude:` in the tab bar. The
reasoning is recorded in `docs/architecture/title-resolution.md`.

Closes #46

## How it was checked

`make check` is green, and every commit builds and tests green on its own, since
this lands by rebase.

`TestAnAgentTabDoesNotRepeatItsOwnDirectory` was run against the code before the
change and fails there with `dashboard › claude › dashboard`, so it covers the
behaviour rather than restating it. The three cases from the issue have tests of
their own — work without the name, the name stripped out of the activity text,
and a silent agent falling back to its directory and then to `Shell` — plus the
workspace case, where a hidden name must not cost the tab its directory.

**Not run against a live session.** The change is deterministic and covered by
tests, but `make run` renames real tabs, so that is left to whoever merges.

## Notes for review

Two things worth a second look:

- **The join moved to the end of `Resolve`, after `withoutRepetition`.** That is
  what makes the repetition visible; it also means `Parts.Agent` survives
  `take`, which gained a branch, and `complete()` counts an agent's name as the
  activity half so the walk still stops where it did. The credit rules and the
  order sources are asked in are unchanged.
- **The name is dropped before the repetition check, not after.** Otherwise a
  tab in the workspace it is named after would lose its directory to a name it
  was never going to show, and read `Shell`.

`resolver.Options` states the setting as `HideAgentName` rather than
`ShowAgentName` so that the zero value keeps the name: `New` is exported and
builds a resolver without options, and a positive field would have made every
such resolver hide the name by accident. The single negation lives in
`cmd/herdr-auto-title/main.go`.

## Before merging

- [x] `make check` is green locally.
- [x] One logical change per commit, Conventional Commits, no co-author
      trailer. **PRs are rebased, never squashed or merged**, so the commit
      messages are what lands in the history and in the changelog.
- [x] Tests land with the behaviour they cover.
- [x] `CHANGELOG.md`, the tags and the version in `herdr-plugin.toml` are
      untouched — they belong to release-please.
- [x] Nothing was probed here; the socket API is untouched.
- [x] This pull request is one thing: the agent's name stops being part of the
      activity. The fix and the setting are the two things that follow from it,
      and neither is reachable without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8peBFpR48PPRgcv9Yjqwm
