### PR TITLE
docs: move the onboarding to AGENTS.md

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -26,7 +26,7 @@ else written into the repository, whatever language the request was made in.
   when that is not obvious. Never who calls it or when it runs — call sites
   move and the comment then lies.
 - Never record provenance: which probe, which issue, which measurement session,
-  which commit. That is what `git log`, `CLAUDE.md` and `docs/architecture`
+  which commit. That is what `git log`, `AGENTS.md` and `docs/architecture`
   are for. A *measured value* is worth stating; the session that measured it is
   not.
 - Never justify code somewhere else. A contract is stated where it is relied

--- a/.claude/skills/validate-agent-work/SKILL.md
+++ b/.claude/skills/validate-agent-work/SKILL.md
@@ -5,7 +5,7 @@ description: Use when finishing any change to this repository, or when the user 
 
 # Validate Agent Work
 
-The rules live in [CLAUDE.md](../../../CLAUDE.md) and
+The rules live in [AGENTS.md](../../../AGENTS.md) and
 [CONTRIBUTING.md](../../../CONTRIBUTING.md); this is the order to check them in
 before handing work back.
 
@@ -34,12 +34,12 @@ before handing work back.
    [`.claude/rules/comments.md`](../../rules/comments.md), over the comments
    this change added or touched.
 
-4. **Read the diff against the mandatory rules in CLAUDE.md** — the language,
+4. **Read the diff against the mandatory rules in AGENTS.md** — the language,
    commit, type, script and comment rules, and the "Working here" list. The
    linter checks none of them. Two need a search rather than a read: a field,
    method or constant added without a reader in the same change, and a probe
    whose finding has not reached `docs/architecture/herdr-socket-api.md`, which
-   is the record — `CLAUDE.md` takes it only if it misleads the code in
+   is the record — `AGENTS.md` takes it only if it misleads the code in
    silence.
 
 5. **Check nothing was left running:**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,6 @@ session, a pane arranged to reproduce the bug, a probe under `scripts/`.
 - [ ] Tests land with the behaviour they cover.
 - [ ] `CHANGELOG.md`, the tags and the version in `herdr-plugin.toml` are
       untouched — they belong to release-please.
-- [ ] A probe that taught something new is recorded in `CLAUDE.md` and in
+- [ ] A probe that taught something new is recorded in `AGENTS.md` and in
       `docs/architecture/herdr-socket-api.md`.
 - [ ] This pull request is one thing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,22 @@ Herdr Auto Title — a Herdr plugin, written in Go, that generates tab titles fr
 each tab's current context. Long-running process that polls the Herdr session,
 no LLM and no external service.
 
+## Repository layout
+
+```
+cmd/herdr-auto-title  the binary
+internal/app          the poll loop, configuration, failure handling
+internal/herdr        the socket client; herdrtest beside it is its stub
+internal/state        a session snapshot turned into what each tab is doing
+internal/resolver     that state turned into a title, one source at a time
+internal/claude       what a Claude Code session is about, from its transcript
+internal/git          what a repository has checked out, read from .git
+scripts/              the Python probes
+docs/architecture/    how the plugin works and why
+```
+
+Each package's doc comment says the rest.
+
 ## Language rule (mandatory)
 
 **Everything written into this repository is in English.** Code comments, commit
@@ -29,6 +45,22 @@ Scope is a package or area (`resolver`, `state`, `herdr`, `app`).
 - The body explains why, not what — the diff already says what.
 - One logical change per commit.
 - Never add a co-author trailer.
+
+## Branches and pull requests (mandatory)
+
+**Never commit to `main`.** Branch from it first, named `<type>/<kebab-summary>`
+with the types the commits use: `feat/optional-agent-name`,
+`docs/security-policy`, `chore/tighten-the-linter-set`.
+
+- **Pull requests are merged by rebase.** Merge commits and squashing are both
+  disabled, and each broke something: GitHub puts the conventional PR title into
+  a merge commit, so release-please counted every change twice, and a squash
+  collapses a pull request into one changelog line, losing the granularity that
+  "one logical change per commit" exists to produce.
+- **`CHANGELOG.md`, the tags and the version in `herdr-plugin.toml` belong to
+  release-please.** Never edit one by hand.
+- Keep a pull request to one thing. A refactor, a feature and a formatting sweep
+  are three pull requests.
 
 ## Type rule (mandatory)
 
@@ -151,6 +183,10 @@ are only the facts that would otherwise mislead the code in silence.
   pane — and how far each agent transcript has been read, because a transcript
   only grows and re-reading megabytes twice a second to find one new line would
   cost more than the rest of the loop together.
+- **The code is the source of truth, then `docs/architecture`, then a comment.**
+  A doc that contradicts the code is a bug in the doc, so fix it in the change
+  that found it rather than leaving the next reader to rediscover the same
+  thing.
 - Never pass terminal-derived values to a shell. Renames go over the socket API.
 - How the plugin works and why — the poll loop, title resolution, sanitizing
   untrusted values, manual rename protection — is in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,160 @@
+# AGENTS.md
+
+Herdr Auto Title — a Herdr plugin, written in Go, that generates tab titles from
+each tab's current context. Long-running process that polls the Herdr session,
+no LLM and no external service.
+
+## Language rule (mandatory)
+
+**Everything written into this repository is in English.** Code comments, commit
+messages, log and error messages, documentation, test names, ticket text — all
+English, with no exceptions. This holds regardless of the language the request
+was made in; only the conversation with the user follows the user's language.
+
+## Commit convention (mandatory)
+
+Commits follow [Conventional Commits](https://www.conventionalcommits.org):
+
+```
+<type>(<optional scope>): <subject>
+
+<optional body explaining why, wrapped at 72 columns>
+```
+
+Types in use: `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `chore`.
+Scope is a package or area (`resolver`, `state`, `herdr`, `app`).
+
+- Subject in the imperative mood, lowercase, no trailing period, ≤72 characters
+  ("add manual rename protection", not "Added manual rename protection.").
+- The body explains why, not what — the diff already says what.
+- One logical change per commit.
+- Never add a co-author trailer.
+
+## Type rule (mandatory)
+
+**A struct field exists only if code reads it.** Herdr's wire objects carry far
+more than Auto Title needs; mirroring them in full makes a type claim a
+dependency the code does not have, and every unread field is a promise to keep
+something working that nothing exercises. Add a field when the code that reads
+it lands in the same change, and delete a field the moment its last reader goes.
+The same holds for methods, constants and event payload types.
+
+## Script rule (mandatory)
+
+**Everything in `scripts/` is Python 3 and uses the standard library only.**
+Shell stays where it belongs: the one-line recipes in the Makefile. Anything
+with a loop, a branch or a data structure is a Python script.
+
+Two scripting languages in one repository means two sets of portability traps to
+remember — `stat -f` against `stat -c`, `trap` against signal handlers, quoting
+rules that differ per shell — for tooling nobody should have to think about.
+Python was already here for the probes, so it is what the rest is written in.
+
+Each script is executable, opens with `#!/usr/bin/env python3` and a module
+docstring saying what it is for, and takes no dependency outside the standard
+library.
+
+## Comment rule (mandatory)
+
+**A comment is at most three lines**, in every language in the repository, and
+it says what is surprising rather than what is visible. A decision that needs a
+paragraph goes in [docs/architecture](docs/architecture/), with one line in the
+code pointing at it.
+
+The rule in full, in Go terms and with worked examples of what to keep and what
+to delete, is in [.claude/rules/comments.md](.claude/rules/comments.md).
+
+## Commands
+
+```sh
+make            # list every target
+make check      # fmt + vet + lint + test   ← the gate before any commit
+make lint       # golangci-lint, pinned in tools/go.mod
+make test       # go test -race ./...
+make run        # build and run in the current Herdr session, DEBUG logging
+make dev        # the same, restarting on every source change
+make ps         # show running plugin/watcher instances
+make stop       # stop them
+make tabs       # current tab names
+make watch-tabs # ...refreshed every second
+make probe-snapshot # the session snapshot the plugin polls
+```
+
+`go test -race` is the gate, not `go test`: the poll loop and the change history
+it keeps are exercised concurrently in tests, and a future reset action will
+touch that history from outside the loop.
+
+The linter lives in `tools/go.mod`, a module of its own, so its dependency tree
+stays out of the plugin's: the main module keeps two dependencies and still
+builds on Go 1.24, which is what Herdr needs at install time. `errcheck` is off
+— the places that swallow an error say why they do.
+
+## Herdr socket API — the traps
+
+The originating specification is wrong on several protocol details. Everything
+here was verified against Herdr 0.8.2, protocol 20. **Probe before assuming
+anything** (`make probe-*`, `scripts/probe.py`).
+
+The facts in full — the measured costs, the field inventories, the event kinds,
+what every object carries — are in
+[docs/architecture/herdr-socket-api.md](docs/architecture/herdr-socket-api.md),
+which is the record. **A probe that teaches something new goes there.** Below
+are only the facts that would otherwise mislead the code in silence.
+
+- **One request per connection.** Herdr closes the connection after answering,
+  so every `Call` dials its own. That is why nothing here reconnects.
+- Auto Title uses three methods and no others: `session.snapshot`,
+  `pane.process_info` and `tab.rename`.
+- **Do not reintroduce an event subscription.** `events.subscribe` replays
+  about ten seconds of backlog per pane before anything live, with no cursor to
+  skip it, so a subscriber opens by reacting to a session that is gone. A
+  snapshot describes the present and costs less than the rename that follows it.
+- **No single field is a pane's directory.** `cwd` is the pane's own shell,
+  which a subshell leaves behind; `foreground_cwd` is the _deepest
+  descendant's_, so anything a program starts elsewhere takes the pane with it.
+  The directory is the foreground process's own `cwd`, which only
+  `pane.process_info` reports.
+- **A revision does not track what is running in a pane.** Measured, the
+  foreground processes changed nine times while the revision moved four. A
+  revision says the pane drew: a hint that a process read is due, never a
+  promise that one is not.
+- **`TabInfo.number` is not the label an unnamed tab carries.** Herdr labels an
+  unnamed tab with its _position_, which slides down when a tab to its left
+  closes, while `number` counts every tab the workspace has held and never
+  repeats. Reading `number` as the label once locked every tab made after start.
+- **An unnamed tab reports one of two labels**: its position, or the empty
+  string `tab.rename` stores verbatim when given one. Code reading the label to
+  mean "nobody named this" must accept either.
+- **A tab label is one line.** `tab.rename` takes a newline and stores it
+  verbatim, but the tab bar renders one row and Herdr exposes no height setting.
+- **`PaneInfo.title` is the agent's own title, and is null in practice.** Claude
+  Code reports its topic through `terminal_title_stripped` instead, and
+  `agent_session` stays null until that agent's integration is installed.
+- **A plugin the server starts inherits the server's environment**, not the
+  shell of whoever installed it, which is why `HERDR_AUTO_TITLE_*` settings
+  arrive through `config.env` (see
+  [docs/architecture/configuration.md](docs/architecture/configuration.md)).
+
+## Working here
+
+- Work from the issue the change belongs to; [CONTRIBUTING.md](CONTRIBUTING.md)
+  says when one is needed. If an issue turns out to rest on something false
+  about Herdr, correct it there rather than silently working around it.
+- Development runs against the user's real Herdr session, so **their tab names
+  change while you work**. Run the plugin in the foreground, never in the
+  background, and check `make ps` when something behaves oddly.
+- **Decide from freshly read state.** Every poll reads the session and throws
+  the result away again. What is carried between polls is only what a snapshot
+  cannot say: when each pane last changed, what it was running when it was last
+  asked — reused only until that pane's revision moves, and for no longer than
+  `processRefresh` either way, because a revision does not track what runs in a
+  pane — and how far each agent transcript has been read, because a transcript
+  only grows and re-reading megabytes twice a second to find one new line would
+  cost more than the rest of the loop together.
+- Never pass terminal-derived values to a shell. Renames go over the socket API.
+- How the plugin works and why — the poll loop, title resolution, sanitizing
+  untrusted values, manual rename protection — is in
+  [docs/architecture](docs/architecture/). Record a design decision there rather
+  than in the README, which is for people using the plugin.
+- The full workflow is in [docs/development.md](docs/development.md);
+  installation and configuration are in [README.md](README.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,9 @@ to Claude Code is below.
 
 ## Tooling
 
-- `validate-agent-work` — the skill to run after any change, before handing work
-  back. It runs `make check` and reads the diff against the mandatory rules.
+- `validate-agent-work` — run it after any change before handing work back, and
+  again before opening a pull request. It runs `make check` and reads the whole
+  branch against the mandatory rules in AGENTS.md, which no linter checks.
 - Delegate a broad multi-file search to the **Explore** agent and keep the
   conclusion, not the file dumps.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,160 +1,18 @@
 # CLAUDE.md
 
-Herdr Auto Title — a Herdr plugin, written in Go, that generates tab titles from
-each tab's current context. Long-running process that polls the Herdr session,
-no LLM and no external service.
+@AGENTS.md
 
-## Language rule (mandatory)
+The canonical onboarding is **AGENTS.md**, imported above. Only what is specific
+to Claude Code is below.
 
-**Everything written into this repository is in English.** Code comments, commit
-messages, log and error messages, documentation, test names, ticket text — all
-English, with no exceptions. This holds regardless of the language the request
-was made in; only the conversation with the user follows the user's language.
+## Tooling
 
-## Commit convention (mandatory)
+- `validate-agent-work` — the skill to run after any change, before handing work
+  back. It runs `make check` and reads the diff against the mandatory rules.
+- Delegate a broad multi-file search to the **Explore** agent and keep the
+  conclusion, not the file dumps.
 
-Commits follow [Conventional Commits](https://www.conventionalcommits.org):
+## MacOS edit note
 
-```
-<type>(<optional scope>): <subject>
-
-<optional body explaining why, wrapped at 72 columns>
-```
-
-Types in use: `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `chore`.
-Scope is a package or area (`resolver`, `state`, `herdr`, `app`).
-
-- Subject in the imperative mood, lowercase, no trailing period, ≤72 characters
-  ("add manual rename protection", not "Added manual rename protection.").
-- The body explains why, not what — the diff already says what.
-- One logical change per commit.
-- Never add a co-author trailer.
-
-## Type rule (mandatory)
-
-**A struct field exists only if code reads it.** Herdr's wire objects carry far
-more than Auto Title needs; mirroring them in full makes a type claim a
-dependency the code does not have, and every unread field is a promise to keep
-something working that nothing exercises. Add a field when the code that reads
-it lands in the same change, and delete a field the moment its last reader goes.
-The same holds for methods, constants and event payload types.
-
-## Script rule (mandatory)
-
-**Everything in `scripts/` is Python 3 and uses the standard library only.**
-Shell stays where it belongs: the one-line recipes in the Makefile. Anything
-with a loop, a branch or a data structure is a Python script.
-
-Two scripting languages in one repository means two sets of portability traps to
-remember — `stat -f` against `stat -c`, `trap` against signal handlers, quoting
-rules that differ per shell — for tooling nobody should have to think about.
-Python was already here for the probes, so it is what the rest is written in.
-
-Each script is executable, opens with `#!/usr/bin/env python3` and a module
-docstring saying what it is for, and takes no dependency outside the standard
-library.
-
-## Comment rule (mandatory)
-
-**A comment is at most three lines**, in every language in the repository, and
-it says what is surprising rather than what is visible. A decision that needs a
-paragraph goes in [docs/architecture](docs/architecture/), with one line in the
-code pointing at it.
-
-The rule in full, in Go terms and with worked examples of what to keep and what
-to delete, is in [.claude/rules/comments.md](.claude/rules/comments.md).
-
-## Commands
-
-```sh
-make            # list every target
-make check      # fmt + vet + lint + test   ← the gate before any commit
-make lint       # golangci-lint, pinned in tools/go.mod
-make test       # go test -race ./...
-make run        # build and run in the current Herdr session, DEBUG logging
-make dev        # the same, restarting on every source change
-make ps         # show running plugin/watcher instances
-make stop       # stop them
-make tabs       # current tab names
-make watch-tabs # ...refreshed every second
-make probe-snapshot # the session snapshot the plugin polls
-```
-
-`go test -race` is the gate, not `go test`: the poll loop and the change history
-it keeps are exercised concurrently in tests, and a future reset action will
-touch that history from outside the loop.
-
-The linter lives in `tools/go.mod`, a module of its own, so its dependency tree
-stays out of the plugin's: the main module keeps two dependencies and still
-builds on Go 1.24, which is what Herdr needs at install time. `errcheck` is off
-— the places that swallow an error say why they do.
-
-## Herdr socket API — the traps
-
-The originating specification is wrong on several protocol details. Everything
-here was verified against Herdr 0.8.2, protocol 20. **Probe before assuming
-anything** (`make probe-*`, `scripts/probe.py`).
-
-The facts in full — the measured costs, the field inventories, the event kinds,
-what every object carries — are in
-[docs/architecture/herdr-socket-api.md](docs/architecture/herdr-socket-api.md),
-which is the record. **A probe that teaches something new goes there.** Below
-are only the facts that would otherwise mislead the code in silence.
-
-- **One request per connection.** Herdr closes the connection after answering,
-  so every `Call` dials its own. That is why nothing here reconnects.
-- Auto Title uses three methods and no others: `session.snapshot`,
-  `pane.process_info` and `tab.rename`.
-- **Do not reintroduce an event subscription.** `events.subscribe` replays
-  about ten seconds of backlog per pane before anything live, with no cursor to
-  skip it, so a subscriber opens by reacting to a session that is gone. A
-  snapshot describes the present and costs less than the rename that follows it.
-- **No single field is a pane's directory.** `cwd` is the pane's own shell,
-  which a subshell leaves behind; `foreground_cwd` is the *deepest
-  descendant's*, so anything a program starts elsewhere takes the pane with it.
-  The directory is the foreground process's own `cwd`, which only
-  `pane.process_info` reports.
-- **A revision does not track what is running in a pane.** Measured, the
-  foreground processes changed nine times while the revision moved four. A
-  revision says the pane drew: a hint that a process read is due, never a
-  promise that one is not.
-- **`TabInfo.number` is not the label an unnamed tab carries.** Herdr labels an
-  unnamed tab with its *position*, which slides down when a tab to its left
-  closes, while `number` counts every tab the workspace has held and never
-  repeats. Reading `number` as the label once locked every tab made after start.
-- **An unnamed tab reports one of two labels**: its position, or the empty
-  string `tab.rename` stores verbatim when given one. Code reading the label to
-  mean "nobody named this" must accept either.
-- **A tab label is one line.** `tab.rename` takes a newline and stores it
-  verbatim, but the tab bar renders one row and Herdr exposes no height setting.
-- **`PaneInfo.title` is the agent's own title, and is null in practice.** Claude
-  Code reports its topic through `terminal_title_stripped` instead, and
-  `agent_session` stays null until that agent's integration is installed.
-- **A plugin the server starts inherits the server's environment**, not the
-  shell of whoever installed it, which is why `HERDR_AUTO_TITLE_*` settings
-  arrive through `config.env` (see
-  [docs/architecture/configuration.md](docs/architecture/configuration.md)).
-
-## Working here
-
-- Work from the issue the change belongs to; [CONTRIBUTING.md](CONTRIBUTING.md)
-  says when one is needed. If an issue turns out to rest on something false
-  about Herdr, correct it there rather than silently working around it.
-- Development runs against the user's real Herdr session, so **their tab names
-  change while you work**. Run the plugin in the foreground, never in the
-  background, and check `make ps` when something behaves oddly.
-- **Decide from freshly read state.** Every poll reads the session and throws
-  the result away again. What is carried between polls is only what a snapshot
-  cannot say: when each pane last changed, what it was running when it was last
-  asked — reused only until that pane's revision moves, and for no longer than
-  `processRefresh` either way, because a revision does not track what runs in a
-  pane — and how far each agent transcript has been read, because a transcript
-  only grows and re-reading megabytes twice a second to find one new line would
-  cost more than the rest of the loop together.
-- Never pass terminal-derived values to a shell. Renames go over the socket API.
-- How the plugin works and why — the poll loop, title resolution, sanitizing
-  untrusted values, manual rename protection — is in
-  [docs/architecture](docs/architecture/). Record a design decision there rather
-  than in the README, which is for people using the plugin.
-- The full workflow is in [docs/development.md](docs/development.md);
-  installation and configuration are in [README.md](README.md).
+BSD `sed -i` differs from GNU sed — prefer `perl -pi -e 's/old/new/g' file` for
+in-place substitution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ in [docs/architecture](docs/architecture/).
   `scripts/probe.py`): the originating specification is wrong in several
   places. Record what a probe teaches you in
   [docs/architecture/herdr-socket-api.md](docs/architecture/herdr-socket-api.md),
-  which is the record; `CLAUDE.md` keeps only the facts that mislead in silence.
+  which is the record; `AGENTS.md` keeps only the facts that mislead in silence.
 
 ## Pull requests
 

--- a/docs/architecture/herdr-socket-api.md
+++ b/docs/architecture/herdr-socket-api.md
@@ -14,7 +14,7 @@ originating specification is wrong on several protocol details, so every fact
 below was verified against a live **Herdr 0.8.2, protocol 20** install with
 `scripts/probe.py` or a direct socket request. **Probe before assuming anything
 not listed here**, and record what a probe teaches you in this file, which is
-the record. `CLAUDE.md` carries the short list of facts that would otherwise
+the record. `AGENTS.md` carries the short list of facts that would otherwise
 mislead the code in silence; a new one goes there too.
 
 ## Transport

--- a/docs/development.md
+++ b/docs/development.md
@@ -99,7 +99,7 @@ per active pane before anything live.
 
 The current list of verified facts lives in
 [architecture/herdr-socket-api.md](architecture/herdr-socket-api.md), with a
-summary of it — and the measurements behind the polling decision — in CLAUDE.md.
+summary of it — and the measurements behind the polling decision — in AGENTS.md.
 When a probe teaches you something new, add it to both.
 
 ## Registering it with Herdr
@@ -195,7 +195,7 @@ and logged at DEBUG; if you see it as a warning, something regressed.
 **Do not reach for the event stream.** It looks like the obvious mechanism and
 it is a trap: subscribing replays about ten seconds of history per active pane
 before anything live, and there is no cursor to skip it. The measurements are in
-CLAUDE.md. If you think you have found a way around it, measure and record the
+AGENTS.md. If you think you have found a way around it, measure and record the
 result there before changing the design back.
 
 **`go test -race` is the gate, not `go test`.** The change history is shared


### PR DESCRIPTION
## What this changes

The rules in this repository are not Claude Code's, and a file named for
one tool reads as if they were. `AGENTS.md` is the file every agent looks
for, so the onboarding lives there now and `CLAUDE.md` imports it, keeping
only the two things that really are Claude-Code-specific. Every file that
pointed at `CLAUDE.md` for a rule points at `AGENTS.md` instead — the
`validate-agent-work` skill included, which reads the diff against those
rules and would otherwise have sent a reader to a file that no longer held
them.

The second commit adds three things an agent had to reconstruct or could
not know at all: where the packages live, which was only ever in their doc
comments; how a branch is named and that pull requests merge by rebase,
which lived only in `CONTRIBUTING.md`, a file nobody asked to commit reads;
and the source of truth order, implied throughout and stated nowhere.

No probe, and no change to any Herdr API fact.

## How it was checked

`make check` green on both commits. Every `CLAUDE.md` reference in the
repository was enumerated before and after, and the import was confirmed to
resolve by reading the loaded context. The invented tooling section this
replaces named eight skills and two agents that do not exist here — only
`validate-agent-work` does.

## Before merging

- [x] `make check` is green locally.
- [x] One logical change per commit, Conventional Commits, no co-author
      trailer. **PRs are rebased, never squashed or merged**, so the commit
      messages are what lands in the history and in the changelog.
- [x] Tests land with the behaviour they cover.
- [x] `CHANGELOG.md`, the tags and the version in `herdr-plugin.toml` are
      untouched — they belong to release-please.
- [x] A probe that taught something new is recorded in `AGENTS.md` and in
      `docs/architecture/herdr-socket-api.md`.
- [x] This pull request is one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WQ7NeTKYtgr327nsF5Evf
