### PR TITLE
docs(resolver): fix comments against the comment rule

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -90,8 +90,7 @@ type Source interface {
 	// what it reads, not for what it happened to find this time.
 	Confidence() int
 	// Resolve reports the parts this source derives, or false when the pane
-	// carries nothing this source recognizes. The pane is never nil: a tab
-	// with no panes is declined by collect, before any source is asked.
+	// carries nothing this source recognizes. The pane is never nil.
 	Resolve(pane *state.PaneState) (Parts, bool)
 }
 

--- a/internal/resolver/ssh.go
+++ b/internal/resolver/ssh.go
@@ -8,8 +8,8 @@ import (
 
 const (
 	// sshKind marks a session as remote: `ssh › prod-01`, or `ssh` alone when
-	// the host cannot be read. It goes in the context, never the activity,
-	// which the terminal title would outrank — see docs/architecture.
+	// the host cannot be read. It goes in the context, never the activity the
+	// terminal title outranks — see docs/architecture/title-resolution.md.
 	sshKind = "ssh"
 )
 

--- a/internal/resolver/ssh_test.go
+++ b/internal/resolver/ssh_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
 
-// sshPane builds a pane running the given ssh command line, beside the shell
-// that started it — which is how Herdr reports a pane's processes.
 // paneCWD is the directory every ssh pane in these tests sits in.
 const paneCWD = "/Users/dev/work/dashboard"
 
+// sshPane builds a pane running the given ssh command line, beside the shell
+// that started it — which is how Herdr reports a pane's processes.
 func sshPane(argv ...string) *state.PaneState {
 	return &state.PaneState{
 		Dir: paneCWD,
@@ -23,8 +23,8 @@ func sshPane(argv ...string) *state.PaneState {
 }
 
 func TestTheHostBecomesTheContext(t *testing.T) {
-	// Every form the ticket lists, and the flags that must not be mistaken for
-	// a destination.
+	// Every destination form ssh accepts, and the flags that must not be
+	// mistaken for one.
 	cases := map[string]string{
 		"ssh prod-01":                             "prod-01",
 		"ssh root@prod-01":                        "prod-01",


### PR DESCRIPTION
## What this changes

A pass over every comment in the repository against
[.claude/rules/comments.md](.claude/rules/comments.md) turned up four
places where the code says something the rule forbids, all of them in
`resolver`. A doc comment had been welded onto the constant declared
above it, so `sshPane` carried no comment at all and `paneCWD`'s started
with another name. `Source.Resolve` named `collect` as the caller that
guarantees its pane is non-nil — the contract belongs on the interface,
the call site does not, because call sites move and the comment then
lies. `sshKind` pointed at the `docs/architecture` directory rather than
at the page holding its paragraph, the only one of the repository's
nineteen pointers that did not name a file. And a test comment recorded
the ticket its cases came from, which is what `git log` is for.

Comments only: no line of code changed, and the rest of the repository
came through the pass clean — no block over three lines, one package
comment per package, every other docs pointer resolving.

## How it was checked

`make check`, and a re-read of the four comments against the rule: each
is at most three lines, starts with the name it documents, records no
provenance and names no caller. Nothing to see in a live session — the
plugin behaves identically.

## Before merging

- [x] `make check` is green locally.
- [x] One logical change per commit, Conventional Commits, no co-author
      trailer. **PRs are rebased, never squashed or merged**, so the commit
      messages are what lands in the history and in the changelog.
- [x] Tests land with the behaviour they cover — no behaviour changed here.
- [x] `CHANGELOG.md`, the tags and the version in `herdr-plugin.toml` are
      untouched — they belong to release-please.
- [x] A probe that taught something new is recorded in `AGENTS.md` and in
      `docs/architecture/herdr-socket-api.md` — no probe was run.
- [x] This pull request is one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GiwNEJ6X9MhqYE8X5bgGQM
