### PR TITLE
refactor(app): give a pane's reads a module of their own

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ no LLM and no external service.
 
 ```
 cmd/herdr-auto-title  the binary
-internal/app          the poll loop, configuration, failure handling
+internal/app          the poll loop and the reads it spends, configuration
 internal/herdr        the socket client; herdrtest beside it is its stub
 internal/state        a session snapshot turned into what each tab is doing
 internal/resolver     that state turned into a title, one source at a time

--- a/docs/architecture/poll-loop.md
+++ b/docs/architecture/poll-loop.md
@@ -116,8 +116,9 @@ changes name at most once per poll however fast its pane is churning, so
 4. `tabsIn` — assemble tabs with their panes from the snapshot alone. Nothing
    is read here: assembly is what says which pane will be asked about.
 5. Per tab: skip it if locked, otherwise read the one pane the tab is named
-   from (`readInto`), resolve a title, check whether the label moved under us,
-   and rename when the result differs from the label the tab already carries.
+   from (`paneReads.fill`), resolve a title, check whether the label moved
+   under us, and rename when the result differs from the label the tab already
+   carries.
 
 **Only the pane that names its tab is read**, and only while its tab is
 nobody's. `pane.process_info` is asked about the panes that moved since they

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/kryptamine/herdr-auto-title/internal/claude"
 	"github.com/kryptamine/herdr-auto-title/internal/herdr"
 	"github.com/kryptamine/herdr-auto-title/internal/resolver"
 	"github.com/kryptamine/herdr-auto-title/internal/state"
@@ -23,9 +22,7 @@ type App struct {
 	titles  resolver.TitleResolver
 	changes *state.Changes
 	manual  *state.Manual
-	// topics reads what an agent's own session is about. It keeps its place in
-	// each transcript, so a poll reads only what was appended since the last.
-	topics *claude.Reader
+	reads   *paneReader
 	// failures is the run of polls that have failed in a row, which decides
 	// how loudly the next one is reported.
 	failures failureLog
@@ -34,13 +31,15 @@ type App struct {
 // New builds the application. The client belongs to Run rather than to the
 // App, so one App can be driven by any connection.
 func New(cfg Config, log *slog.Logger, titles resolver.TitleResolver) *App {
+	changes := state.NewChanges()
+
 	return &App{
 		cfg:     cfg,
 		log:     log,
 		titles:  titles,
-		changes: state.NewChanges(),
+		changes: changes,
 		manual:  state.LoadManual(cfg.ManualPath),
-		topics:  claude.NewReader(),
+		reads:   newPaneReader(cfg, log, changes),
 	}
 }
 
@@ -97,14 +96,12 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 	}
 
 	a.changes.Observe(snapshot.Panes)
-	a.topics.Retain(sessionsIn(snapshot.Panes))
 	// Taken from the snapshot rather than from the tabs below, because this is
 	// what decides which of them are locked, and a locked tab is never read.
 	a.manual.Retain(labelsIn(snapshot.Tabs))
 
 	tabs := a.tabsIn(snapshot)
-	// One memo for this poll, because the tabs of a project share a directory.
-	checkouts := make(checkoutMemo, len(tabs))
+	reads := a.reads.forPoll(snapshot.Panes)
 
 	for _, tab := range tabs {
 		if ctx.Err() != nil {
@@ -118,7 +115,7 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 		// Read here rather than during assembly: the reads are what a poll
 		// spends, and only a tab that will be renamed is worth them. The
 		// resolver picks the same pane, because the choice is made from state.
-		a.readInto(ctx, client, state.SelectContextPane(tab), checkouts)
+		reads.fill(ctx, client, state.SelectContextPane(tab))
 
 		decision := a.titles.Resolve(tab)
 		if a.manual.Observe(state.SightingFrom(tab, decision.Name)) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -17,12 +17,14 @@ const pollTimeout = 5 * time.Second
 
 // App is one run of the Auto Title loop.
 type App struct {
-	cfg     Config
-	log     *slog.Logger
-	titles  resolver.TitleResolver
-	changes *state.Changes
-	manual  *state.Manual
-	reads   *paneReader
+	// pollEvery is how often the session is read, which is all the loop itself
+	// decides anything by.
+	pollEvery time.Duration
+	log       *slog.Logger
+	titles    resolver.TitleResolver
+	changes   *state.Changes
+	manual    *state.Manual
+	reads     *paneReader
 	// failures is the run of polls that have failed in a row, which decides
 	// how loudly the next one is reported.
 	failures failureLog
@@ -34,12 +36,12 @@ func New(cfg Config, log *slog.Logger, titles resolver.TitleResolver) *App {
 	changes := state.NewChanges()
 
 	return &App{
-		cfg:     cfg,
-		log:     log,
-		titles:  titles,
-		changes: changes,
-		manual:  state.LoadManual(cfg.ManualPath),
-		reads:   newPaneReader(cfg, log, changes),
+		pollEvery: cfg.Poll,
+		log:       log,
+		titles:    titles,
+		changes:   changes,
+		manual:    state.LoadManual(cfg.ManualPath),
+		reads:     newPaneReader(cfg, log, changes),
 	}
 }
 
@@ -50,7 +52,7 @@ func (a *App) Run(ctx context.Context, client herdr.Client) {
 	// Name what already exists before waiting for the first tick.
 	a.poll(ctx, client)
 
-	ticker := time.NewTicker(a.cfg.Poll)
+	ticker := time.NewTicker(a.pollEvery)
 	defer ticker.Stop()
 
 	for {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kryptamine/herdr-auto-title/internal/herdr"
 	"github.com/kryptamine/herdr-auto-title/internal/herdr/herdrtest"
 	"github.com/kryptamine/herdr-auto-title/internal/resolver"
+	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
 
 const testPoll = 10 * time.Millisecond
@@ -746,7 +747,14 @@ func TestALockedTabIsNotReadEither(t *testing.T) {
 // `main`, so passing that as the branch is how a tab on the trunk is written.
 func repoAt(t *testing.T, branch string) string {
 	t.Helper()
-	root := t.TempDir()
+	return repoIn(t, t.TempDir(), branch)
+}
+
+// repoIn builds one in a directory that already exists, so a test can watch a
+// repository appear under a pane that was read before it did.
+func repoIn(t *testing.T, root, branch string) string {
+	t.Helper()
+
 	gitDir := filepath.Join(root, ".git")
 
 	remote := filepath.Join(gitDir, "refs", "remotes", "origin")
@@ -763,6 +771,12 @@ func repoAt(t *testing.T, branch string) string {
 	write(filepath.Join(remote, "HEAD"), "ref: refs/remotes/origin/main\n")
 
 	return root
+}
+
+// paneAt is a pane sitting in dir and running nothing Herdr will answer for,
+// so that a read of it finds only what the directory holds.
+func paneAt(paneID, dir string) *state.PaneState {
+	return state.PaneFrom(herdr.PaneInfo{PaneID: paneID, TabID: "wE:t1", CWD: dir}, time.Time{})
 }
 
 func TestAPollNamesATabAfterItsBranch(t *testing.T) {
@@ -806,15 +820,19 @@ func TestCheckingOutABranchRetitlesTheTab(t *testing.T) {
 
 func TestARepositoryIsWalkedOncePerPoll(t *testing.T) {
 	// Every tab of a project reads the same directory, and the walk up to it is
-	// the read. Rewriting HEAD between the two calls is how the test sees that
-	// the second one never reached the disk.
+	// the read. Rewriting HEAD between two panes of one poll is how the test
+	// sees that the second one never reached the disk.
 	repo := repoAt(t, "feat/oauth")
 	app := New(testConfig(), discardLogger(), testResolver(t))
-	ctx := context.Background()
+	ctx, client := context.Background(), herdrtest.New(nil, nil)
 
-	poll := make(checkoutMemo)
-	if got := app.checkoutIn(ctx, repo, poll).Branch; got != "feat/oauth" {
-		t.Fatalf("branch = %q, want feat/oauth", got)
+	reads := app.reads.forPoll(nil)
+
+	first := paneAt("wE:p1", repo)
+	reads.fill(ctx, client, first)
+
+	if first.Git.Branch != "feat/oauth" {
+		t.Fatalf("branch = %q, want feat/oauth", first.Git.Branch)
 	}
 
 	head := filepath.Join(repo, ".git", "HEAD")
@@ -822,12 +840,18 @@ func TestARepositoryIsWalkedOncePerPoll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := app.checkoutIn(ctx, repo, poll).Branch; got != "feat/oauth" {
-		t.Errorf("branch = %q, want the answer this poll already had", got)
+	second := paneAt("wE:p2", repo)
+	reads.fill(ctx, client, second)
+
+	if second.Git.Branch != "feat/oauth" {
+		t.Errorf("branch = %q, want the answer this poll already had", second.Git.Branch)
 	}
 
-	if got := app.checkoutIn(ctx, repo, make(checkoutMemo)).Branch; got != "fix/token" {
-		t.Errorf("branch = %q, want the next poll to read HEAD again", got)
+	next := paneAt("wE:p3", repo)
+	app.reads.forPoll(nil).fill(ctx, client, next)
+
+	if next.Git.Branch != "fix/token" {
+		t.Errorf("branch = %q, want the next poll to read HEAD again", next.Git.Branch)
 	}
 }
 
@@ -836,14 +860,26 @@ func TestADirectoryHoldingNoRepositoryIsRememberedToo(t *testing.T) {
 	// as finding one, so a pane outside a checkout must not repeat it per tab.
 	dir := t.TempDir()
 	app := New(testConfig(), discardLogger(), testResolver(t))
+	ctx, client := context.Background(), herdrtest.New(nil, nil)
 
-	poll := make(checkoutMemo)
-	if got := app.checkoutIn(context.Background(), dir, poll); got != (git.Checkout{}) {
-		t.Fatalf("checkout = %+v, want nothing found", got)
+	reads := app.reads.forPoll(nil)
+
+	first := paneAt("wE:p1", dir)
+	reads.fill(ctx, client, first)
+
+	if first.Git != (git.Checkout{}) {
+		t.Fatalf("checkout = %+v, want nothing found", first.Git)
 	}
 
-	if _, remembered := poll[dir]; !remembered {
-		t.Error("a directory holding no repository was not remembered")
+	// A repository under the same directory is what a second walk would find,
+	// and a poll that remembered the miss makes none.
+	repoIn(t, dir, "feat/oauth")
+
+	second := paneAt("wE:p2", dir)
+	reads.fill(ctx, client, second)
+
+	if second.Git != (git.Checkout{}) {
+		t.Errorf("checkout = %+v, want the miss this poll already had", second.Git)
 	}
 }
 
@@ -856,12 +892,11 @@ func TestBranchesSwitchedOffAreNotRead(t *testing.T) {
 	cfg.BranchMax = 0
 	app := New(cfg, discardLogger(), testResolver(t))
 
-	if checkout := app.checkoutIn(
-		context.Background(),
-		repo,
-		make(checkoutMemo),
-	); checkout != (git.Checkout{}) {
-		t.Errorf("checkout = %+v, want nothing read", checkout)
+	pane := paneAt("wE:p1", repo)
+	app.reads.forPoll(nil).fill(context.Background(), herdrtest.New(nil, nil), pane)
+
+	if pane.Git != (git.Checkout{}) {
+		t.Errorf("checkout = %+v, want nothing read", pane.Git)
 	}
 }
 
@@ -956,7 +991,7 @@ func TestAPollPastItsDeadlineStopsReadingTheFilesystem(t *testing.T) {
 	// The live read first, so a checkout that never resolves cannot make the
 	// spent one below look like the guard working.
 	live := app.tabsIn(snapshot)
-	app.readInto(context.Background(), client, live[0].Panes[0], make(checkoutMemo))
+	app.reads.forPoll(nil).fill(context.Background(), client, live[0].Panes[0])
 
 	if got := live[0].Panes[0].Git.Branch; got != "feat/oauth" {
 		t.Fatalf("branch = %q with time left, so this test proves nothing", got)
@@ -966,7 +1001,7 @@ func TestAPollPastItsDeadlineStopsReadingTheFilesystem(t *testing.T) {
 	cancel()
 
 	tabs := app.tabsIn(snapshot)
-	app.readInto(spent, client, tabs[0].Panes[0], make(checkoutMemo))
+	app.reads.forPoll(nil).fill(spent, client, tabs[0].Panes[0])
 
 	if got := tabs[0].Panes[0].Git; got != (git.Checkout{}) {
 		t.Errorf("checkout = %+v, want a poll past its deadline to read nothing", got)
@@ -998,7 +1033,7 @@ func TestAPaneIsReadFromItsForegroundProcessesDirectory(t *testing.T) {
 	})
 
 	read := tabs[0].Panes[0]
-	app.readInto(context.Background(), client, read, make(checkoutMemo))
+	app.reads.forPoll(nil).fill(context.Background(), client, read)
 
 	if read.Dir != repo {
 		t.Errorf("dir = %q, want the agent's own %q", read.Dir, repo)

--- a/internal/app/reads.go
+++ b/internal/app/reads.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/kryptamine/herdr-auto-title/internal/claude"
 	"github.com/kryptamine/herdr-auto-title/internal/git"
@@ -11,7 +12,7 @@ import (
 
 // tabsIn assembles the snapshot's tabs with their panes, and reads nothing:
 // what a pane is running, has checked out and is talking about each costs a
-// request or a file, and readInto spends that on the panes that earn it.
+// request or a file, and paneReads spends that on the panes that earn it.
 func (a *App) tabsIn(snapshot herdr.Snapshot) []state.TabState {
 	workspaces := make(map[string]string, len(snapshot.Workspaces))
 
@@ -50,63 +51,99 @@ func (a *App) tabsIn(snapshot herdr.Snapshot) []state.TabState {
 	return tabs
 }
 
-// readInto fills in what the snapshot could not say about the one pane a tab
-// is named from. The other panes of that tab keep what the snapshot said,
-// because nothing reads any more of them.
-func (a *App) readInto(
-	ctx context.Context,
-	client herdr.Client,
-	pane *state.PaneState,
-	checkouts checkoutMemo,
-) {
+// paneReader reads what a snapshot cannot say about a pane. It outlives a poll
+// because what it remembers does: what each pane was last seen running, and how
+// far each agent's transcript has been read.
+type paneReader struct {
+	changes *state.Changes
+	topics  *claude.Reader
+	log     *slog.Logger
+	// branchMax and readTranscripts are the settings that turn a read off
+	// rather than shape it, so they are tested before one is started.
+	branchMax       int
+	readTranscripts bool
+}
+
+func newPaneReader(cfg Config, log *slog.Logger, changes *state.Changes) *paneReader {
+	return &paneReader{
+		changes:         changes,
+		topics:          claude.NewReader(),
+		log:             log,
+		branchMax:       cfg.BranchMax,
+		readTranscripts: cfg.ReadTranscripts,
+	}
+}
+
+// forPoll opens the reads of one poll, forgetting the agent sessions the
+// snapshot no longer holds. The panes come from the snapshot rather than from
+// the tabs, because a session is gone once no pane holds it.
+func (r *paneReader) forPoll(panes []herdr.PaneInfo) *paneReads {
+	r.topics.Retain(sessionsIn(panes))
+
+	return &paneReads{reader: r, checkouts: make(checkoutMemo)}
+}
+
+// paneReads are one poll's reads. It is a thing of its own so that what it
+// memoizes cannot outlast the poll that filled it.
+type paneReads struct {
+	reader    *paneReader
+	checkouts checkoutMemo
+}
+
+// fill supplies what the snapshot could not say about the one pane a tab is
+// named from. The other panes of that tab keep what the snapshot said, because
+// nothing reads any more of them.
+func (p *paneReads) fill(ctx context.Context, client herdr.Client, pane *state.PaneState) {
 	if pane == nil {
 		return
 	}
 
-	processes := a.processesIn(ctx, client, pane.ID)
+	processes := p.processes(ctx, client, pane.ID)
 	dir := state.PaneDir(processes, pane.Dir)
 
-	pane.Read(state.Reads{
-		Processes: processes,
-		Dir:       dir,
-		Git:       a.checkoutIn(ctx, dir, checkouts),
-		Topic:     a.topicIn(ctx, pane, dir),
-	})
+	pane.Processes = state.ProcessesFrom(processes)
+	pane.Dir = dir
+	pane.Git = p.checkout(ctx, dir)
+	pane.AgentTopic = p.topic(ctx, pane, dir)
 }
 
-// processesIn reports what a pane is running, reusing the last read while the
+// processes reports what a pane is running, reusing the last read while the
 // pane's revision holds and that read is recent. Neither test is exact, which
 // is why there are two — see docs/architecture/poll-loop.md.
-func (a *App) processesIn(
+func (p *paneReads) processes(
 	ctx context.Context,
 	client herdr.Client,
 	paneID string,
 ) []herdr.PaneProcessInfoProcess {
-	if processes, read := a.changes.Processes(paneID); read {
+	if processes, read := p.reader.changes.Processes(paneID); read {
 		return processes
 	}
 
 	processes, err := herdr.PaneProcesses(ctx, client, paneID)
 	if err != nil {
 		if herdr.ErrorCode(err) != herdr.CodePaneNotFound && ctx.Err() == nil {
-			a.log.Debug("could not read what a pane is running", "pane_id", paneID, "error", err)
+			p.reader.log.Debug(
+				"could not read what a pane is running",
+				"pane_id", paneID,
+				"error", err,
+			)
 		}
 
 		return nil
 	}
 
-	a.changes.Ran(paneID, processes)
+	p.reader.changes.Ran(paneID, processes)
 
 	return processes
 }
 
-// checkoutIn reports what the repository holding the pane has checked out.
+// checkout reports what the repository holding the pane has checked out.
 // Nothing is remembered past the poll, and why not is in
 // docs/architecture/title-resolution.md.
-func (a *App) checkoutIn(ctx context.Context, dir string, checkouts checkoutMemo) git.Checkout {
+func (p *paneReads) checkout(ctx context.Context, dir string) git.Checkout {
 	// A branch width of zero is how branches are turned off, and a read whose
 	// answer is thrown away is still a read on every pane twice a second.
-	if a.cfg.BranchMax <= 0 {
+	if p.reader.branchMax <= 0 {
 		return git.Checkout{}
 	}
 
@@ -114,7 +151,7 @@ func (a *App) checkoutIn(ctx context.Context, dir string, checkouts checkoutMemo
 		return git.Checkout{}
 	}
 
-	return checkouts.read(dir)
+	return p.checkouts.read(dir)
 }
 
 // checkoutMemo holds the checkouts one poll has read. The tabs of a project
@@ -136,11 +173,11 @@ func (m checkoutMemo) read(dir string) git.Checkout {
 	return checkout
 }
 
-// topicIn reports what the session the pane's agent is holding says it is
-// about. Only Claude Code's transcripts are understood, and only Herdr's
-// integration hook says which session a pane holds.
-func (a *App) topicIn(ctx context.Context, pane *state.PaneState, dir string) string {
-	if !a.cfg.ReadTranscripts || spentPoll(ctx) {
+// topic reports what the session the pane's agent is holding says it is about.
+// Only Claude Code's transcripts are understood, and only Herdr's integration
+// hook says which session a pane holds.
+func (p *paneReads) topic(ctx context.Context, pane *state.PaneState, dir string) string {
+	if !p.reader.readTranscripts || spentPoll(ctx) {
 		return ""
 	}
 
@@ -149,7 +186,7 @@ func (a *App) topicIn(ctx context.Context, pane *state.PaneState, dir string) st
 		return ""
 	}
 
-	return a.topics.Topic(sessionID, dir).Text()
+	return p.reader.topics.Topic(sessionID, dir).Text()
 }
 
 // spentPoll reports that this poll is past its deadline. The reads it guards

--- a/internal/state/tab.go
+++ b/internal/state/tab.go
@@ -59,19 +59,6 @@ type Process struct {
 	Args []string
 }
 
-// Reads is what a poll learned about a pane that its snapshot entry does not
-// carry: each field costs a request or a file of its own, which is why only
-// the pane that names its tab is read.
-type Reads struct {
-	Processes []herdr.PaneProcessInfoProcess
-	// Dir is the directory the pane speaks for, which only what it is running
-	// says exactly — see PaneDir.
-	Dir string
-	Git git.Checkout
-	// Topic is what the agent's own session says it is about.
-	Topic string
-}
-
 // PaneDir is the directory a pane speaks for, settled by what it is running:
 // the list is deepest first, so the pane's own foreground process is last and
 // the directory it is in is the pane's. A read saying nothing leaves guess.
@@ -113,17 +100,10 @@ func PaneFrom(info herdr.PaneInfo, changedAt time.Time) *PaneState {
 	}
 }
 
-// Read fills in what a snapshot does not carry. It is a step of its own so a
-// poll can leave it out: a tab is named from one pane, and every read behind
-// this costs a request or a file — see docs/architecture/poll-loop.md.
-func (p *PaneState) Read(reads Reads) {
-	p.Processes = processesFrom(reads.Processes)
-	p.Dir = reads.Dir
-	p.Git = reads.Git
-	p.AgentTopic = reads.Topic
-}
-
-func processesFrom(processes []herdr.PaneProcessInfoProcess) []Process {
+// ProcessesFrom is a process read as a pane holds it: the name and the whole
+// argument vector. The directory a process is in is read by PaneDir and not
+// carried.
+func ProcessesFrom(processes []herdr.PaneProcessInfoProcess) []Process {
 	if len(processes) == 0 {
 		return nil
 	}

--- a/internal/state/tab_test.go
+++ b/internal/state/tab_test.go
@@ -76,7 +76,7 @@ func TestPaneFromReadsAgentContext(t *testing.T) {
 		DisplayAgent:          "Claude Code",
 		AgentStatus:           herdr.AgentStatusWorking,
 	}, stamp)
-	pane.Read(Reads{Dir: pane.Dir, Topic: "Rework the poll loop"})
+	pane.AgentTopic = "Rework the poll loop"
 
 	switch {
 	case pane.TerminalTitle != "Claude Code":
@@ -235,7 +235,8 @@ func TestPaneDirTakesTheForegroundProcessesOwnDirectory(t *testing.T) {
 		PaneID: "wE:p1", Agent: "claude",
 		CWD: "/work/dashboard", ForegroundCWD: "/opt/gimp-mcp",
 	}, time.Time{})
-	pane.Read(Reads{Processes: processes, Dir: PaneDir(processes, pane.Dir)})
+	pane.Dir = PaneDir(processes, pane.Dir)
+	pane.Processes = ProcessesFrom(processes)
 
 	if pane.Dir != "/work/self-care-portal" {
 		t.Errorf("dir = %q, want the foreground process's own", pane.Dir)


### PR DESCRIPTION
## What this changes

"What one pane costs to read, and when that read is skipped" was spread over
four methods on `App`, a `checkoutMemo` the caller had to make and pass, a
`spentPoll` helper, and three exported names in `state` — nine names of interface
over about a hundred lines, which is a surface nearly matching what sits behind
it. `App` carried `cfg`, `changes` and `topics` only to feed them.

It is now `paneReader.forPoll(panes)` and `paneReads.fill(ctx, client, pane)`.
Two types rather than one, because the memo has to die with the poll that filled
it and a type can say that where a convention cannot: the reader outlives a poll
because what it remembers does — the last process read of each pane, how far each
transcript has been read — and the reads of one poll own the memo and go with it.
`forPoll` also does the transcript retention, which is exactly when it should
happen. The client is still passed rather than held, because an `App` holds none
either.

`state.Reads` carried four values across one call and `PaneState.Read` assigned
them; both were pass-throughs and are gone. `state.PaneDir` stays — it states
that the process list is deepest first and the pane's own process last, which is
a fact about `state`'s data rather than about fetching it — and the conversion
behind `Read` stays beside it as `state.ProcessesFrom`, since `PaneState.Processes`
is `state`'s own type. Net: nine names down to three, and `App` drops `topics` and
narrows `cfg Config` to the one interval the loop reads.

Closes #52

## How it was checked

`make check` is green. Beyond it:

- The three checkout tests reached past the interface into `checkoutIn` with a
  memo of their own. They now go through `fill`, which is the only way to see
  that the memo really lives in one poll's object rather than in the caller's
  hand. "A directory holding no repository is remembered too" is the sharper for
  it: it fills a pane, *creates* a `.git` under the same directory, fills a
  second pane and requires the repository still not to be seen — where before it
  only asserted on the memo map's contents.
- A mutation to confirm that: making `checkoutMemo.read` walk every time fails
  both, with `branch = "fix/token", want the answer this poll already had` and
  `checkout = {Branch:feat/oauth …}, want the miss this poll already had`.

A comment pass over the branch caught three of its own comments: `paneAt` named
its call sites, `fill fills` restated itself, and `ProcessesFrom` claimed the
name and argv were "all a title is derived from" when a process's directory is
read too, by `PaneDir`. All three are fixed in the commit that introduced them.

`docs/architecture/poll-loop.md` named `readInto` in the per-tab step and is
corrected. `docs/architecture/title-resolution.md` names `checkoutMemo` in
`internal/app/reads.go`, which stays true. The package map in `AGENTS.md` gains
the reads; "failure handling" comes off the same line rather than being added to,
because the line has a width and failure handling is thirty lines of the loop's
own behaviour.

## Before merging

- [x] `make check` is green locally.
- [x] One logical change per commit, Conventional Commits, no co-author
      trailer. **PRs are rebased, never squashed or merged**, so the commit
      messages are what lands in the history and in the changelog.
- [x] Tests land with the behaviour they cover.
- [x] `CHANGELOG.md`, the tags and the version in `herdr-plugin.toml` are
      untouched — they belong to release-please.
- [x] A probe that taught something new is recorded in `AGENTS.md` and in
      `docs/architecture/herdr-socket-api.md`. *(No probe was run.)*
- [x] This pull request is one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGXTj5GCADqPKdkRTLcniy
