### PR TITLE
feat: support windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,15 @@ jobs:
           go-version: stable
       - run: go build ./...
       - run: go test -race ./...
+
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: go build ./...
+      # The race detector needs cgo on Windows, and the runner ships gcc.
+      - run: go test -race ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiled binary
 /herdr-auto-title
+/herdr-auto-title.exe
 
 # Go build and test artifacts
 *.test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ are only the facts that would otherwise mislead the code in silence.
 - **On Windows `pane.process_info` lists only the pane's shell or a recognized
   agent**, never an editor, a build or an ssh session running under the shell.
   Names arrive with `.exe` and a process's `cwd` with a trailing backslash; the
-  state package strips the one, and every path is cleaned before it is used.
+  state package strips both as they arrive, so no reader of a pane sees either.
 - Auto Title uses three methods and no others: `session.snapshot`,
   `pane.process_info` and `tab.rename`.
 - **Do not reintroduce an event subscription.** `events.subscribe` replays

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,14 @@ are only the facts that would otherwise mislead the code in silence.
 
 - **One request per connection.** Herdr closes the connection after answering,
   so every `Call` dials its own. That is why nothing here reconnects.
+- **On Windows the socket is a named pipe**, `\\.\pipe\` followed by the whole
+  of `HERDR_SOCKET_PATH`. The path itself names a small text file, and dialing
+  it as a Unix socket is refused; `dial_windows.go` opens the pipe, and nothing
+  else in the client differs.
+- **On Windows `pane.process_info` lists only the pane's shell or a recognized
+  agent**, never an editor, a build or an ssh session running under the shell.
+  Names arrive with `.exe` and a process's `cwd` with a trailing backslash; the
+  state package strips the one, and every path is cleaned before it is used.
 - Auto Title uses three methods and no others: `session.snapshot`,
   `pane.process_info` and `tab.rename`.
 - **Do not reintroduce an event subscription.** `events.subscribe` replays

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ in [docs/architecture](docs/architecture/).
 
 - `make check` green locally. CI then runs `go vet`, `go build` and
   `go test -race` on Go 1.24 and stable, the formatters and `golangci-lint`
-  once, and a build and test run on macOS.
+  once, and a build and test run on macOS and on Windows.
 - **PRs are merged by rebase.** Merge commits are disabled on the repository:
   GitHub puts the PR title into the merge commit, and since the titles here are
   conventional, release-please counted every change twice. Squashing would

--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,4 @@ probe-snapshot: ## Show the session snapshot the plugin polls
 
 .PHONY: clean
 clean: ## Remove the built binary
-	@rm -f $(BINARY)
+	@rm -f $(BINARY) $(BINARY).exe

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ https://github.com/user-attachments/assets/606fde6a-dfd3-4010-b4f3-80c79d74ea63
 ## Quick start
 
 > [!NOTE]
-> Requires Herdr 0.8.2+ and Go 1.24+ on macOS or Linux. Herdr compiles the
-> plugin from source on your machine when it installs it.
+> Requires Herdr 0.8.2+ and Go 1.24+ on macOS, Linux or Windows. Herdr compiles
+> the plugin from source on your machine when it installs it.
 
 ```sh
 herdr plugin install kryptamine/herdr-auto-title
@@ -102,6 +102,10 @@ These rules explain most surprises:
   because they only repeat what the screen already shows.
 - A tab with several panes takes its name from one of them: the focused pane, a
   pane running a busy agent, or the pane that changed last.
+- **On Windows, an editor or an ssh session does not name its tab.** Herdr
+  reports only the shell or an agent as what a pane there is running, so
+  `nvim › auth.provider.ts` and `ssh › prod-01` are titles other platforms get;
+  the directory, the branch and every agent title work the same.
 
 ## Configuration
 
@@ -112,6 +116,7 @@ Settings live in a file Auto Title reads once, at startup:
 | -------- | ----------------------------------------------------------- |
 | macOS    | `~/Library/Application Support/herdr-auto-title/config.env` |
 | Linux    | `~/.config/herdr-auto-title/config.env`                     |
+| Windows  | `%APPDATA%\herdr-auto-title\config.env`                     |
 
 Nothing creates it for you; [`config.env.example`](config.env.example) lists
 every setting commented out. **A change reaches the plugin only when it

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,8 +32,9 @@ rather not be named.
 
 ## Scope
 
-Auto Title polls a local Herdr session over a Unix socket and renames tabs. It
-starts no subprocess, and that socket is the only thing it talks to. Every
+Auto Title polls a local Herdr session over a local socket — a Unix socket, or
+a named pipe on Windows — and renames tabs. It starts no subprocess, and that
+socket is the only thing it talks to. Every
 value that reaches a tab title comes from terminal output and is treated as
 hostile; [docs/architecture/sanitization.md](docs/architecture/sanitization.md)
 says what is stripped and what is rejected.

--- a/config.env.example
+++ b/config.env.example
@@ -1,7 +1,8 @@
 # Auto Title configuration. Copy to the directory Auto Title reads it from:
 #
-#   macOS  ~/Library/Application Support/herdr-auto-title/config.env
-#   Linux  ~/.config/herdr-auto-title/config.env
+#   macOS    ~/Library/Application Support/herdr-auto-title/config.env
+#   Linux    ~/.config/herdr-auto-title/config.env
+#   Windows  %APPDATA%\herdr-auto-title\config.env
 #
 # Every line below is the default, so this file as it stands changes nothing.
 # A variable set in the environment overrides what is written here.

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -36,6 +36,7 @@ it did before.
 |----------|------|
 | macOS | `~/Library/Application Support/herdr-auto-title/config.env` |
 | Linux | `~/.config/herdr-auto-title/config.env` (`$XDG_CONFIG_HOME` if set) |
+| Windows | `%APPDATA%\herdr-auto-title\config.env` |
 
 That is `os.UserConfigDir()`, the same call `state.DefaultManualPath` makes.
 One directory holds everything Auto Title owns, and a user who has found one
@@ -44,8 +45,9 @@ because a configuration file whose location is itself configurable needs a
 configuration file to find it.
 
 **Herdr offers a directory of its own and Auto Title does not use it.** Herdr
-creates `~/.config/herdr/plugins/config/<plugin id>/` and prints it in `herdr
-plugin list`, and it names `HERDR_PLUGIN_CONFIG_DIR` among the variables it
+creates `~/.config/herdr/plugins/config/<plugin id>/` (under `%APPDATA%\herdr`
+on Windows) and prints it in `herdr plugin list`, and it names
+`HERDR_PLUGIN_CONFIG_DIR` among the variables it
 passes a plugin it starts — see [the socket API note](./herdr-socket-api.md) for
 how far that second half is verified. Two reasons against it: it exists only when the server starts the
 plugin, so a plugin run by hand — `make run`, `make dev`, every debugging

--- a/docs/architecture/herdr-socket-api.md
+++ b/docs/architecture/herdr-socket-api.md
@@ -9,13 +9,14 @@ generated: { by: claude-code/opus-5, at: 2026-08-25T12:46:22+03:00 }
 
 # Herdr Socket API
 
-Everything Auto Title knows about a session arrives over one Unix socket. The
-originating specification is wrong on several protocol details, so every fact
-below was verified against a live **Herdr 0.8.2, protocol 20** install with
-`scripts/probe.py` or a direct socket request. **Probe before assuming anything
-not listed here**, and record what a probe teaches you in this file, which is
-the record. `AGENTS.md` carries the short list of facts that would otherwise
-mislead the code in silence; a new one goes there too.
+Everything Auto Title knows about a session arrives over one local socket: a
+Unix socket, or on Windows a named pipe. The originating specification is wrong
+on several protocol details, so every fact below was verified against a live
+**Herdr 0.8.2, protocol 20** install with `scripts/probe.py` or a direct socket
+request, and the Windows facts against **0.8.2-preview, protocol 22**. **Probe
+before assuming anything not listed here**, and record what a probe teaches you
+in this file, which is the record. `AGENTS.md` carries the short list of facts
+that would otherwise mislead the code in silence; a new one goes there too.
 
 ## Transport
 
@@ -32,6 +33,17 @@ See [the poll loop](./poll-loop.md).
 
 A malformed request is answered with an uncorrelated error frame, and the
 connection is then closed.
+
+**On Windows the socket is a named pipe.** `HERDR_SOCKET_PATH` still names a
+file, `%APPDATA%\herdr\herdr.sock`, but that file is 25 bytes of text —
+`<server pid>:<start time in ns>` — and not a socket: dialing it as a Unix
+socket is refused, and Herdr listens instead on `\\.\pipe\` followed by the
+whole path, drive letter and backslashes included. `dial_windows.go` opens that
+pipe as a file. Opened so it takes no read deadline, but closing it from another
+goroutine does unblock a pending read — measured on Go 1.24.0 and 1.26.3 — which
+is what cancelling a call relies on. Framing and the one request per connection
+are unchanged: one line comes back, then EOF. A `session.snapshot` of nineteen
+panes measured 1.0 ms and 29 KB over the pipe, `pane.process_info` 1.0 ms.
 
 ## What Herdr gives a plugin process
 
@@ -154,6 +166,21 @@ reads, so this section describes Herdr rather than those types.
   pane's entry carries `shell_pid` and `foreground_process_group_id`. Auto
   Title reads the name, the arguments and the directory; the rest is listed
   here so a future change need not probe again.
+- **On Windows, `foreground_processes` holds the pane's shell or a recognized
+  agent, and nothing else.** Probed with `python.exe` and then `node.exe`
+  running under a pane's `pwsh.exe`, both confirmed present in the process tree:
+  the list held `pwsh.exe` alone, while a Claude Code pane listed `claude.exe`
+  alone. Windows has no foreground process group, and Herdr's detection there
+  scans for agents and known wrappers rather than reading one. The process and
+  ssh sources therefore go quiet on Windows; the directory read still holds,
+  because Herdr's pwsh prompt hook keeps the shell's own directory current —
+  `Set-Location C:\Windows` moved both `cwd` and the process's `cwd` within one
+  prompt. Names carry `.exe`, a process's `cwd` carries a trailing backslash
+  (`C:\github\x\`), and `foreground_cwd` was null on every pane.
+- **A Windows pane whose program has set no title carries `pwsh in <dir>`**,
+  the shell and the basename of its directory, `pwsh in Windows` after the
+  `Set-Location` above. It is Herdr's own fallback, and the resolver refuses it
+  the way it refuses a shell prompt.
 - **`PaneInfo` carries no foreground process name.** Only `pane.process_info`
   answers that, and nothing announces that a command started.
 - **`PaneInfo.title` is the agent's own title**, not the terminal's. Herdr left

--- a/docs/architecture/title-resolution.md
+++ b/docs/architecture/title-resolution.md
@@ -162,6 +162,13 @@ specified and is deliberately not built: the commands it would map are invisible
 in the process table, visible only in the terminal title, and a source below the
 terminal title can never fill an activity the terminal title has already filled.
 
+**On Windows this source and the ssh one below are mostly silent.** Herdr lists
+only the pane's shell or a recognized agent as what a pane there is running —
+see [the socket API](./herdr-socket-api.md) — so an editor or an ssh session
+never reaches either source, and its tab is named from the terminal title and
+the directory alone. Process names arrive there with an `.exe` the state package
+strips, so `pwsh.exe` is read as the shell it is.
+
 ### SSH
 
 A pane running `ssh` is named after the machine it reached, not the directory it
@@ -267,7 +274,10 @@ moved on.
 
 Directories that say nothing — the home directory, the filesystem root, a
 relative path — yield nothing, and a tab left with no name at all becomes
-`Shell`.
+`Shell`. On Windows the home directory is matched without regard to case, which
+is how Windows spells one, and Herdr's own title for an idle pane there,
+`pwsh in dashboard`, is refused as a shell prompt is: it names the shell and
+the directory the context already names.
 
 ## The workspace is not repeated
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,7 +9,10 @@ that is the plugin doing its job, not a problem to fix.
 Everything below assumes `make`, Go 1.24+ and a shell running inside a Herdr
 pane (which is what exports `HERDR_SOCKET_PATH`).
 
-Run `make` on its own to list every target.
+Run `make` on its own to list every target. On Windows, Git Bash ships neither
+`make`, `pgrep` nor `pkill`; every recipe is one line, so run the line itself —
+`go test -race ./...`, `go tool -modfile=tools/go.mod golangci-lint run ./...` —
+and stop a stray plugin from the task manager.
 
 ## The three loops
 
@@ -26,9 +29,13 @@ make check       # fmt + vet + lint + test, run this before every commit
 
 The same four run in CI on every push and pull request
 (`.github/workflows/ci.yml`), plus the Go version floor the manifest promises,
-which a laptop on the newest toolchain does not cover. Windows was tried once
-and dropped: the fixtures assume Unix paths, so `filepath.IsAbs` rejects every
-directory in them and every tab falls back to `Shell`.
+which a laptop on the newest toolchain does not cover, and the suite on macOS
+and Windows. The fixtures take their directories from `herdrtest.Dir`, which
+roots them on whichever filesystem the tests run on: spelled as `/Users/dev/...`
+they were relative on Windows, and every tab fell back to `Shell`. On Windows
+the client tests speak to a named pipe server of their own, so the transport
+the plugin ships there is what the suite exercises, and `go test -race` needs a
+C compiler — gcc on `PATH` with `CGO_ENABLED=1`, which the CI runner ships.
 
 The suite drives the whole loop through `herdrtest.Client`: the first poll, a
 tab appearing later, deduplication, rename failures, a poll that fails outright.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -5,14 +5,24 @@ name = "Auto Title"
 version = "0.4.0"
 min_herdr_version = "0.8.2"
 description = "Automatically generates contextual tab titles"
-# Windows is not claimed: nothing has ever run there, and the test fixtures
-# that assume Unix paths say the code has not been thought about on it either.
-platforms = ["linux", "macos"]
+# Herdr enforces this list: on a platform left out of it, nothing below runs.
+platforms = ["linux", "macos", "windows"]
 
-# Built at install time; Go is the only requirement.
+# Built at install time; Go is the only requirement. Windows has a pair of its
+# own so the binary carries the extension Windows expects of one.
 [[build]]
+platforms = ["linux", "macos"]
 command = ["go", "build", "-o", "herdr-auto-title", "./cmd/herdr-auto-title"]
+
+[[build]]
+platforms = ["windows"]
+command = ["go", "build", "-o", "herdr-auto-title.exe", "./cmd/herdr-auto-title"]
 
 # A one-shot launch, not a supervised daemon: the process stays alive itself.
 [[startup]]
+platforms = ["linux", "macos"]
 command = ["./herdr-auto-title"]
+
+[[startup]]
+platforms = ["windows"]
+command = ["./herdr-auto-title.exe"]

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1105,3 +1105,27 @@ func TestRunNamesWhatExistsBeforeTheFirstTick(t *testing.T) {
 	cancel()
 	<-done
 }
+
+func TestAWindowsShellPaneIsNamedAfterItsDirectory(t *testing.T) {
+	// What Herdr reports for an idle pane on Windows: the shell with its
+	// extension, its directory with a trailing separator, and a title of
+	// Herdr's own making that names both. None of it is what the pane is doing.
+	h := start(
+		t,
+		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		[]herdr.PaneInfo{{
+			PaneID: "wE:p1", TabID: "wE:t1", Focused: true,
+			CWD:                   dashboard,
+			TerminalTitleStripped: "pwsh in dashboard",
+		}},
+	)
+	h.client.SetProcesses("wE:p1", herdr.PaneProcessInfoProcess{
+		Name: "pwsh.exe",
+		CWD:  dashboard + string(filepath.Separator),
+	})
+	h.poll()
+
+	if got := h.client.Renames()[0].Label; got != "dashboard" {
+		t.Errorf("rename = %q, want dashboard", got)
+	}
+}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -66,10 +66,6 @@ type harness struct {
 	t      *testing.T
 	app    *App
 	client *herdrtest.Client
-	// polled is when the last poll finished. The clock is what orders the
-	// changes a poll sees, and on Windows it ticks too coarsely to tell two
-	// polls apart unless one waits for it.
-	polled time.Time
 }
 
 func start(t *testing.T, tabs []herdr.TabInfo, panes []herdr.PaneInfo) *harness {
@@ -89,12 +85,7 @@ func startConfigured(t *testing.T, client *herdrtest.Client, cfg Config) *harnes
 func (h *harness) poll() {
 	h.t.Helper()
 
-	for !time.Now().After(h.polled) {
-		time.Sleep(time.Millisecond)
-	}
-
 	h.app.poll(context.Background(), h.client)
-	h.polled = time.Now()
 }
 
 func (h *harness) polls(n int) {
@@ -102,6 +93,16 @@ func (h *harness) polls(n int) {
 
 	for range n {
 		h.poll()
+	}
+}
+
+// awaitClock returns once the wall clock has moved on. Which pane changed last
+// is told by the clock, and on Windows it ticks too coarsely to tell two polls
+// apart unless one waits for it.
+func awaitClock() {
+	start := time.Now()
+	for !time.Now().After(start) {
+		time.Sleep(time.Millisecond)
 	}
 }
 
@@ -347,6 +348,7 @@ func TestTheMostRecentlyChangedPaneNamesTheTab(t *testing.T) {
 	h.client.SetPane(herdr.PaneInfo{
 		PaneID: "wE:p2", TabID: "wE:t1", Revision: 2, CWD: api,
 	})
+	awaitClock()
 	h.poll()
 
 	if got := h.client.Renames()[1].Label; got != "api" {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -19,6 +19,14 @@ import (
 
 const testPoll = 10 * time.Millisecond
 
+// The directories the fixtures sit in, absolute on whichever platform the
+// tests run on: a relative directory names no tab, and Windows has no /Users.
+var (
+	dashboard = herdrtest.Dir("work", "dashboard")
+	api       = herdrtest.Dir("work", "api")
+	billing   = herdrtest.Dir("work", "billing")
+)
+
 func testConfig() Config {
 	return Config{
 		Poll:      testPoll,
@@ -31,12 +39,20 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
 }
 
+// setHome points os.UserHomeDir at dir. Unix reads HOME and Windows reads
+// USERPROFILE, and setting both spares every fixture from knowing which.
+func setHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+}
+
 // testResolver builds the shipped chain against a home directory of the test's
 // own, because CWD declines a pane sitting in the user's and the fixtures below
 // must not depend on whose machine they run on.
 func testResolver(t *testing.T) resolver.TitleResolver {
 	t.Helper()
-	t.Setenv("HOME", filepath.Join(t.TempDir(), "home"))
+	setHome(t, filepath.Join(t.TempDir(), "home"))
 
 	return resolver.Default(resolver.Options{
 		MaxLength: resolver.DefaultMaxLength,
@@ -50,6 +66,10 @@ type harness struct {
 	t      *testing.T
 	app    *App
 	client *herdrtest.Client
+	// polled is when the last poll finished. The clock is what orders the
+	// changes a poll sees, and on Windows it ticks too coarsely to tell two
+	// polls apart unless one waits for it.
+	polled time.Time
 }
 
 func start(t *testing.T, tabs []herdr.TabInfo, panes []herdr.PaneInfo) *harness {
@@ -68,7 +88,13 @@ func startConfigured(t *testing.T, client *herdrtest.Client, cfg Config) *harnes
 // exercises what the loop does rather than a shortcut past it.
 func (h *harness) poll() {
 	h.t.Helper()
+
+	for !time.Now().After(h.polled) {
+		time.Sleep(time.Millisecond)
+	}
+
 	h.app.poll(context.Background(), h.client)
+	h.polled = time.Now()
 }
 
 func (h *harness) polls(n int) {
@@ -84,7 +110,7 @@ func TestTabsAreNamedFromTheFirstPoll(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.poll()
@@ -108,7 +134,7 @@ func TestATabAppearingLaterIsNamed(t *testing.T) {
 	h.client.SetTab(herdr.TabInfo{TabID: "wE:t1", Label: "1"})
 	h.client.SetPane(herdr.PaneInfo{
 		PaneID: "wE:p1", TabID: "wE:t1", Focused: true,
-		CWD:                   "/Users/dev/work/dashboard",
+		CWD:                   dashboard,
 		TerminalTitleStripped: "Fix OAuth redirect",
 	})
 	h.poll()
@@ -124,14 +150,14 @@ func TestChangedContextRetitlesTheTab(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.poll()
 
 	h.client.SetPane(herdr.PaneInfo{
 		PaneID: "wE:p1", TabID: "wE:t1", Focused: true, Revision: 2,
-		CWD: "/Users/dev/work/api",
+		CWD: api,
 	})
 	h.poll()
 
@@ -147,7 +173,7 @@ func TestAnUnchangedSessionIsRenamedOnce(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.polls(10)
@@ -162,7 +188,7 @@ func TestATabAlreadyCorrectlyNamedIsLeftAlone(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "dashboard"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.polls(5)
@@ -191,8 +217,8 @@ func TestATabClosingMidPollIsNotFatal(t *testing.T) {
 			{TabID: "wE:t2", Label: "2"},
 		},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
-			{PaneID: "wE:p2", TabID: "wE:t2", CWD: "/Users/dev/work/api", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
+			{PaneID: "wE:p2", TabID: "wE:t2", CWD: api, Focused: true},
 		},
 	)
 	h.poll()
@@ -201,7 +227,7 @@ func TestATabClosingMidPollIsNotFatal(t *testing.T) {
 	h.client.ClosePane("wE:p1")
 	h.client.SetPane(herdr.PaneInfo{
 		PaneID: "wE:p2", TabID: "wE:t2", Focused: true, Revision: 2,
-		CWD: "/Users/dev/work/billing",
+		CWD: billing,
 	})
 	h.poll()
 
@@ -215,7 +241,7 @@ func TestFailedRenameIsRetriedOnTheNextPoll(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.client.SetRenameError(errors.New("herdr is busy"))
@@ -240,7 +266,7 @@ func TestAFailedPollIsFollowedByAWorkingOne(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.poll()
@@ -251,7 +277,7 @@ func TestAFailedPollIsFollowedByAWorkingOne(t *testing.T) {
 
 	h.client.SetPane(herdr.PaneInfo{
 		PaneID: "wE:p1", TabID: "wE:t1", Focused: true, Revision: 2,
-		CWD: "/Users/dev/work/api",
+		CWD: api,
 	})
 	h.poll()
 
@@ -268,7 +294,7 @@ func TestAFailingFirstPollIsTreatedLikeAnyOther(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.client.SetCallError(errors.New("no such socket"))
@@ -286,7 +312,7 @@ func TestRunStopsCleanlyOnCancellation(t *testing.T) {
 	client := herdrtest.New(
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	app := New(testConfig(), discardLogger(), testResolver(t))
@@ -312,14 +338,14 @@ func TestTheMostRecentlyChangedPaneNamesTheTab(t *testing.T) {
 	h := start(t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", Revision: 1, CWD: "/Users/dev/work/dashboard"},
-			{PaneID: "wE:p2", TabID: "wE:t1", Revision: 1, CWD: "/Users/dev/work/api"},
+			{PaneID: "wE:p1", TabID: "wE:t1", Revision: 1, CWD: dashboard},
+			{PaneID: "wE:p2", TabID: "wE:t1", Revision: 1, CWD: api},
 		},
 	)
 	h.poll()
 
 	h.client.SetPane(herdr.PaneInfo{
-		PaneID: "wE:p2", TabID: "wE:t1", Revision: 2, CWD: "/Users/dev/work/api",
+		PaneID: "wE:p2", TabID: "wE:t1", Revision: 2, CWD: api,
 	})
 	h.poll()
 
@@ -333,7 +359,7 @@ func TestAgentContextNamesTheTab(t *testing.T) {
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{{
 			PaneID: "wE:p1", TabID: "wE:t1", Focused: true,
-			CWD:         "/Users/dev/work/dashboard",
+			CWD:         dashboard,
 			Agent:       "claude",
 			AgentStatus: herdr.AgentStatusWorking,
 			Title:       "Implement OAuth scopes",
@@ -355,8 +381,8 @@ func TestAnAgentPaneIsNamedAfterTheAgentsOwnDirectory(t *testing.T) {
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{{
 			PaneID: "wE:p1", TabID: "wE:t1", Focused: true,
-			CWD:           "/Users/dev/work/dashboard",
-			ForegroundCWD: "/private/tmp",
+			CWD:           dashboard,
+			ForegroundCWD: herdrtest.Dir("tmp"),
 			Agent:         "claude",
 			AgentStatus:   herdr.AgentStatusWorking,
 			Title:         "Implement OAuth scopes",
@@ -364,10 +390,10 @@ func TestAnAgentPaneIsNamedAfterTheAgentsOwnDirectory(t *testing.T) {
 	)
 	h.client.SetProcesses(
 		"wE:p1",
-		herdr.PaneProcessInfoProcess{Name: "fff-mcp", CWD: "/private/tmp"},
+		herdr.PaneProcessInfoProcess{Name: "fff-mcp", CWD: herdrtest.Dir("tmp")},
 		herdr.PaneProcessInfoProcess{
 			Name: "claude",
-			CWD:  "/Users/dev/work/self-care-portal",
+			CWD:  herdrtest.Dir("work", "self-care-portal"),
 		},
 	)
 	h.poll()
@@ -385,7 +411,7 @@ func TestARemoteSessionIsNamedAfterItsHost(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.poll()
@@ -402,7 +428,7 @@ func TestARemoteSessionIsNamedAfterItsHost(t *testing.T) {
 	)
 	h.client.SetPane(herdr.PaneInfo{
 		PaneID: "wE:p1", TabID: "wE:t1", Focused: true, Revision: 2,
-		CWD: "/Users/dev/work/dashboard",
+		CWD: dashboard,
 	})
 	h.poll()
 
@@ -418,7 +444,7 @@ func TestAPaneWhoseProcessesCannotBeReadIsStillNamed(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.client.SetProcessError(&herdr.APIError{
@@ -443,7 +469,7 @@ func TestAWorkspaceNameIsNotRepeatedInItsTabs(t *testing.T) {
 		[]herdr.TabInfo{{TabID: "wE:t1", WorkspaceID: "wE", Label: "1"}},
 		[]herdr.PaneInfo{{
 			PaneID: "wE:p1", TabID: "wE:t1", Focused: true,
-			CWD:                   "/Users/dev/work/dashboard",
+			CWD:                   dashboard,
 			TerminalTitleStripped: "Fix OAuth redirect",
 		}},
 	)
@@ -460,7 +486,7 @@ func TestARenameByTheUserTurnsAutomaticNamingOff(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.poll()
@@ -471,7 +497,7 @@ func TestARenameByTheUserTurnsAutomaticNamingOff(t *testing.T) {
 	// The context moves on; the tab does not.
 	h.client.SetPane(herdr.PaneInfo{
 		PaneID: "wE:p1", TabID: "wE:t1", Focused: true, Revision: 2,
-		CWD: "/Users/dev/work/api",
+		CWD: api,
 	})
 	h.poll()
 
@@ -487,7 +513,7 @@ func TestClearingTheNameHandsTheTabBack(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.poll()
@@ -510,7 +536,7 @@ func TestATabPutBackOnItsPositionIsHandedBack(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.poll()
@@ -533,7 +559,7 @@ func TestThePluginsOwnRenamesDoNotLockTheTab(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.poll()
@@ -541,7 +567,7 @@ func TestThePluginsOwnRenamesDoNotLockTheTab(t *testing.T) {
 	for i, dir := range []string{"api", "billing", "dashboard"} {
 		h.client.SetPane(herdr.PaneInfo{
 			PaneID: "wE:p1", TabID: "wE:t1", Focused: true, Revision: uint64(i + 2),
-			CWD: "/Users/dev/work/" + dir,
+			CWD: herdrtest.Dir("work", dir),
 		})
 		h.poll()
 
@@ -561,8 +587,8 @@ func TestNoTabIsLockedOnTheFirstPoll(t *testing.T) {
 			{TabID: "wE:t2", Label: "2"},
 		},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
-			{PaneID: "wE:p2", TabID: "wE:t2", CWD: "/Users/dev/work/api", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
+			{PaneID: "wE:p2", TabID: "wE:t2", CWD: api, Focused: true},
 		},
 	)
 	h.poll()
@@ -586,14 +612,14 @@ func TestATabCreatedAndNamedBeforeTheNextPollIsLeftAlone(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.poll()
 
 	h.client.SetTab(herdr.TabInfo{TabID: "wE:t9", Label: "My thing"})
 	h.client.SetPane(
-		herdr.PaneInfo{PaneID: "wE:p9", TabID: "wE:t9", CWD: "/Users/dev/work/api", Focused: true},
+		herdr.PaneInfo{PaneID: "wE:p9", TabID: "wE:t9", CWD: api, Focused: true},
 	)
 	h.polls(2)
 
@@ -612,14 +638,14 @@ func TestATabCreatedWithoutANameIsNamed(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.poll()
 
 	h.client.SetTab(herdr.TabInfo{TabID: "wE:t9", Label: "2"})
 	h.client.SetPane(
-		herdr.PaneInfo{PaneID: "wE:p9", TabID: "wE:t9", CWD: "/Users/dev/work/api", Focused: true},
+		herdr.PaneInfo{PaneID: "wE:p9", TabID: "wE:t9", CWD: api, Focused: true},
 	)
 	h.poll()
 
@@ -636,7 +662,7 @@ func TestAPaneHoldingStillIsAskedAboutOnce(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.polls(10)
@@ -651,7 +677,7 @@ func TestAPaneThatMovedIsAskedAboutAgain(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.poll()
@@ -659,7 +685,7 @@ func TestAPaneThatMovedIsAskedAboutAgain(t *testing.T) {
 	h.client.SetProcesses("wE:p1", herdr.PaneProcessInfoProcess{Name: "nvim"})
 	h.client.SetPane(herdr.PaneInfo{
 		PaneID: "wE:p1", TabID: "wE:t1", Focused: true, Revision: 2,
-		CWD: "/Users/dev/work/dashboard",
+		CWD: dashboard,
 	})
 	h.poll()
 
@@ -674,7 +700,7 @@ func TestAPaneThatCannotBeReadIsAskedAgain(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.client.SetProcessError(errors.New("herdr is busy"))
@@ -699,9 +725,9 @@ func TestAPaneThatDoesNotNameItsTabIsNotRead(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
-			{PaneID: "wE:p2", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard"},
-			{PaneID: "wE:p3", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard"},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
+			{PaneID: "wE:p2", TabID: "wE:t1", CWD: dashboard},
+			{PaneID: "wE:p3", TabID: "wE:t1", CWD: dashboard},
 		},
 	)
 	h.polls(10)
@@ -718,7 +744,7 @@ func TestALockedTabIsNotReadEither(t *testing.T) {
 		t,
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 	h.poll()
@@ -732,7 +758,7 @@ func TestALockedTabIsNotReadEither(t *testing.T) {
 	for i := range 4 {
 		h.client.SetPane(herdr.PaneInfo{
 			PaneID: "wE:p1", TabID: "wE:t1", Focused: true, Revision: uint64(i + 2),
-			CWD: "/Users/dev/work/dashboard",
+			CWD: dashboard,
 		})
 		h.poll()
 	}
@@ -901,10 +927,7 @@ func TestBranchesSwitchedOffAreNotRead(t *testing.T) {
 }
 
 // The session an agent pane is holding in the tests below.
-const (
-	testSession = "8852bfe0-8b24-4a23-a35e-7521d04da061"
-	testDir     = "/Users/dev/work/dashboard"
-)
+const testSession = "8852bfe0-8b24-4a23-a35e-7521d04da061"
 
 // transcript lays down a Claude Code session transcript and points the plugin
 // at the state directory holding it. Which project directory it lands in is
@@ -928,7 +951,7 @@ func transcript(t *testing.T, lines ...string) {
 // terminal, which is the only pane shape these tests care about.
 func agentPane() herdr.PaneInfo {
 	return herdr.PaneInfo{
-		PaneID: "wE:p1", TabID: "wE:t1", Focused: true, CWD: testDir,
+		PaneID: "wE:p1", TabID: "wE:t1", Focused: true, CWD: dashboard,
 		TerminalTitleStripped: "Claude Code",
 		Agent:                 "claude",
 		AgentStatus:           "idle",
@@ -1051,7 +1074,7 @@ func TestRunNamesWhatExistsBeforeTheFirstTick(t *testing.T) {
 	client := herdrtest.New(
 		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
 		[]herdr.PaneInfo{
-			{PaneID: "wE:p1", TabID: "wE:t1", CWD: "/Users/dev/work/dashboard", Focused: true},
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
 

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -12,15 +12,18 @@ import (
 	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
 
-// isolate takes a test off the developer's machine: HOME decides where the
-// configuration file is looked for, and every variable Auto Title reads is
-// removed so the test sees only what it sets.
+// isolate takes a test off the developer's machine: the home decides where
+// the configuration file is looked for, and every variable Auto Title reads
+// is removed so the test sees only what it sets.
 func isolate(t *testing.T) {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
-	// Where os.UserConfigDir looks first on Linux, so HOME alone does not
-	// isolate anything until it is out of the way.
+
+	home := t.TempDir()
+	setHome(t, home)
+	// Where os.UserConfigDir looks first on Linux and on Windows, so the home
+	// alone does not isolate anything until both point elsewhere.
 	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("AppData", filepath.Join(home, "AppData", "Roaming"))
 
 	names := []string{
 		EnvDebug, EnvPoll, EnvMaxLength, EnvBranchMax,

--- a/internal/claude/transcript.go
+++ b/internal/claude/transcript.go
@@ -190,8 +190,11 @@ func (r *Reader) locate(sessionID, dir string) (string, bool) {
 }
 
 // slugOf is how Claude Code names a project directory: every character that is
-// not a letter or a digit becomes a dash, the leading separator included.
+// not a letter or a digit becomes a dash, the leading separator included. A
+// trailing one is not, because the directory Claude Code names carries none.
 func slugOf(dir string) string {
+	dir = filepath.Clean(dir)
+
 	var slug strings.Builder
 	slug.Grow(len(dir))
 

--- a/internal/claude/transcript.go
+++ b/internal/claude/transcript.go
@@ -190,11 +190,8 @@ func (r *Reader) locate(sessionID, dir string) (string, bool) {
 }
 
 // slugOf is how Claude Code names a project directory: every character that is
-// not a letter or a digit becomes a dash, the leading separator included. A
-// trailing one is not, because the directory Claude Code names carries none.
+// not a letter or a digit becomes a dash, the leading separator included.
 func slugOf(dir string) string {
-	dir = filepath.Clean(dir)
-
 	var slug strings.Builder
 	slug.Grow(len(dir))
 

--- a/internal/claude/transcript_test.go
+++ b/internal/claude/transcript_test.go
@@ -346,6 +346,13 @@ func TestSlugMatchesHowClaudeCodeNamesAProject(t *testing.T) {
 	if got := slugOf("/Users/dev/.claude/skills"); got != "-Users-dev--claude-skills" {
 		t.Errorf("slug = %q", got)
 	}
+
+	// Windows reports a process's directory with a trailing separator, and
+	// Claude Code names the project without one.
+	trailing := filepath.Join("work", "dashboard") + string(filepath.Separator)
+	if got := slugOf(trailing); got != "work-dashboard" {
+		t.Errorf("slug = %q, want the separator dropped", got)
+	}
 }
 
 func TestATranscriptThatWentMissingIsLookedForAgain(t *testing.T) {

--- a/internal/claude/transcript_test.go
+++ b/internal/claude/transcript_test.go
@@ -346,13 +346,6 @@ func TestSlugMatchesHowClaudeCodeNamesAProject(t *testing.T) {
 	if got := slugOf("/Users/dev/.claude/skills"); got != "-Users-dev--claude-skills" {
 		t.Errorf("slug = %q", got)
 	}
-
-	// Windows reports a process's directory with a trailing separator, and
-	// Claude Code names the project without one.
-	trailing := filepath.Join("work", "dashboard") + string(filepath.Separator)
-	if got := slugOf(trailing); got != "work-dashboard" {
-		t.Errorf("slug = %q, want the separator dropped", got)
-	}
 }
 
 func TestATranscriptThatWentMissingIsLookedForAgain(t *testing.T) {

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
 	"os"
 	"sync/atomic"
 )
@@ -62,9 +61,7 @@ func (c *SocketClient) Call(ctx context.Context, method string, params any, resu
 		params = emptyParams{}
 	}
 
-	var d net.Dialer
-
-	conn, err := d.DialContext(ctx, "unix", c.path)
+	conn, err := dial(ctx, c.path)
 	if err != nil {
 		return fmt.Errorf("connect to herdr socket %s: %w", c.path, err)
 	}

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -6,9 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"net"
-	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 )
@@ -20,10 +17,17 @@ type incoming struct {
 	Params json.RawMessage `json:"params"`
 }
 
+// listener accepts connections the way Herdr does on this platform: over a
+// Unix socket, or on Windows over the named pipe carrying the socket's path.
+type listener interface {
+	accept() (io.ReadWriteCloser, error)
+	close()
+}
+
 // testServer imitates Herdr: one request per connection, answered and closed.
 type testServer struct {
 	t    *testing.T
-	ln   net.Listener
+	ln   listener
 	path string
 
 	mu          sync.Mutex
@@ -37,35 +41,19 @@ type testServer struct {
 func newTestServer(t *testing.T, reply func(incoming) string) *testServer {
 	t.Helper()
 
-	// t.TempDir() names the directory after the test, which measured 122 bytes
-	// here — past the 104 a socket's sun_path holds.
-	//nolint:usetesting // t.TempDir() overruns sun_path, as measured above
-	dir, err := os.MkdirTemp("", "at")
-	if err != nil {
-		t.Fatalf("temp dir: %v", err)
-	}
-
-	path := filepath.Join(dir, "h.sock")
-
-	ln, err := net.Listen("unix", path)
-	if err != nil {
-		t.Fatalf("listen on %s: %v", path, err)
-	}
+	ln, path := listen(t)
 
 	s := &testServer{t: t, ln: ln, path: path, reply: reply}
 	go s.accept()
 
-	t.Cleanup(func() {
-		ln.Close()
-		os.RemoveAll(dir)
-	})
+	t.Cleanup(ln.close)
 
 	return s
 }
 
 func (s *testServer) accept() {
 	for {
-		conn, err := s.ln.Accept()
+		conn, err := s.ln.accept()
 		if err != nil {
 			return
 		}
@@ -74,7 +62,7 @@ func (s *testServer) accept() {
 	}
 }
 
-func (s *testServer) serve(conn net.Conn) {
+func (s *testServer) serve(conn io.ReadWriteCloser) {
 	s.mu.Lock()
 	s.connections++
 	s.mu.Unlock()

--- a/internal/herdr/dial_unix.go
+++ b/internal/herdr/dial_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package herdr
+
+import (
+	"context"
+	"io"
+	"net"
+)
+
+// dial opens one connection to the Unix socket at path.
+func dial(ctx context.Context, path string) (io.ReadWriteCloser, error) {
+	var d net.Dialer
+
+	return d.DialContext(ctx, "unix", path)
+}

--- a/internal/herdr/dial_windows.go
+++ b/internal/herdr/dial_windows.go
@@ -1,0 +1,19 @@
+package herdr
+
+import (
+	"context"
+	"io"
+	"os"
+)
+
+// pipePrefix is the named pipe namespace. On Windows HERDR_SOCKET_PATH names a
+// plain file, and the pipe Herdr listens on carries that whole path as its
+// name, drive letter and backslashes included.
+const pipePrefix = `\\.\pipe\`
+
+// dial opens one connection to the pipe behind path. A pipe takes no deadline,
+// but closing it does unblock a pending read, which is all cancellation needs.
+func dial(_ context.Context, path string) (io.ReadWriteCloser, error) {
+	//nolint:gosec // the path is HERDR_SOCKET_PATH, never terminal-derived
+	return os.OpenFile(pipePrefix+path, os.O_RDWR, 0)
+}

--- a/internal/herdr/herdrtest/dir.go
+++ b/internal/herdr/herdrtest/dir.go
@@ -1,0 +1,22 @@
+package herdrtest
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+// Dir is an absolute directory as Herdr reports one on the platform the tests
+// run on. A fixture spelled `/Users/dev/work` is relative on Windows, where
+// filepath.IsAbs wants a drive, and a relative directory names no tab.
+func Dir(elems ...string) string {
+	return filepath.Join(append([]string{Root(), "Users", "dev"}, elems...)...)
+}
+
+// Root is the filesystem root the fixtures hang off: `/`, or `C:\` on Windows.
+func Root() string {
+	if runtime.GOOS == "windows" {
+		return `C:\`
+	}
+
+	return "/"
+}

--- a/internal/herdr/listen_unix_test.go
+++ b/internal/herdr/listen_unix_test.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+package herdr
+
+import (
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type socketListener struct{ net.Listener }
+
+func (l socketListener) accept() (io.ReadWriteCloser, error) { return l.Accept() }
+func (l socketListener) close()                              { l.Close() }
+
+// listen opens a Unix socket for the client to dial.
+func listen(t *testing.T) (listener, string) {
+	t.Helper()
+
+	// t.TempDir() names the directory after the test, which measured 122 bytes
+	// here — past the 104 a socket's sun_path holds.
+	//nolint:usetesting // t.TempDir() overruns sun_path, as measured above
+	dir, err := os.MkdirTemp("", "at")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	path := filepath.Join(dir, "h.sock")
+
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen on %s: %v", path, err)
+	}
+
+	return socketListener{ln}, path
+}

--- a/internal/herdr/listen_windows_test.go
+++ b/internal/herdr/listen_windows_test.go
@@ -1,0 +1,128 @@
+package herdr
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"unsafe"
+)
+
+// The kernel32 calls a named pipe server needs and package syscall does not
+// wrap.
+var (
+	kernel32             = syscall.NewLazyDLL("kernel32.dll")
+	procCreateNamedPipeW = kernel32.NewProc("CreateNamedPipeW")
+	procConnectNamedPipe = kernel32.NewProc("ConnectNamedPipe")
+)
+
+const (
+	pipeAccessDuplex       = 0x00000003
+	pipeTypeByte           = 0x00000000
+	pipeUnlimitedInstances = 255
+	pipeBuffer             = 64 << 10
+	// errPipeConnected is how ConnectNamedPipe reports a client that arrived
+	// before it was called, which is a connection rather than a failure.
+	errPipeConnected = syscall.Errno(535)
+)
+
+var errListenerClosed = errors.New("listener closed")
+
+// pipeListener hands out one pipe instance per connection, as Herdr does. One
+// instance is always waiting: a client finds nothing to open otherwise.
+type pipeListener struct {
+	name   *uint16
+	path   string
+	next   syscall.Handle
+	closed chan struct{}
+}
+
+// listen names a pipe after a socket path, the way Herdr does, so the client
+// under test dials exactly what it dials in a session.
+func listen(t *testing.T) (listener, string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "h.sock")
+
+	name, err := syscall.UTF16PtrFromString(pipePrefix + path)
+	if err != nil {
+		t.Fatalf("pipe name: %v", err)
+	}
+
+	l := &pipeListener{name: name, path: path, closed: make(chan struct{})}
+
+	if l.next, err = l.instance(); err != nil {
+		t.Fatalf("create pipe %s: %v", path, err)
+	}
+
+	return l, path
+}
+
+func (l *pipeListener) instance() (syscall.Handle, error) {
+	handle, _, err := procCreateNamedPipeW.Call(
+		uintptr(unsafe.Pointer(l.name)),
+		pipeAccessDuplex,
+		pipeTypeByte,
+		pipeUnlimitedInstances,
+		pipeBuffer,
+		pipeBuffer,
+		0,
+		0,
+	)
+	if syscall.Handle(handle) == syscall.InvalidHandle {
+		return syscall.InvalidHandle, err
+	}
+
+	return syscall.Handle(handle), nil
+}
+
+// accept waits for a client on the instance that is up, and puts up the next
+// one before handing this one out.
+func (l *pipeListener) accept() (io.ReadWriteCloser, error) {
+	handle := l.next
+
+	ok, _, err := procConnectNamedPipe.Call(uintptr(handle), 0)
+	if ok == 0 && !errors.Is(err, errPipeConnected) {
+		syscall.CloseHandle(handle)
+
+		return nil, err
+	}
+
+	select {
+	case <-l.closed:
+		syscall.CloseHandle(handle)
+
+		return nil, errListenerClosed
+	default:
+	}
+
+	if l.next, err = l.instance(); err != nil {
+		syscall.CloseHandle(handle)
+
+		return nil, err
+	}
+
+	return pipeConn{os.NewFile(uintptr(handle), l.path)}, nil
+}
+
+// close stops accepting. ConnectNamedPipe returns only when a client arrives,
+// so one is sent to wake the accept that is waiting.
+func (l *pipeListener) close() {
+	close(l.closed)
+
+	if f, err := os.OpenFile(pipePrefix+l.path, os.O_RDWR, 0); err == nil {
+		f.Close()
+	}
+}
+
+// pipeConn is a server end whose Close first waits for the client to read what
+// was written: closing a pipe instance discards anything still unread.
+type pipeConn struct{ *os.File }
+
+func (c pipeConn) Close() error {
+	_ = c.Sync()
+
+	return c.File.Close()
+}

--- a/internal/herdr/protocol.go
+++ b/internal/herdr/protocol.go
@@ -1,6 +1,6 @@
 // Package herdr implements a client for the Herdr local socket API: NDJSON over
-// the socket named by HERDR_SOCKET_PATH, one request per connection.
-// Verified against Herdr v0.8.2, protocol 20.
+// the socket named by HERDR_SOCKET_PATH — a named pipe on Windows — with one
+// request per connection. Verified against Herdr v0.8.2, protocol 20.
 package herdr
 
 import (

--- a/internal/resolver/agent_test.go
+++ b/internal/resolver/agent_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAgentTitleBeatsEverySourceBelowIt(t *testing.T) {
 	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "Claude Code",
 		Agent:         "claude",
 		AgentStatus:   herdr.AgentStatusWorking,
@@ -31,7 +31,7 @@ func TestAgentTitleBeatsEverySourceBelowIt(t *testing.T) {
 
 func TestAgentTitleOutranksAMeaningfulTerminalTitle(t *testing.T) {
 	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "Fix OAuth redirect",
 		Agent:         "claude",
 		AgentStatus:   herdr.AgentStatusWorking,
@@ -49,7 +49,7 @@ func TestGenericAgentNameFallsThrough(t *testing.T) {
 	for _, title := range []string{"Claude", "Claude Code", "Agent", "Coding Agent", ""} {
 		t.Run(title, func(t *testing.T) {
 			got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-				Dir:           "/Users/dev/work/dashboard",
+				Dir:           dashboard,
 				TerminalTitle: "Fix OAuth redirect",
 				Agent:         "claude",
 				AgentStatus:   herdr.AgentStatusWorking,
@@ -72,7 +72,7 @@ func TestAgentEchoingItsOwnNameIsNotAgentContext(t *testing.T) {
 	// off as a report of their work. The name still reaches the tab, but as the
 	// kind of program running there rather than as what it is doing.
 	pane := &state.PaneState{
-		Dir:          "/Users/dev/work/dashboard",
+		Dir:          dashboard,
 		Agent:        "acme-bot",
 		DisplayAgent: "Acme Bot",
 		AgentStatus:  herdr.AgentStatusWorking,
@@ -97,7 +97,7 @@ func TestAnEchoedAgentNameIsDeclinedWhateverReportsIt(t *testing.T) {
 	// A terminal title and a transcript topic carry the echo as readily as the
 	// agent title does, and it says no more about the work there.
 	pane := &state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		Agent:         "acme-bot",
 		DisplayAgent:  "Acme Bot",
 		AgentStatus:   herdr.AgentStatusWorking,
@@ -123,7 +123,7 @@ func TestAgentTitleWithoutAnAgentIsIgnored(t *testing.T) {
 	// Herdr leaves the title on a pane whose agent it no longer recognizes;
 	// without an agent it is not agent context.
 	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:        "/Users/dev/work/dashboard",
+		Dir:        dashboard,
 		AgentTitle: "Implement OAuth scopes",
 	}))
 
@@ -152,12 +152,12 @@ func TestContextAndActivityComeFromTheSamePane(t *testing.T) {
 		Panes: []*state.PaneState{
 			{
 				ID:            "wE:p1",
-				Dir:           "/Users/dev/work/api",
+				Dir:           api,
 				TerminalTitle: "Run migrations",
 			},
 			{
 				ID:          "wE:p2",
-				Dir:         "/Users/dev/work/dashboard",
+				Dir:         dashboard,
 				Agent:       "claude",
 				AgentStatus: herdr.AgentStatusWorking,
 				AgentTitle:  "Implement OAuth scopes",
@@ -176,7 +176,7 @@ func TestAnAgentTabDoesNotRepeatItsOwnDirectory(t *testing.T) {
 	// the activity says what the context already does. The agent's name in
 	// front of it must not hide that.
 	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "dashboard",
 		Agent:         "claude",
 		AgentStatus:   herdr.AgentStatusWorking,
@@ -197,7 +197,7 @@ func hiddenAgentChain() *Deterministic {
 
 func TestAHiddenAgentNameLeavesTheWorkAlone(t *testing.T) {
 	got := hiddenAgentChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:         "/Users/dev/work/dashboard",
+		Dir:         dashboard,
 		Agent:       "claude",
 		AgentStatus: herdr.AgentStatusWorking,
 		AgentTitle:  "Implement OAuth scopes",
@@ -212,7 +212,7 @@ func TestAHiddenAgentNameIsAlsoStrippedFromTheWork(t *testing.T) {
 	// An agent that signs its terminal title must not smuggle its name back in
 	// as text once the name itself is turned off.
 	got := hiddenAgentChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "Claude — Implement OAuth scopes",
 		Agent:         "claude",
 		AgentStatus:   herdr.AgentStatusWorking,
@@ -227,7 +227,7 @@ func TestASilentAgentHiddenLeavesTheTabToItsDirectory(t *testing.T) {
 	// The name is the whole title of a pane whose agent has reported nothing,
 	// so turning it off has to leave that tab named like any other.
 	pane := &state.PaneState{
-		Dir:         "/Users/dev/work/dashboard",
+		Dir:         dashboard,
 		Agent:       "claude",
 		AgentStatus: herdr.AgentStatusWorking,
 	}
@@ -256,7 +256,7 @@ func TestAHiddenAgentNameKeepsAWorkspaceDirectory(t *testing.T) {
 	// The workspace is dropped only when something else is left to read, and a
 	// name that is about to be hidden is not something else.
 	tab := tabWithPane(&state.PaneState{
-		Dir:         "/Users/dev/work/dashboard",
+		Dir:         dashboard,
 		Agent:       "claude",
 		AgentStatus: herdr.AgentStatusWorking,
 	})

--- a/internal/resolver/cwd.go
+++ b/internal/resolver/cwd.go
@@ -3,6 +3,8 @@ package resolver
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
@@ -54,7 +56,7 @@ func (c CWD) base(dir string) string {
 		return ""
 	}
 
-	if c.home != "" && clean == c.home {
+	if c.home != "" && sameDir(clean, c.home) {
 		return ""
 	}
 
@@ -65,4 +67,14 @@ func (c CWD) base(dir string) string {
 	}
 
 	return base
+}
+
+// sameDir compares two clean paths the way the platform does: on Windows a
+// path spelled in another case is the same directory.
+func sameDir(a, b string) bool {
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+
+	return a == b
 }

--- a/internal/resolver/generic.go
+++ b/internal/resolver/generic.go
@@ -40,6 +40,11 @@ var uriPattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*://`)
 // already says, and never what the user is doing.
 var promptPattern = regexp.MustCompile(`^[^\s@]+@[^\s@:]+:\S*$`)
 
+// fallbackTitlePattern matches the title Herdr gives a Windows pane whose
+// program has set none: `pwsh in dashboard`, which names the shell and where
+// it is, and the context already says where.
+var fallbackTitlePattern = regexp.MustCompile(`^(\S+) in .+$`)
+
 // punctuation wraps and joins words inside titles such as
 // `Makefile (~/work/dashboard) - Nvim`.
 const punctuation = `()[]{}<>"'` + ",;:-–—|"
@@ -48,7 +53,12 @@ const punctuation = `()[]{}<>"'` + ",;:-–—|"
 // anything useful survived: `auth.ts (~/work/src) - Nvim` keeps `auth.ts -
 // Nvim`, while a bare `~` leaves nothing.
 func Meaningful(value string) (string, bool) {
-	cleaned := stripLocations(strings.TrimSpace(value))
+	trimmed := strings.TrimSpace(value)
+	if isFallbackTitle(trimmed) {
+		return "", false
+	}
+
+	cleaned := stripLocations(trimmed)
 	if cleaned == "" {
 		return "", false
 	}
@@ -82,15 +92,36 @@ func stripLocations(value string) string {
 	return tidy(kept)
 }
 
+// isFallbackTitle reports a title that only says which shell sits where. The
+// check runs before locations are stripped, because the place can be one.
+func isFallbackTitle(value string) bool {
+	match := fallbackTitlePattern.FindStringSubmatch(value)
+
+	return match != nil && isGeneric(strings.ToLower(match[1]))
+}
+
 func isLocation(word string) bool {
 	switch {
-	case word == "~", strings.HasPrefix(word, "~/"):
+	case word == "~", strings.HasPrefix(word, "~/"), strings.HasPrefix(word, `~\`):
 		return true
-	case strings.HasPrefix(word, "/"):
+	case strings.HasPrefix(word, "/"), strings.HasPrefix(word, `\\`):
+		return true
+	case isDrivePath(word):
 		return true
 	default:
 		return uriPattern.MatchString(word)
 	}
+}
+
+// isDrivePath reports a path rooted on a Windows drive, `C:\work` or `C:/work`.
+func isDrivePath(word string) bool {
+	if len(word) < 3 || word[1] != ':' || (word[2] != '\\' && word[2] != '/') {
+		return false
+	}
+
+	letter := word[0] | 0x20
+
+	return letter >= 'a' && letter <= 'z'
 }
 
 // tidy joins words back together, dropping the punctuation that only made sense

--- a/internal/resolver/generic_test.go
+++ b/internal/resolver/generic_test.go
@@ -27,6 +27,9 @@ func TestMeaningful(t *testing.T) {
 		{"korn shell", "ksh", "", false},
 		{"c shell", "csh", "", false},
 		{"the login shell", "login", "", false},
+		{"the windows shells", "pwsh", "", false},
+		{"the older windows shell", "PowerShell", "", false},
+		{"the oldest windows shell", "cmd", "", false},
 		{"multi-word program name", "Claude Code", "", false},
 		{"runtime name", "node", "", false},
 		{"surrounded by whitespace", "  bash  ", "", false},
@@ -37,6 +40,29 @@ func TestMeaningful(t *testing.T) {
 		{"home directory", "~", "", false},
 		{"abbreviated path", "~/W/herdr-auto-title", "", false},
 		{"absolute path", "/Users/dev/work/dashboard", "", false},
+		{"windows path", `C:\Users\dev\work\dashboard`, "", false},
+		{"windows path with forward slashes", "C:/Users/dev/work/dashboard", "", false},
+		{"windows home path", `~\work\dashboard`, "", false},
+		{"unc path", `\\build-01\share\dashboard`, "", false},
+		{"drive letter alone is not a path", "C:", "C:", true},
+
+		// Herdr's own title for a Windows pane whose program has set none. It
+		// names the shell and the directory, and neither is what the user is
+		// doing there.
+		{"herdr's title for an idle windows pane", "pwsh in dashboard", "", false},
+		{"the same under cmd", "cmd in herdr-auto-title", "", false},
+		{"the same in the home directory", "pwsh in ~", "", false},
+		{
+			"work that happens to be in something",
+			"Fix login in dashboard",
+			"Fix login in dashboard",
+			true,
+		},
+		{
+			"editor title carrying a windows path",
+			`auth.ts (C:\Users\dev\work\dashboard) - Nvim`,
+			"auth.ts - Nvim", true,
+		},
 
 		// Every one of these was observed on a live session.
 		{

--- a/internal/resolver/git_test.go
+++ b/internal/resolver/git_test.go
@@ -12,7 +12,7 @@ import (
 // origin/HEAD naming defaultBranch.
 func repoPane(branch, defaultBranch string) *state.PaneState {
 	return &state.PaneState{
-		Dir: "/Users/dev/work/dashboard",
+		Dir: dashboard,
 		Git: git.Checkout{Branch: branch, Default: defaultBranch},
 	}
 }
@@ -67,7 +67,7 @@ func TestARepositoryWithNoRecordedTrunkAlwaysShowsItsBranch(t *testing.T) {
 
 func TestADetachedHeadShowsTheCommit(t *testing.T) {
 	pane := &state.PaneState{
-		Dir: "/Users/dev/work/dashboard",
+		Dir: dashboard,
 		Git: git.Checkout{Commit: "a1b2c3d", Default: "main"},
 	}
 

--- a/internal/resolver/position_test.go
+++ b/internal/resolver/position_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rivo/uniseg"
 
+	"github.com/kryptamine/herdr-auto-title/internal/herdr/herdrtest"
 	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
 
@@ -30,9 +31,9 @@ func TestPositionLeadsTheTitle(t *testing.T) {
 		dir      string
 		want     string
 	}{
-		{"the first tab", 1, "/Users/dev/work/dashboard", "1 · dashboard"},
-		{"a tab past the ninth", 12, "/Users/dev/work/dashboard", "12 · dashboard"},
-		{"a tab with nothing to say", 3, "/", "3 · " + GenericFallback},
+		{"the first tab", 1, dashboard, "1 · dashboard"},
+		{"a tab past the ninth", 12, dashboard, "12 · dashboard"},
+		{"a tab with nothing to say", 3, herdrtest.Root(), "3 · " + GenericFallback},
 	}
 
 	for _, tc := range tests {
@@ -45,7 +46,7 @@ func TestPositionLeadsTheTitle(t *testing.T) {
 }
 
 func TestPositionKeepsTheDecisionItWraps(t *testing.T) {
-	got := numberedCWD(DefaultMaxLength).Resolve(atPosition(1, "/Users/dev/work/dashboard"))
+	got := numberedCWD(DefaultMaxLength).Resolve(atPosition(1, dashboard))
 	if got.Reason != "cwd" {
 		t.Errorf("reason = %q, want cwd", got.Reason)
 	}
@@ -58,7 +59,7 @@ func TestPositionKeepsTheDecisionItWraps(t *testing.T) {
 func TestAPositionIsCountedAgainstTheWidth(t *testing.T) {
 	const maxLength = 16
 
-	long := "/Users/dev/work/" + strings.Repeat("a", 40)
+	long := herdrtest.Dir("work", strings.Repeat("a", 40))
 
 	got := numberedCWD(maxLength).Resolve(atPosition(7, long))
 	if width := uniseg.StringWidth(got.Name); width > maxLength {
@@ -73,7 +74,7 @@ func TestAPositionIsCountedAgainstTheWidth(t *testing.T) {
 // A tab bar narrower than the position itself keeps the name over the number:
 // a title cut down to nothing has lost more than the position is worth.
 func TestAPositionWithNoRoomIsDropped(t *testing.T) {
-	got := numberedCWD(3).Resolve(atPosition(10, "/Users/dev/work/dashboard"))
+	got := numberedCWD(3).Resolve(atPosition(10, dashboard))
 	if got.Name != "das" {
 		t.Errorf("name = %q, want the bare title", got.Name)
 	}
@@ -82,7 +83,7 @@ func TestAPositionWithNoRoomIsDropped(t *testing.T) {
 func TestNumberedWithoutAWidthTakesTheDefault(t *testing.T) {
 	// Zero means "no bound" to Sanitize but would leave no room at all here,
 	// so every tab would quietly lose the position instead.
-	got := NewNumbered(New(Options{}, NewCWD()), 0).Resolve(atPosition(2, "/Users/dev/work/api"))
+	got := NewNumbered(New(Options{}, NewCWD()), 0).Resolve(atPosition(2, api))
 	if got.Name != "2 · api" {
 		t.Errorf("name = %q, want the position kept", got.Name)
 	}
@@ -105,7 +106,7 @@ func TestAnyResolverCanBeNumbered(t *testing.T) {
 		Reason:     "test_source",
 	}}
 
-	got := NewNumbered(inner, DefaultMaxLength).Resolve(atPosition(4, "/Users/dev/work/api"))
+	got := NewNumbered(inner, DefaultMaxLength).Resolve(atPosition(4, api))
 	want := Decision{
 		Name:       "4 · release notes",
 		Confidence: ConfidenceAgent,
@@ -122,7 +123,7 @@ func TestAnyResolverCanBeNumbered(t *testing.T) {
 func TestANumberedTitleLeavesNoDanglingSeparator(t *testing.T) {
 	inner := fixedResolver{decision: Decision{Name: "dashboard › nvim"}}
 
-	got := NewNumbered(inner, 16).Resolve(atPosition(1, "/Users/dev/work/dashboard"))
+	got := NewNumbered(inner, 16).Resolve(atPosition(1, dashboard))
 	if got.Name != "1 · dashboard" {
 		t.Errorf("name = %q, want %q", got.Name, "1 · dashboard")
 	}

--- a/internal/resolver/process.go
+++ b/internal/resolver/process.go
@@ -7,10 +7,11 @@ import (
 )
 
 // shellNames are the programs that run in a pane without being what the pane is
-// for. A pane running a shell is described by what the shell is running.
+// for. A pane running a shell is described by what the shell is running. The
+// last three are Windows shells, spelled without the `.exe` Windows reports.
 var shellNames = map[string]struct{}{
 	"bash": {}, "zsh": {}, "fish": {}, "sh": {}, "dash": {}, "ksh": {},
-	"tcsh": {}, "csh": {}, "login": {},
+	"tcsh": {}, "csh": {}, "login": {}, "pwsh": {}, "powershell": {}, "cmd": {},
 }
 
 // paneKind names what a pane is running, or "" when that cannot be said. The

--- a/internal/resolver/process_test.go
+++ b/internal/resolver/process_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"testing"
 
+	"github.com/kryptamine/herdr-auto-title/internal/herdr/herdrtest"
 	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
 
@@ -19,7 +20,7 @@ func running(names ...string) []state.Process {
 func TestTheKindQualifiesTheTitle(t *testing.T) {
 	// The editor names itself in its own title; under the kind that is noise.
 	pane := &state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "auth.provider.ts - Nvim",
 		Processes:     running("nvim"),
 	}
@@ -33,7 +34,7 @@ func TestTheKindQualifiesTheTitle(t *testing.T) {
 func TestAKindWithNothingToAddStandsAlone(t *testing.T) {
 	// Neovim showing a file manager titles the window after itself alone.
 	pane := &state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "Nvim",
 		Processes:     running("nvim"),
 	}
@@ -45,7 +46,7 @@ func TestAKindWithNothingToAddStandsAlone(t *testing.T) {
 }
 
 func TestAKindWithNoTitleAtAllStillNamesThePane(t *testing.T) {
-	pane := &state.PaneState{Dir: "/Users/dev/work/dashboard", Processes: running("htop")}
+	pane := &state.PaneState{Dir: dashboard, Processes: running("htop")}
 
 	got := defaultChain().Resolve(tabWithPane(pane))
 	if want := "dashboard › htop"; got.Name != want {
@@ -91,7 +92,7 @@ func TestARemoteSessionIsNotNamedTwice(t *testing.T) {
 	// ssh is marked on the host, where the mark cannot be outranked. Repeating
 	// it in the activity would read `ssh › prod-01 › ssh`.
 	pane := &state.PaneState{
-		Dir:       "/Users/dev/work/dashboard",
+		Dir:       dashboard,
 		Processes: []state.Process{{Name: "ssh", Args: []string{"ssh", "prod-01"}}},
 	}
 
@@ -125,7 +126,7 @@ func TestAProjectNeverTakesAColon(t *testing.T) {
 	// The rule the format rests on: a colon binds a kind to its detail, and a
 	// project is a place rather than a kind.
 	pane := &state.PaneState{
-		Dir:           "/Users/dev/work/self-care-portal",
+		Dir:           herdrtest.Dir("work", "self-care-portal"),
 		TerminalTitle: "yarn dev",
 		Processes:     running("esbuild", "node", "node"),
 	}
@@ -141,7 +142,7 @@ func TestAnAgentIsItsOwnKind(t *testing.T) {
 	// agent shows up as a caffeinate, several nodes and an MCP helper, with its
 	// own name nowhere among them.
 	pane := &state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "Git email configuration",
 		Agent:         "claude",
 		Processes:     running("caffeinate", "node", "node", "fff-mcp"),
@@ -161,7 +162,7 @@ func TestAStartingAgentIsNamedByItsKindAlone(t *testing.T) {
 	// Claude Code titles its window after itself until the conversation has a
 	// subject. That is generic as an activity, and exactly right as a kind.
 	pane := &state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "Claude Code",
 		Agent:         "claude",
 	}
@@ -173,7 +174,7 @@ func TestAStartingAgentIsNamedByItsKindAlone(t *testing.T) {
 }
 
 func TestAPaneWithoutAnAgentIsNotNamedAfterOne(t *testing.T) {
-	pane := &state.PaneState{Dir: "/Users/dev/work/dashboard", TerminalTitle: "Claude Code"}
+	pane := &state.PaneState{Dir: dashboard, TerminalTitle: "Claude Code"}
 
 	if got := defaultChain().Resolve(tabWithPane(pane)); got.Name != "dashboard" {
 		t.Errorf("name = %q, want dashboard", got.Name)

--- a/internal/resolver/process_test.go
+++ b/internal/resolver/process_test.go
@@ -180,3 +180,16 @@ func TestAPaneWithoutAnAgentIsNotNamedAfterOne(t *testing.T) {
 		t.Errorf("name = %q, want dashboard", got.Name)
 	}
 }
+
+func TestAWindowsShellIsNotWhatAPaneIsFor(t *testing.T) {
+	// The shells Windows panes run, spelled as they arrive once the extension
+	// is gone: a pane running one is described by its directory, like any
+	// other shell's.
+	for _, shell := range []string{"pwsh", "powershell", "cmd"} {
+		pane := &state.PaneState{Dir: dashboard, Processes: running(shell)}
+
+		if got := defaultChain().Resolve(tabWithPane(pane)); got.Name != "dashboard" {
+			t.Errorf("%s pane = %q, want dashboard", shell, got.Name)
+		}
+	}
+}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -301,6 +302,22 @@ func TestSourcesAreOrderedByConfidenceNotByArgument(t *testing.T) {
 
 func TestTheShippedChainResolvesATabWithNoPanes(t *testing.T) {
 	got := defaultChain().Resolve(state.TabState{ID: "wE:t1"})
+	if got.Name != GenericFallback {
+		t.Errorf("name = %q, want %q", got.Name, GenericFallback)
+	}
+}
+
+func TestTheHomeDirectoryIsMatchedTheWayWindowsSpellsIt(t *testing.T) {
+	// A Windows path names the same directory in any case, and a pane sitting
+	// in the home directory must yield nothing whichever case it arrived in.
+	if runtime.GOOS != "windows" {
+		t.Skip("only Windows compares paths without regard to case")
+	}
+
+	home := t.TempDir()
+	r := New(Options{MaxLength: DefaultMaxLength}, CWD{home: filepath.Clean(home)})
+
+	got := r.Resolve(tabWithCWD(strings.ToUpper(home)))
 	if got.Name != GenericFallback {
 		t.Errorf("name = %q, want %q", got.Name, GenericFallback)
 	}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -7,7 +7,15 @@ import (
 	"testing"
 
 	"github.com/kryptamine/herdr-auto-title/internal/herdr"
+	"github.com/kryptamine/herdr-auto-title/internal/herdr/herdrtest"
 	"github.com/kryptamine/herdr-auto-title/internal/state"
+)
+
+// The directories the fixtures sit in, absolute on whichever platform the
+// tests run on: a relative directory names no tab, and Windows has no /Users.
+var (
+	dashboard = herdrtest.Dir("work", "dashboard")
+	api       = herdrtest.Dir("work", "api")
 )
 
 func defaultChain() *Deterministic {
@@ -34,16 +42,16 @@ func TestResolveFromCWD(t *testing.T) {
 		want       string
 		wantReason string
 	}{
-		{"project directory becomes the title", "/Users/dev/work/dashboard", "dashboard", "cwd"},
+		{"project directory becomes the title", dashboard, "dashboard", "cwd"},
 		{
 			"nested directory uses its own basename",
-			"/Users/dev/work/dashboard/src/api",
+			herdrtest.Dir("work", "dashboard", "src", "api"),
 			"api",
 			"cwd",
 		},
-		{"trailing slash is ignored", "/Users/dev/work/dashboard/", "dashboard", "cwd"},
+		{"trailing slash is ignored", dashboard + string(filepath.Separator), "dashboard", "cwd"},
 		{"home directory falls back", home, GenericFallback, "generic_fallback"},
-		{"filesystem root falls back", "/", GenericFallback, "generic_fallback"},
+		{"filesystem root falls back", herdrtest.Root(), GenericFallback, "generic_fallback"},
 		{"relative path falls back", "work/dashboard", GenericFallback, "generic_fallback"},
 		{"empty path falls back", "", GenericFallback, "generic_fallback"},
 	}
@@ -67,7 +75,7 @@ func TestResolveNamesATabAfterItsDirectory(t *testing.T) {
 	tab := state.TabState{
 		ID: "wE:t1",
 		Panes: []*state.PaneState{
-			{ID: "wE:p1", Dir: "/Users/dev/work/api", Focused: true},
+			{ID: "wE:p1", Dir: api, Focused: true},
 		},
 	}
 
@@ -89,7 +97,7 @@ func TestResolveTruncatesToMaxLength(t *testing.T) {
 	long := strings.Repeat("x", 100)
 	r := New(Options{MaxLength: 10}, NewCWD())
 
-	got := r.Resolve(tabWithCWD("/Users/dev/" + long))
+	got := r.Resolve(tabWithCWD(herdrtest.Dir(long)))
 	if len([]rune(got.Name)) != 10 {
 		t.Errorf("name %q has %d runes, want 10", got.Name, len([]rune(got.Name)))
 	}
@@ -98,9 +106,9 @@ func TestResolveTruncatesToMaxLength(t *testing.T) {
 func TestResolveIsDeterministic(t *testing.T) {
 	r := New(Options{MaxLength: DefaultMaxLength}, NewCWD())
 	panes := []*state.PaneState{
-		{ID: "wE:p1", Dir: "/Users/dev/work/dashboard"},
-		{ID: "wE:p2", Dir: "/Users/dev/work/api"},
-		{ID: "wE:p3", Dir: "/Users/dev/work/infra"},
+		{ID: "wE:p1", Dir: dashboard},
+		{ID: "wE:p2", Dir: api},
+		{ID: "wE:p3", Dir: herdrtest.Dir("work", "infra")},
 	}
 
 	// The same panes in whichever order a snapshot listed them must name the
@@ -135,7 +143,7 @@ func TestHigherPrioritySourceSuppliesActivity(t *testing.T) {
 		NewCWD(),
 	)
 
-	got := r.Resolve(tabWithCWD("/Users/dev/work/dashboard"))
+	got := r.Resolve(tabWithCWD(dashboard))
 	if got.Name != "dashboard › Tests" {
 		t.Errorf("name = %q, want %q", got.Name, "dashboard › Tests")
 	}
@@ -161,7 +169,7 @@ func TestHigherPrioritySourceOverridesContext(t *testing.T) {
 		NewCWD(),
 	)
 
-	got := r.Resolve(tabWithCWD("/Users/dev/work/dashboard"))
+	got := r.Resolve(tabWithCWD(dashboard))
 	if got.Name != "prod-01 › SSH" {
 		t.Errorf("name = %q, want %q", got.Name, "prod-01 › SSH")
 	}
@@ -173,7 +181,7 @@ func TestSourceThatDeclinesIsSkipped(t *testing.T) {
 		NewCWD(),
 	)
 
-	got := r.Resolve(tabWithCWD("/Users/dev/work/dashboard"))
+	got := r.Resolve(tabWithCWD(dashboard))
 	if got.Name != "dashboard" || got.Reason != "cwd" {
 		t.Errorf("decision = %+v, want dashboard via cwd", got)
 	}
@@ -183,7 +191,7 @@ func TestATabDoesNotRepeatItsWorkspace(t *testing.T) {
 	// Herdr shows the workspace above its tabs, so a tab in the workspace it is
 	// named after spends half its width saying what is already on screen.
 	tab := tabWithPane(&state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "Fix OAuth redirect",
 	})
 	tab.WorkspaceName = "dashboard"
@@ -197,7 +205,7 @@ func TestATabDoesNotRepeatItsWorkspace(t *testing.T) {
 func TestATabWithNothingElseKeepsItsContext(t *testing.T) {
 	// Dropping it here would leave the tab with no name at all, which loses
 	// more than it saves.
-	tab := tabWithPane(&state.PaneState{Dir: "/Users/dev/work/dashboard"})
+	tab := tabWithPane(&state.PaneState{Dir: dashboard})
 	tab.WorkspaceName = "dashboard"
 
 	got := defaultChain().Resolve(tab)
@@ -210,7 +218,7 @@ func TestADifferentWorkspaceIsNotDropped(t *testing.T) {
 	// A tab whose directory left its workspace behind is exactly the tab that
 	// needs to say where it is.
 	tab := tabWithPane(&state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "Fix OAuth redirect",
 	})
 	tab.WorkspaceName = "api"
@@ -224,7 +232,7 @@ func TestADifferentWorkspaceIsNotDropped(t *testing.T) {
 func TestAWorkspaceWithoutAName(t *testing.T) {
 	// An unnamed workspace must not make every context look like a repeat.
 	tab := tabWithPane(&state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "Fix OAuth redirect",
 	})
 

--- a/internal/resolver/ssh_test.go
+++ b/internal/resolver/ssh_test.go
@@ -7,14 +7,11 @@ import (
 	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
 
-// paneCWD is the directory every ssh pane in these tests sits in.
-const paneCWD = "/Users/dev/work/dashboard"
-
 // sshPane builds a pane running the given ssh command line, beside the shell
 // that started it — which is how Herdr reports a pane's processes.
 func sshPane(argv ...string) *state.PaneState {
 	return &state.PaneState{
-		Dir: paneCWD,
+		Dir: dashboard,
 		Processes: []state.Process{
 			{Name: "fish", Args: []string{"-fish"}},
 			{Name: "ssh", Args: argv},
@@ -146,7 +143,7 @@ func TestAValueSpelledNIsNotTheTunnelSwitch(t *testing.T) {
 
 func TestAPaneWithoutSSHIsUnaffected(t *testing.T) {
 	pane := &state.PaneState{
-		Dir: "/Users/dev/work/dashboard",
+		Dir: dashboard,
 		Processes: []state.Process{
 			{Name: "fish", Args: []string{"-fish"}},
 			{Name: "nvim", Args: []string{"nvim"}},
@@ -163,7 +160,7 @@ func TestSSHIsFoundAmongOtherProcesses(t *testing.T) {
 	// Herdr lists the foreground process and its descendants, so ssh can be
 	// anywhere in the list.
 	pane := &state.PaneState{
-		Dir: "/Users/dev/work/dashboard",
+		Dir: dashboard,
 		Processes: []state.Process{
 			{Name: "fish", Args: []string{"-fish"}},
 			{Name: "ssh", Args: []string{"ssh", "prod-01"}},

--- a/internal/resolver/terminal_test.go
+++ b/internal/resolver/terminal_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kryptamine/herdr-auto-title/internal/herdr/herdrtest"
 	"github.com/kryptamine/herdr-auto-title/internal/state"
 )
 
@@ -20,7 +21,7 @@ func tabWithPane(pane *state.PaneState) state.TabState {
 
 func TestTerminalTitleBeatsTheWorkingDirectory(t *testing.T) {
 	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "Fix OAuth redirect",
 	}))
 
@@ -42,7 +43,7 @@ func TestGenericTerminalTitleFallsThrough(t *testing.T) {
 	for _, title := range []string{"zsh", "Claude Code", "node", "~", "~/W/dashboard", ""} {
 		t.Run(title, func(t *testing.T) {
 			got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-				Dir:           "/Users/dev/work/dashboard",
+				Dir:           dashboard,
 				TerminalTitle: title,
 			}))
 
@@ -59,7 +60,7 @@ func TestGenericTerminalTitleFallsThrough(t *testing.T) {
 
 func TestTerminalTitleFallsBackToTheRawField(t *testing.T) {
 	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:              "/Users/dev/work/dashboard",
+		Dir:              dashboard,
 		TerminalTitleRaw: "\x1b[32m✳ Fix OAuth redirect\x1b[0m",
 	}))
 
@@ -71,7 +72,7 @@ func TestTerminalTitleFallsBackToTheRawField(t *testing.T) {
 
 func TestStrippedTerminalTitleWinsOverTheRawOne(t *testing.T) {
 	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:              "/Users/dev/work/dashboard",
+		Dir:              dashboard,
 		TerminalTitle:    "Fix OAuth redirect",
 		TerminalTitleRaw: "◐ Fix OAuth redirect",
 	}))
@@ -83,7 +84,7 @@ func TestStrippedTerminalTitleWinsOverTheRawOne(t *testing.T) {
 
 func TestTerminalTitleIsSanitized(t *testing.T) {
 	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "\x1b[31mFix OAuth\nredirect\x1b[0m\t",
 	}))
 
@@ -94,7 +95,7 @@ func TestTerminalTitleIsSanitized(t *testing.T) {
 
 func TestLongTerminalTitleIsTruncatedAsAWhole(t *testing.T) {
 	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: strings.Repeat("long ", 40),
 	}))
 
@@ -120,7 +121,7 @@ func TestTerminalTitleWithoutAWorkingDirectory(t *testing.T) {
 
 func TestTerminalTitleRepeatingTheContextIsDropped(t *testing.T) {
 	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "Dashboard",
 	}))
 
@@ -168,7 +169,7 @@ func TestEditorTitleKeepsTheFileAndDropsThePath(t *testing.T) {
 			got := Default(
 				Options{MaxLength: wide, BranchMax: DefaultBranchMaxLength},
 			).Resolve(tabWithPane(&state.PaneState{
-				Dir:           "/Users/dev/Work/herdr-auto-title",
+				Dir:           herdrtest.Dir("Work", "herdr-auto-title"),
 				TerminalTitle: tc.title,
 			}))
 

--- a/internal/resolver/transcript_test.go
+++ b/internal/resolver/transcript_test.go
@@ -11,7 +11,7 @@ func TestATopicNamesATabTheTerminalTitleCannot(t *testing.T) {
 	// The session that motivated the source: the agent never titled its
 	// terminal, so without the transcript the tab is just `claude`.
 	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "Claude Code",
 		Agent:         "claude",
 		AgentStatus:   "idle",
@@ -34,7 +34,7 @@ func TestATopicNamesATabTheTerminalTitleCannot(t *testing.T) {
 func TestATerminalTitleOutranksTheTranscript(t *testing.T) {
 	// Both say what the session is about, and the agent says it sooner.
 	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:           "/Users/dev/work/dashboard",
+		Dir:           dashboard,
 		TerminalTitle: "Fix OAuth redirect",
 		Agent:         "claude",
 		AgentStatus:   herdr.AgentStatusWorking,
@@ -54,7 +54,7 @@ func TestATopicWithoutAnAgentIsIgnored(t *testing.T) {
 	// A pane whose agent Herdr no longer recognizes keeps whatever was read of
 	// its session, and that is no longer what the pane is doing.
 	if _, ok := NewTranscript().Resolve(&state.PaneState{
-		Dir:        "/Users/dev/work/dashboard",
+		Dir:        dashboard,
 		AgentTopic: "grill-me",
 	}); ok {
 		t.Error("the transcript source claimed a pane with no agent")
@@ -63,7 +63,7 @@ func TestATopicWithoutAnAgentIsIgnored(t *testing.T) {
 
 func TestATopicThatNamesTheAgentFallsThrough(t *testing.T) {
 	got := defaultChain().Resolve(tabWithPane(&state.PaneState{
-		Dir:         "/Users/dev/work/dashboard",
+		Dir:         dashboard,
 		Agent:       "claude",
 		AgentStatus: "idle",
 		AgentTopic:  "Claude Code",

--- a/internal/state/tab.go
+++ b/internal/state/tab.go
@@ -3,6 +3,7 @@
 package state
 
 import (
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -64,7 +65,7 @@ type Process struct {
 // the directory it is in is the pane's. A read saying nothing leaves guess.
 func PaneDir(processes []herdr.PaneProcessInfoProcess, guess string) string {
 	if last := len(processes) - 1; last >= 0 && processes[last].CWD != "" {
-		return processes[last].CWD
+		return cleanDir(processes[last].CWD)
 	}
 
 	return guess
@@ -75,10 +76,21 @@ func PaneDir(processes []herdr.PaneProcessInfoProcess, guess string) string {
 // is preferred — but it is a descendant's, and only PaneDir is exact.
 func snapshotDir(info herdr.PaneInfo) string {
 	if info.ForegroundCWD != "" {
-		return info.ForegroundCWD
+		return cleanDir(info.ForegroundCWD)
 	}
 
-	return info.CWD
+	return cleanDir(info.CWD)
+}
+
+// cleanDir is a reported directory as filepath.Clean spells it, the trailing
+// separator Windows adds gone. "" stays "": a pane without a directory is real,
+// and Clean would spell it ".".
+func cleanDir(dir string) string {
+	if dir == "" {
+		return ""
+	}
+
+	return filepath.Clean(dir)
 }
 
 // PaneFrom builds pane context from a snapshot entry and when a poll last saw

--- a/internal/state/tab.go
+++ b/internal/state/tab.go
@@ -110,10 +110,22 @@ func ProcessesFrom(processes []herdr.PaneProcessInfoProcess) []Process {
 
 	out := make([]Process, 0, len(processes))
 	for _, p := range processes {
-		out = append(out, Process{Name: p.Name, Args: p.Argv})
+		out = append(out, Process{Name: programName(p.Name), Args: p.Argv})
 	}
 
 	return out
+}
+
+// exeSuffix is what Windows spells a program name with, and it says nothing
+// about the program: `pwsh.exe` is the shell every other platform calls pwsh.
+const exeSuffix = ".exe"
+
+func programName(name string) string {
+	if len(name) > len(exeSuffix) && strings.EqualFold(name[len(name)-len(exeSuffix):], exeSuffix) {
+		return name[:len(name)-len(exeSuffix)]
+	}
+
+	return name
 }
 
 // HasAgent reports whether Herdr recognizes an agent in the pane.

--- a/internal/state/tab_test.go
+++ b/internal/state/tab_test.go
@@ -247,6 +247,20 @@ func TestPaneDirTakesTheForegroundProcessesOwnDirectory(t *testing.T) {
 	}
 }
 
+func TestAProcessIsNamedWithoutItsWindowsExtension(t *testing.T) {
+	// Windows reports `pwsh.exe` where every other platform reports `pwsh`,
+	// and the extension would keep a shell from being read as one.
+	processes := ProcessesFrom([]herdr.PaneProcessInfoProcess{
+		{Name: "pwsh.exe"}, {Name: "claude.EXE"}, {Name: "nvim"}, {Name: ".exe"},
+	})
+
+	for i, want := range []string{"pwsh", "claude", "nvim", ".exe"} {
+		if processes[i].Name != want {
+			t.Errorf("process %d = %q, want %q", i, processes[i].Name, want)
+		}
+	}
+}
+
 func TestPaneDirKeepsTheSnapshotsGuessWhenItLearnsNone(t *testing.T) {
 	if dir := PaneDir(nil, "/work/api"); dir != "/work/api" {
 		t.Errorf("dir = %q for an unread pane, want the snapshot's", dir)

--- a/internal/state/tab_test.go
+++ b/internal/state/tab_test.go
@@ -1,10 +1,12 @@
 package state
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/kryptamine/herdr-auto-title/internal/herdr"
+	"github.com/kryptamine/herdr-auto-title/internal/herdr/herdrtest"
 )
 
 func TestSelectContextPanePrefersFocused(t *testing.T) {
@@ -208,17 +210,19 @@ func TestAgentIsActiveOnANilPane(t *testing.T) {
 func TestPaneFromPrefersTheForegroundDirectory(t *testing.T) {
 	// A subshell — `chezmoi cd`, `nix develop` — moves the foreground process
 	// and leaves the pane's own shell where it was started.
+	dashboard, chezmoi := herdrtest.Dir("work", "dashboard"), herdrtest.Dir("work", "chezmoi")
+
 	both := PaneFrom(herdr.PaneInfo{
-		PaneID: "wE:p1", CWD: "/work/dashboard", ForegroundCWD: "/work/chezmoi",
+		PaneID: "wE:p1", CWD: dashboard, ForegroundCWD: chezmoi,
 	}, time.Time{})
-	if both.Dir != "/work/chezmoi" {
+	if both.Dir != chezmoi {
 		t.Errorf("dir = %q, want the foreground process's", both.Dir)
 	}
 
-	shell := PaneFrom(herdr.PaneInfo{
-		PaneID: "wE:p1", CWD: "/work/api",
-	}, time.Time{})
-	if shell.Dir != "/work/api" {
+	api := herdrtest.Dir("work", "api")
+
+	shell := PaneFrom(herdr.PaneInfo{PaneID: "wE:p1", CWD: api}, time.Time{})
+	if shell.Dir != api {
 		t.Errorf("dir = %q, want the shell's own", shell.Dir)
 	}
 }
@@ -226,19 +230,20 @@ func TestPaneFromPrefersTheForegroundDirectory(t *testing.T) {
 func TestPaneDirTakesTheForegroundProcessesOwnDirectory(t *testing.T) {
 	// A snapshot reports the deepest descendant's directory, which for an agent
 	// is a server it spawned. The process list is deepest first.
+	server, portal := herdrtest.Dir("opt", "gimp-mcp"), herdrtest.Dir("work", "self-care-portal")
 	processes := []herdr.PaneProcessInfoProcess{
-		{Name: "gimp-mcp", CWD: "/opt/gimp-mcp"},
-		{Name: "claude", CWD: "/work/self-care-portal"},
+		{Name: "gimp-mcp", CWD: server},
+		{Name: "claude", CWD: portal},
 	}
 
 	pane := PaneFrom(herdr.PaneInfo{
 		PaneID: "wE:p1", Agent: "claude",
-		CWD: "/work/dashboard", ForegroundCWD: "/opt/gimp-mcp",
+		CWD: herdrtest.Dir("work", "dashboard"), ForegroundCWD: server,
 	}, time.Time{})
 	pane.Dir = PaneDir(processes, pane.Dir)
 	pane.Processes = ProcessesFrom(processes)
 
-	if pane.Dir != "/work/self-care-portal" {
+	if pane.Dir != portal {
 		t.Errorf("dir = %q, want the foreground process's own", pane.Dir)
 	}
 
@@ -258,6 +263,28 @@ func TestAProcessIsNamedWithoutItsWindowsExtension(t *testing.T) {
 		if processes[i].Name != want {
 			t.Errorf("process %d = %q, want %q", i, processes[i].Name, want)
 		}
+	}
+}
+
+func TestAPaneDirectoryIsCleanedAsItArrives(t *testing.T) {
+	// Windows reports a directory with a trailing separator, which no reader
+	// of Dir should have to know; a pane without one keeps "" rather than the
+	// "." filepath.Clean would make of it.
+	dir := herdrtest.Dir("work", "dashboard")
+	trailing := dir + string(filepath.Separator)
+
+	pane := PaneFrom(herdr.PaneInfo{PaneID: "wE:p1", CWD: trailing}, time.Time{})
+	if pane.Dir != dir {
+		t.Errorf("dir = %q from the snapshot, want %q", pane.Dir, dir)
+	}
+
+	read := []herdr.PaneProcessInfoProcess{{Name: "pwsh.exe", CWD: trailing}}
+	if got := PaneDir(read, ""); got != dir {
+		t.Errorf("dir = %q from a process read, want %q", got, dir)
+	}
+
+	if none := PaneFrom(herdr.PaneInfo{PaneID: "wE:p2"}, time.Time{}); none.Dir != "" {
+		t.Errorf("dir = %q for a pane without one, want it empty", none.Dir)
 	}
 }
 


### PR DESCRIPTION
## What this changes

Auto Title runs on Windows. The one thing that stood in the way was the
transport: on Windows `HERDR_SOCKET_PATH` names a 25-byte text file rather
than a socket, and Herdr listens on the named pipe `\\.\pipe\` + that whole
path, so the Unix dial was refused. The client now opens that pipe on Windows,
with no new dependency, and keeps the Unix dial everywhere else. Around it:
the fixtures take their directories from `herdrtest.Dir` so they are absolute
on every platform, process names lose the `.exe` Windows spells them with,
pwsh/PowerShell/cmd count as shells, Herdr's own idle-pane title
`pwsh in <dir>` is refused as a shell prompt is, drive-rooted paths are
stripped from titles, the manifest claims `windows` with a build and startup
entry of its own, and CI runs the suite on Windows.

Probed on Herdr 0.8.2-preview (protocol 22), recorded in
`docs/architecture/herdr-socket-api.md` and `AGENTS.md`: the pipe name, that
`pane.process_info` on Windows lists only the pane's shell or a recognized
agent (a `python.exe` or `node.exe` child is not listed, so the process and
ssh sources go quiet there), that names carry `.exe` and directories a
trailing backslash, and that `Set-Location` in pwsh is tracked through
Herdr's prompt hook.

Closes #55

## How it was checked

- `go vet`, `go build`, `golangci-lint` and `go test -race` on Windows
  (Go 1.26.3), `go vet`/`go build` on the Go 1.24.0 floor, and `go vet` for
  linux and darwin. `make` is not in Git Bash, so the recipes ran by hand.
- The client tests on Windows talk to a named pipe server of their own, so
  the transport the plugin ships is the one the suite exercises.
- Linked the checkout into a live Windows Herdr: the server started
  `herdr-auto-title.exe` through `[[startup]]`, every tab was named over the
  pipe, a `Set-Location` renamed its tab within a poll, a manual rename was
  left alone, and a Claude Code session with a generic terminal title was
  named from its transcript under `%USERPROFILE%\.claude`.

## Before merging

- [x] `make check` is green locally.
- [x] One logical change per commit, Conventional Commits, no co-author
      trailer. **PRs are rebased, never squashed or merged**, so the commit
      messages are what lands in the history and in the changelog.
- [x] Tests land with the behaviour they cover.
- [x] `CHANGELOG.md`, the tags and the version in `herdr-plugin.toml` are
      untouched — they belong to release-please.
- [x] A probe that taught something new is recorded in `AGENTS.md` and in
      `docs/architecture/herdr-socket-api.md`.
- [x] This pull request is one thing.
