### PR TITLE
fix: leave when another server takes the socket

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,13 @@ are only the facts that would otherwise mislead the code in silence.
   shell of whoever installed it, which is why `HERDR_AUTO_TITLE_*` settings
   arrive through `config.env` (see
   [docs/architecture/configuration.md](docs/architecture/configuration.md)).
+- **Herdr keeps no handle on a plugin it started.** A startup hook is spawned
+  and forgotten: the server stops nothing when it stops, and runs the hooks
+  again at every start and live handoff, so an instance that stayed would run
+  beside its successor and lock the tabs the two name differently.
+  `App.superseded` is what makes it leave instead; the loop must not survive
+  a change of server (see
+  [docs/architecture/poll-loop.md](docs/architecture/poll-loop.md)).
 
 ## Working here
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ herdr plugin install kryptamine/herdr-auto-title
 
 Herdr clones the repository, builds the binary and registers it. Until the
 server has restarted, nothing is renamed. `herdr plugin list` shows the plugin,
-`herdr plugin disable` turns it off.
+`herdr plugin disable` turns it off. Every server start brings a fresh instance,
+and the one the previous server started leaves on its own.
 
 ### Better names for agent tabs
 

--- a/docs/architecture/herdr-socket-api.md
+++ b/docs/architecture/herdr-socket-api.md
@@ -64,6 +64,20 @@ exists here.
 > `herdr server stop`, which closes the session. The directory and the two CLI
 > commands were confirmed directly. Auto Title depends on none of it.
 
+**A startup hook is run and forgotten.** In the Herdr source,
+`start_plugin_command` (`src/app/api/plugins/runtime.rs`) spawns the command
+and waits on it in a thread of its own, keeping no handle; server shutdown
+(`complete_shutdown`, `src/server/headless/lifecycle.rs`) closes clients and
+removes the socket files and touches no plugin process; and
+`run_plugin_startup_hooks` runs from both server entry points
+(`src/server/headless/bootstrap.rs`), a fresh start and a live handoff import.
+What tells one server from the next is the socket file itself, the test Herdr
+uses to decide whether a socket file is its own (`socket_file_identity`,
+`src/ipc.rs`): on macOS and Linux the socket's device and inode, new with every
+bind; on Windows the file's content, `<pid>:<unix nanoseconds>` written when
+the pipe is bound. `Client.Server` reads it, and [the poll loop](./poll-loop.md)
+leaves when it changes.
+
 ## The methods Auto Title uses
 
 Three, and no others (`internal/herdr/session.go`):

--- a/docs/architecture/poll-loop.md
+++ b/docs/architecture/poll-loop.md
@@ -169,17 +169,47 @@ recovery is the first dial that succeeds.
   the way out says how many polls were missed.
 
 The only failure that stops the process is a missing `HERDR_SOCKET_PATH`, caught
-in `herdr.New` before the loop is ever entered.
+in `herdr.New` before the loop is ever entered. What else ends a run is not a
+failure at all: another server on the socket, below.
 
 Measured on a live session: with the socket removed for eight seconds the
 process stayed up and polls resumed the moment it returned; started with no
 socket at all, it stayed up for ten seconds on five warnings and named every tab
 as soon as the socket appeared.
 
+## A successor on the socket
+
+Herdr starts a plugin through a one-shot startup hook and forgets it. Read from
+the Herdr source: `start_plugin_command` in `src/app/api/plugins/runtime.rs`
+spawns the command and only waits on it, keeping no handle; `complete_shutdown`
+in `src/server/headless/lifecycle.rs` closes clients and removes the socket
+files, and touches no plugin process; and `src/server/headless/bootstrap.rs`
+calls `run_plugin_startup_hooks` from both of its entry points, a fresh start
+and a live handoff import. So a server that stops leaves its Auto Title
+running, and the next server starts one of its own.
+
+Two instances are worse than one. Both dial the same socket, and when they
+disagree — after a settings change, the old one still runs the old
+configuration — each reads the other's rename as the user's and locks the tab
+(see [manual rename protection](./manual-rename-protection.md)).
+
+So each instance knows which server it answers to, and leaves when that
+changes. `Client.Server` reads the socket's identity the way Herdr itself tells
+its own socket from a successor's (`socket_file_identity` in `src/ipc.rs`): on
+macOS and Linux the socket file's device and inode, which a fresh bind renews;
+on Windows the marker Herdr writes into the socket file when it binds the pipe,
+its pid and start time. `App.superseded` records the first identity a poll can
+read and ends the run on the first poll that reads a different one. An
+unreadable identity decides nothing: the socket is gone while Herdr is down and
+can be a moment late at startup, and neither is a successor. The process exits
+with status 0, because the successor's own startup hook has already started the
+instance that replaces it.
+
 ## Shutdown
 
 `signal.NotifyContext` in `cmd/herdr-auto-title/main.go` cancels the context on
-`SIGINT` and `SIGTERM`; `Run` returns and the process exits. There are no
+`SIGINT` and `SIGTERM`; `Run` returns and the process exits, as it does when a
+successor takes the socket. There are no
 debounce timers to cancel and no socket to close, because a connection never
 outlives the call that made it.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -28,6 +28,10 @@ type App struct {
 	// failures is the run of polls that have failed in a row, which decides
 	// how loudly the next one is reported.
 	failures failureLog
+	// server identifies the Herdr this instance answers to, learned from the
+	// first poll that could read it. Another server on the socket has started
+	// an instance of its own, and this one leaves rather than double it.
+	server string
 }
 
 // New builds the application. The client belongs to Run rather than to the
@@ -50,7 +54,9 @@ func New(cfg Config, log *slog.Logger, titles resolver.TitleResolver) *App {
 // docs/architecture/poll-loop.md.
 func (a *App) Run(ctx context.Context, client herdr.Client) {
 	// Name what already exists before waiting for the first tick.
-	a.poll(ctx, client)
+	if !a.poll(ctx, client) {
+		return
+	}
 
 	ticker := time.NewTicker(a.pollEvery)
 	defer ticker.Stop()
@@ -61,18 +67,25 @@ func (a *App) Run(ctx context.Context, client herdr.Client) {
 			a.log.Info("shutting down")
 			return
 		case <-ticker.C:
-			a.poll(ctx, client)
+			if !a.poll(ctx, client) {
+				return
+			}
 		}
 	}
 }
 
-// poll is one turn of the loop. No failure is fatal, the first one included: a
-// plugin that gave up would stay dead, and Herdr's socket can be a moment
-// behind the process it just launched.
-func (a *App) poll(ctx context.Context, client herdr.Client) {
+// poll is one turn of the loop, and reports whether there should be another.
+// No failure is fatal — Herdr's socket can lag the process it just launched —
+// but another server on the socket ends the run: docs/architecture/poll-loop.md.
+func (a *App) poll(ctx context.Context, client herdr.Client) bool {
+	if a.superseded(client) {
+		a.log.Info("another server holds the socket and starts an auto title of its own, leaving")
+		return false
+	}
+
 	err := a.readAndRename(ctx, client)
 	if ctx.Err() != nil {
-		return
+		return true
 	}
 
 	if err != nil {
@@ -80,11 +93,30 @@ func (a *App) poll(ctx context.Context, client herdr.Client) {
 			a.log.Warn("poll failed", "error", err, "in a row", run)
 		}
 
-		return
+		return true
 	}
 
 	if run := a.failures.recovered(); run > 0 {
 		a.log.Info("the session is answering again", "polls missed", run)
+	}
+
+	return true
+}
+
+// superseded reports whether the socket has passed to a server other than the
+// one this instance first saw. While no server can be read nothing is decided:
+// Herdr comes and goes, and only a successor is a reason to leave.
+func (a *App) superseded(client herdr.Client) bool {
+	current := client.Server()
+
+	switch {
+	case current == "":
+		return false
+	case a.server == "":
+		a.server = current
+		return false
+	default:
+		return current != a.server
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -81,11 +81,12 @@ func startConfigured(t *testing.T, client *herdrtest.Client, cfg Config) *harnes
 }
 
 // poll runs the step the ticker runs, its failure handling included, so a test
-// exercises what the loop does rather than a shortcut past it.
-func (h *harness) poll() {
+// exercises what the loop does rather than a shortcut past it. It reports what
+// the step reports: whether the loop would go on.
+func (h *harness) poll() bool {
 	h.t.Helper()
 
-	h.app.poll(context.Background(), h.client)
+	return h.app.poll(context.Background(), h.client)
 }
 
 func (h *harness) polls(n int) {
@@ -284,6 +285,101 @@ func TestAFailedPollIsFollowedByAWorkingOne(t *testing.T) {
 
 	if got := h.client.Renames()[1].Label; got != "api" {
 		t.Errorf("rename = %q, want api", got)
+	}
+}
+
+func TestAnotherServerOnTheSocketEndsTheRun(t *testing.T) {
+	// Herdr neither stops a startup process when it stops nor looks for one
+	// when it starts, so the instance an earlier server started would double
+	// the new one's, and lock every tab the two named differently.
+	h := start(
+		t,
+		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		[]herdr.PaneInfo{
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
+		},
+	)
+	if !h.poll() {
+		t.Fatal("the first poll ended the run")
+	}
+
+	h.client.SetServer("")
+
+	if !h.poll() {
+		t.Fatal("a poll with no server on the socket ended the run")
+	}
+
+	h.client.SetServer("herdrtest")
+
+	if !h.poll() {
+		t.Fatal("the same server back on the socket ended the run")
+	}
+
+	h.client.SetServer("successor")
+
+	if h.poll() {
+		t.Error("a successor on the socket did not end the run")
+	}
+}
+
+func TestTheServerIsLearnedFromTheFirstPollThatSeesOne(t *testing.T) {
+	// A startup hook can outrun the socket, so the first poll may find no
+	// server; the one that then appears is this instance's own, not a successor.
+	h := start(
+		t,
+		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		[]herdr.PaneInfo{
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
+		},
+	)
+	h.client.SetServer("")
+	h.polls(3)
+
+	h.client.SetServer("herdrtest")
+
+	if !h.poll() {
+		t.Fatal("the first server seen ended the run")
+	}
+
+	h.client.SetServer("successor")
+
+	if h.poll() {
+		t.Error("a successor on the socket did not end the run")
+	}
+}
+
+func TestRunReturnsWhenAnotherServerTakesTheSocket(t *testing.T) {
+	client := herdrtest.New(
+		[]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}},
+		[]herdr.PaneInfo{
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
+		},
+	)
+
+	cfg := testConfig()
+	cfg.Poll = time.Millisecond
+	app := New(cfg, discardLogger(), testResolver(t))
+
+	done := make(chan struct{})
+
+	go func() { app.Run(t.Context(), client); close(done) }()
+
+	// The first poll has to learn the server before a successor can be one.
+	deadline := time.Now().Add(2 * time.Second)
+	for len(client.Renames()) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("nothing was named in two seconds")
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+
+	client.SetServer("successor")
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within two seconds of another server taking the socket")
 	}
 }
 

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -18,6 +18,9 @@ type Client interface {
 	// Call issues one request and decodes its result into result, which may be
 	// nil when the caller does not need it.
 	Call(ctx context.Context, method string, params any, result any) error
+	// Server identifies the server holding the socket, or is "" while none
+	// does. It changes when another server binds the path.
+	Server() string
 }
 
 // SocketClient speaks NDJSON to the Herdr socket. Herdr closes the connection
@@ -52,6 +55,13 @@ func New() (*SocketClient, error) {
 
 func newWithPath(path string) *SocketClient {
 	return &SocketClient{path: path}
+}
+
+// Server reads the socket's identity the way Herdr tells its own socket from a
+// successor's: the socket file's device and inode, or on Windows the marker
+// written into the file. It performs no request.
+func (c *SocketClient) Server() string {
+	return serverIdentity(c.path)
 }
 
 // Call sends one request on a connection of its own and reads the single

--- a/internal/herdr/herdrtest/stub.go
+++ b/internal/herdr/herdrtest/stub.go
@@ -45,6 +45,7 @@ type Client struct {
 	processErr error
 	callErr    error
 	reads      int
+	server     string
 }
 
 var _ herdr.Client = (*Client)(nil)
@@ -54,6 +55,7 @@ func New(tabs []herdr.TabInfo, panes []herdr.PaneInfo) *Client {
 		tabs:      make(map[string]herdr.TabInfo, len(tabs)),
 		panes:     make(map[string]herdr.PaneInfo, len(panes)),
 		processes: make(map[string][]herdr.PaneProcessInfoProcess),
+		server:    "herdrtest",
 	}
 	for _, tab := range tabs {
 		s.tabs[tab.TabID] = tab
@@ -64,6 +66,22 @@ func New(tabs []herdr.TabInfo, panes []herdr.PaneInfo) *Client {
 	}
 
 	return s
+}
+
+// SetServer changes which server the stub reports on the socket: "" for none,
+// another name for a successor.
+func (s *Client) SetServer(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.server = id
+}
+
+func (s *Client) Server() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.server
 }
 
 func (s *Client) SetWorkspaces(workspaces ...herdr.WorkspaceInfo) {

--- a/internal/herdr/server_unix.go
+++ b/internal/herdr/server_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package herdr
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// serverIdentity is the socket file's device and inode. A server binding the
+// path creates the file anew, so a successor's differs from its predecessor's,
+// and "" says no server holds the path.
+func serverIdentity(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return ""
+	}
+
+	return fmt.Sprintf("%d:%d", stat.Dev, stat.Ino)
+}

--- a/internal/herdr/server_unix_test.go
+++ b/internal/herdr/server_unix_test.go
@@ -1,0 +1,45 @@
+//go:build !windows
+
+package herdr
+
+import (
+	"net"
+	"os"
+	"testing"
+)
+
+func TestAServerIsToldByTheSocketFileItBound(t *testing.T) {
+	ln, path := listen(t)
+
+	before := serverIdentity(path)
+	if before == "" {
+		t.Fatal("no identity for a bound socket")
+	}
+
+	if again := serverIdentity(path); again != before {
+		t.Errorf("identity = %q on a second read, want %q", again, before)
+	}
+
+	// The successor binds the path anew. The old file is kept aside rather
+	// than removed, so the two identities cannot share a recycled inode.
+	if err := os.Rename(path, path+".old"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	ln.close()
+
+	if got := serverIdentity(path); got != "" {
+		t.Errorf("identity = %q with the socket gone, want none", got)
+	}
+
+	successor, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen again on %s: %v", path, err)
+	}
+
+	defer successor.Close()
+
+	if after := serverIdentity(path); after == "" || after == before {
+		t.Errorf("identity = %q after a rebind, want one other than %q", after, before)
+	}
+}

--- a/internal/herdr/server_windows.go
+++ b/internal/herdr/server_windows.go
@@ -1,0 +1,16 @@
+package herdr
+
+import "os"
+
+// serverIdentity is the marker Herdr writes into the socket file when it binds
+// the pipe, its pid and start time, so a successor's differs from its
+// predecessor's; "" says no server holds the path.
+func serverIdentity(path string) string {
+	//nolint:gosec // the path is HERDR_SOCKET_PATH, never terminal-derived
+	marker, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+
+	return string(marker)
+}

--- a/internal/herdr/server_windows_test.go
+++ b/internal/herdr/server_windows_test.go
@@ -1,0 +1,36 @@
+package herdr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAServerIsToldByTheMarkerItWrote(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "herdr.sock")
+
+	if got := serverIdentity(path); got != "" {
+		t.Errorf("identity = %q with no marker, want none", got)
+	}
+
+	write := func(marker string) {
+		t.Helper()
+
+		if err := os.WriteFile(path, []byte(marker), 0o600); err != nil {
+			t.Fatalf("write marker: %v", err)
+		}
+	}
+
+	write("4242:1700000000000000000")
+
+	before := serverIdentity(path)
+	if before != "4242:1700000000000000000" {
+		t.Fatalf("identity = %q, want the marker as written", before)
+	}
+
+	write("4343:1700000000000000001")
+
+	if after := serverIdentity(path); after == before {
+		t.Errorf("identity = %q after a successor wrote its marker, want another", after)
+	}
+}


### PR DESCRIPTION
## What this changes

An instance of Auto Title now leaves when another server takes the socket.
Herdr starts a plugin through a one-shot startup hook and keeps no handle on
it, so a server that stops leaves the process running and the next server
starts a process of its own, at a fresh start and after a live handoff alike;
the two then rename against each other, and once their settings differ each
takes the other's rename for the user's and locks the tab. `Client.Server`
reads the socket's identity the way Herdr tells its own socket from a
successor's (`socket_file_identity` in `src/ipc.rs`): the socket file's device
and inode on macOS and Linux, the `<pid>:<start ns>` marker Herdr writes into
the file on Windows. The loop records the first identity a poll can read and
ends the run on the first poll that reads a different one, exit status 0, since
the successor's startup hook has already started the replacement. An
unreadable identity decides nothing, so an outage or a slow start is still a
run of failed polls, as before. The Herdr code paths this rests on are cited
in `docs/architecture/poll-loop.md` and `herdr-socket-api.md`.

Closes #57

## How it was checked

- Rebased onto `main` after #56 landed: `gofmt`, `go vet`, `golangci-lint`
  and the whole suite under `go test -race` on Windows, plus `go vet` for
  linux and darwin and on the Go 1.24.0 floor. The fork's CI ran the same
  branch on every job, Windows included: https://github.com/recih/herdr-auto-title/actions/runs/34199495704
- The identity read is tested against a real socket on macOS and Linux — a
  rebind at the same path, with the old file kept aside so a recycled inode
  cannot fake a match — and against the marker file on Windows.
- Live, in a throwaway session (`herdr --session at-probe server`): the
  previous build stayed after the server was stopped and started again; this
  build kept polling through the outage and, once the new server was up,
  logged that another server held the socket and left within one poll.

## Before merging

- [x] `make check` is green locally (its recipes run by hand: Git Bash on
      Windows ships no `make`).
- [x] One logical change per commit, Conventional Commits, no co-author
      trailer. **PRs are rebased, never squashed or merged**, so the commit
      messages are what lands in the history and in the changelog.
- [x] Tests land with the behaviour they cover.
- [x] `CHANGELOG.md`, the tags and the version in `herdr-plugin.toml` are
      untouched — they belong to release-please.
- [x] A probe that taught something new is recorded in `AGENTS.md` and in
      `docs/architecture/herdr-socket-api.md`.
- [x] This pull request is one thing.
