### PR TITLE
docs: list contributors in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,8 @@ restarts**, with the same `herdr server stop` the install needs.
   a tab becomes a name, where configuration comes from, and the measured facts
   about the Herdr socket API.
 - [Development](docs/development.md) — working on it.
+
+## Contributors
+
+<a href="https://github.com/recih"><img src="https://github.com/recih.png?size=64" width="64" alt="recih"></a>
+<a href="https://github.com/bartekbp"><img src="https://github.com/bartekbp.png?size=64" width="64" alt="Bartosz Polnik"></a>


### PR DESCRIPTION
Adds a Contributors section at the end of the README, with avatars linking to each profile. Names and order come from the repository's contributor list; the release bot is left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjsgGZmSWUYUykgxT1TUzV