### PR TITLE
fix(resolver): do not repeat a branch its worktree is named after

### DIFF
--- a/docs/architecture/title-resolution.md
+++ b/docs/architecture/title-resolution.md
@@ -279,6 +279,18 @@ is how Windows spells one, and Herdr's own title for an idle pane there,
 `pwsh in dashboard`, is refused as a shell prompt is: it names the shell and
 the directory the context already names.
 
+## A worktree does not say its branch twice
+
+`git worktree add ../feat-oauth feat-oauth` makes a directory and a branch of
+the same name, and the two are one fact rather than two: the title would read
+`feat-oauth › feat-oauth › nvim`. The branch is dropped when it matches the
+directory exactly, because the directory leads the title and the branch only
+qualifies it.
+
+Exactly, and no more than that — the rule below makes the same trade. A worktree
+whose directory spells its branch differently (`xl-knp-3` against `xl-knp.3`)
+keeps both, because nothing here can tell a near-miss from two real facts.
+
 ## The workspace is not repeated
 
 Herdr shows the workspace above its tabs, so a tab in the workspace it is named

--- a/internal/resolver/git_test.go
+++ b/internal/resolver/git_test.go
@@ -116,6 +116,18 @@ func TestABranchIsNotShownForARemoteMachine(t *testing.T) {
 	}
 }
 
+func TestAWorktreeNamedAfterItsBranchSaysItOnce(t *testing.T) {
+	// `git worktree add ../dashboard dashboard` makes a directory and a branch
+	// of the same name, and the two are one fact rather than two.
+	pane := repoPane("dashboard", "main")
+	pane.TerminalTitle = "auth.ts - Nvim"
+	pane.Processes = []state.Process{{Name: "nvim"}}
+
+	if got := resolveRepoPane(pane); got != "dashboard › nvim › auth.ts" {
+		t.Errorf("title %q, want the branch said once", got)
+	}
+}
+
 func TestTheBranchSurvivesTheWorkspaceItRepeats(t *testing.T) {
 	// Herdr shows the workspace above the tabs, so the directory goes — but
 	// the branch is exactly what tells two tabs of that workspace apart.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -279,6 +279,13 @@ func withoutRepetition(parts Parts, workspace string) Parts {
 		parts.Activity = ""
 	}
 
+	// A worktree is usually named after the branch checked out in it, so
+	// `git worktree add ../feat-oauth feat-oauth` would otherwise produce
+	// `feat-oauth › feat-oauth`. The directory leads, so the branch goes.
+	if parts.Branch != "" && strings.EqualFold(parts.Branch, parts.Context) {
+		parts.Branch = ""
+	}
+
 	// Herdr shows the workspace above its tabs, so repeating it wastes half the
 	// width. Dropped only when something else remains: a branch counts, and so
 	// does an agent's name, which by here is gone if it is not to be shown.


### PR DESCRIPTION
## The problem

`git worktree add ../feat-oauth feat-oauth` makes a directory and a branch of the same name. `withoutRepetition` compares the activity against the context and against the branch, but never the context against the branch, so the title reads:

```
feat-oauth › feat-oauth › nvim
```

A third of the tab bar spent on the word it has just said. Reproduced against a live session of six worktrees — every one of them was affected:

```
before   1 · pane-rename › pane-rename › herdr-au
after    1 · pane-rename › herdr-auto-title pane

before   1 · fix-dev › fix-tb-dev
after    1 · fix-tb-dev
```

## The fix

The directory leads a title and the branch only qualifies it, so the branch is the half that goes.

**The match is exact**, as the workspace rule below it is. A worktree whose directory spells its branch differently (`xl-knp-3` against `xl-knp.3`) keeps both, because nothing here can tell a near-miss from two real facts. That is the same trade the workspace rule already documents, so this does not widen it.

## Checks

`make check` is green — fmt, vet, golangci-lint (0 issues) and `go test -race`.

The new test fails without the change, with `pane-rename › pane-rename › claude › herdr-auto-ti`.