### PR TITLE
feat(app): name panes as well as tabs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,8 +143,12 @@ are only the facts that would otherwise mislead the code in silence.
   agent**, never an editor, a build or an ssh session running under the shell.
   Names arrive with `.exe` and a process's `cwd` with a trailing backslash; the
   state package strips both as they arrive, so no reader of a pane sees either.
-- Auto Title uses three methods and no others: `session.snapshot`,
-  `pane.process_info` and `tab.rename`.
+- Auto Title uses four methods and no others: `session.snapshot`,
+  `pane.process_info`, `tab.rename` and `pane.rename`.
+- **A pane carries no label until it has one, and an empty one clears it.**
+  Herdr omits `label` from a pane object entirely until the pane is named, and
+  `pane.rename` clears rather than stores an empty label — the opposite of
+  `tab.rename`. So a pane has one unnamed spelling and a tab has two.
 - **Do not reintroduce an event subscription.** `events.subscribe` replays
   about ten seconds of backlog per pane before anything live, with no cursor to
   skip it, so a subscriber opens by reacting to a session that is gone. A

--- a/README.md
+++ b/README.md
@@ -71,6 +71,31 @@ saying it twice: `HERDR_AUTO_TITLE_AGENT_NAME=false` leaves it out, and
 where the name was all there was — a pane whose agent has reported nothing then
 reads as its directory, `dashboard`, in place of `claude`.
 
+## Naming panes as well as tabs
+
+Herdr's goto panel (`prefix`+`g`) lists panes by their own label, falling back
+to the agent's name — so a session of Claude Code panes reads as a column of
+`claude` with nothing to pick between them. `HERDR_AUTO_TITLE_PANES=true` names
+each pane from its own directory, branch, process and agent topic, preferring
+whatever tells it from its tab:
+
+```
+pane-rename › herdr-auto-title pane      the tab, truncated
+  herdr-auto-title pane 重命名            the pane the tab speaks through
+  herdr-reviewr                          the pane doing something else
+```
+
+Where a pane is stays on the tab's row, so a pane row spends its width on what
+the pane is doing. A pane whose only fact is its directory does repeat its tab —
+which still beats the `claude` Herdr shows for a pane with no label.
+
+It is off by default for two reasons. It changes what an existing user sees,
+and it costs one `pane.process_info` read per pane per poll rather than one per
+tab — a split-heavy session pays for every split, twice a second.
+
+Renaming a pane by hand protects it exactly as renaming a tab does, and
+`herdr pane rename <PANE_ID>` with no name hands it back.
+
 ## What your tabs will be called
 
 ```
@@ -138,6 +163,7 @@ restarts**, with the same `herdr server stop` the install needs.
 | `HERDR_AUTO_TITLE_MANUAL_FILE` | `manual-names.json`, next to `config.env` | Where tabs you renamed by hand are remembered; empty keeps them in memory  |
 | `HERDR_AUTO_TITLE_TRANSCRIPT`  | `true`                                    | Read an agent's own session transcript when it has not titled its terminal |
 | `HERDR_AUTO_TITLE_AGENT_NAME`  | `true`                                    | Put the agent's name in front of what an agent pane is doing               |
+| `HERDR_AUTO_TITLE_PANES`       | `false`                                   | Name each pane as well as its tab, which is what the goto panel lists      |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ reads as its directory, `dashboard`, in place of `claude`.
 
 Herdr's goto panel (`prefix`+`g`) lists panes by their own label, falling back
 to the agent's name — so a session of Claude Code panes reads as a column of
-`claude` with nothing to pick between them. `HERDR_AUTO_TITLE_PANES=true` names
-each pane from its own directory, branch, process and agent topic, preferring
-whatever tells it from its tab:
+`claude` with nothing to pick between them. Auto Title names each pane from its
+own directory, branch, process and agent topic, preferring whatever tells it
+from its tab:
 
 ```
 pane-rename › herdr-auto-title pane      the tab, truncated
@@ -89,9 +89,12 @@ Where a pane is stays on the tab's row, so a pane row spends its width on what
 the pane is doing. A pane whose only fact is its directory does repeat its tab —
 which still beats the `claude` Herdr shows for a pane with no label.
 
-It is off by default for two reasons. It changes what an existing user sees,
-and it costs one `pane.process_info` read per pane per poll rather than one per
-tab — a split-heavy session pays for every split, twice a second.
+`HERDR_AUTO_TITLE_PANES=false` turns it off, which gives back the panel Herdr
+draws on its own and a poll that reads one pane per tab rather than every pane.
+
+> [!WARNING]
+> The first start with pane naming on renames every pane, including one you
+> labelled by hand before. From then on a pane you rename is left alone.
 
 Renaming a pane by hand protects it exactly as renaming a tab does, and
 `herdr pane rename <PANE_ID>` with no name hands it back.
@@ -163,7 +166,7 @@ restarts**, with the same `herdr server stop` the install needs.
 | `HERDR_AUTO_TITLE_MANUAL_FILE` | `manual-names.json`, next to `config.env` | Where tabs you renamed by hand are remembered; empty keeps them in memory  |
 | `HERDR_AUTO_TITLE_TRANSCRIPT`  | `true`                                    | Read an agent's own session transcript when it has not titled its terminal |
 | `HERDR_AUTO_TITLE_AGENT_NAME`  | `true`                                    | Put the agent's name in front of what an agent pane is doing               |
-| `HERDR_AUTO_TITLE_PANES`       | `false`                                   | Name each pane as well as its tab, which is what the goto panel lists      |
+| `HERDR_AUTO_TITLE_PANES`       | `true`                                    | Name each pane as well as its tab, which is what the goto panel lists      |
 
 ## Documentation
 

--- a/cmd/herdr-auto-title/main.go
+++ b/cmd/herdr-auto-title/main.go
@@ -58,7 +58,7 @@ func run() error {
 		titles = resolver.NewNumbered(chain, cfg.MaxLength)
 	}
 
-	app.New(cfg, log, titles).Run(ctx, client)
+	app.New(cfg, log, titles, chain).Run(ctx, client)
 
 	return nil
 }

--- a/cmd/herdr-auto-title/main.go
+++ b/cmd/herdr-auto-title/main.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/kryptamine/herdr-auto-title/internal/app"
 	"github.com/kryptamine/herdr-auto-title/internal/herdr"
-	"github.com/kryptamine/herdr-auto-title/internal/resolver"
 )
 
 func main() {
@@ -47,18 +46,8 @@ func run() error {
 		return err
 	}
 
-	chain := resolver.Default(resolver.Options{
-		MaxLength:     cfg.MaxLength,
-		BranchMax:     cfg.BranchMax,
-		HideAgentName: !cfg.ShowAgentName,
-	})
-
-	var titles resolver.TitleResolver = chain
-	if cfg.ShowPosition {
-		titles = resolver.NewNumbered(chain, cfg.MaxLength)
-	}
-
-	app.New(cfg, log, titles, chain).Run(ctx, client)
+	titles, panes := app.Resolvers(cfg)
+	app.New(cfg, log, titles, panes).Run(ctx, client)
 
 	return nil
 }

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -9,7 +9,7 @@ generated: { by: claude-code/opus-5, at: 2026-08-26T14:14:17+03:00 }
 
 # Configuration
 
-Every setting Auto Title has is one of eight `HERDR_AUTO_TITLE_*` variables,
+Every setting Auto Title has is one of nine `HERDR_AUTO_TITLE_*` variables,
 read in `internal/app/config.go`. They can be set in the environment, or written
 into a file that is loaded into the environment before anything reads it.
 
@@ -90,22 +90,27 @@ pair it reads into the environment, and a key Auto Title does not read simply
 has no effect. Nothing checks names against a list, so a typo is silent — the
 cost of that is one line in the README table.
 
-## Why naming panes is a setting and not the behaviour
+## Why naming panes is on by default, and still a setting
 
-Auto Title renames tabs. `HERDR_AUTO_TITLE_PANES` makes it name panes too, and
-it defaults to off for two reasons that are worth keeping separate.
+Auto Title names panes as well as tabs unless `HERDR_AUTO_TITLE_PANES=false`.
+It was first built switched off, for two reasons, and neither held up.
 
 **It changes what an existing user sees.** A pane nobody has labelled is listed
-by the agent running in it, and a user who has come to read that column as "the
-agent" would find it replaced. A setting that changes an existing display
-defaults to what the user already has.
+by the agent running in it, so a session of Claude Code panes is a column of
+`claude`. That column is the problem the feature exists for rather than a
+display anyone relies on, so the change shipped as a breaking one instead of as
+an opt-in. The one real loss is on the first start: nothing marks a pane label
+as the user's before Auto Title has watched it, so a pane labelled by hand
+before then is renamed once. After that it is protected like a tab
+([manual rename protection](./manual-rename-protection.md)).
 
-**It multiplies what a poll spends.** Naming a tab reads one pane of it — the
-one the tab speaks through — so the cost is a `pane.process_info` per tab.
-Naming panes reads every pane, so a session of four-way splits pays four times
-as much twice a second. The measured per-read cost is in
-[the socket API note](./herdr-socket-api.md); what makes it a decision rather
-than a rounding error is that it scales with how the user splits.
+**It multiplies what a poll spends.** Naming a tab reads one pane of it, so the
+cost is a `pane.process_info` per tab; naming panes reads every pane. A read is
+reused while its pane sits still and for at most `processRefresh`, so a pane
+costs between one read every two seconds and two a second. At the measured
+0.17 ms a read ([the socket API note](./herdr-socket-api.md)), twenty panes all
+busy at once cost Herdr about 7 ms a second — it scales with how the user
+splits, but from a floor too low to decide a default by.
 
 The setting decides one thing only: whether `App` holds a pane resolver at all.
 Everything below that — which pane is read, how it is named, whether the user

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -90,6 +90,27 @@ pair it reads into the environment, and a key Auto Title does not read simply
 has no effect. Nothing checks names against a list, so a typo is silent — the
 cost of that is one line in the README table.
 
+## Why naming panes is a setting and not the behaviour
+
+Auto Title renames tabs. `HERDR_AUTO_TITLE_PANES` makes it name panes too, and
+it defaults to off for two reasons that are worth keeping separate.
+
+**It changes what an existing user sees.** A pane nobody has labelled is listed
+by the agent running in it, and a user who has come to read that column as "the
+agent" would find it replaced. A setting that changes an existing display
+defaults to what the user already has.
+
+**It multiplies what a poll spends.** Naming a tab reads one pane of it — the
+one the tab speaks through — so the cost is a `pane.process_info` per tab.
+Naming panes reads every pane, so a session of four-way splits pays four times
+as much twice a second. The measured per-read cost is in
+[the socket API note](./herdr-socket-api.md); what makes it a decision rather
+than a rounding error is that it scales with how the user splits.
+
+The setting decides one thing only: whether `App` holds a pane resolver at all.
+Everything below that — which pane is read, how it is named, whether the user
+has claimed it — is the same code either way.
+
 ## Why it is not reread
 
 The file is read once. Half the settings are consumed in `main.run` while it

--- a/docs/architecture/herdr-socket-api.md
+++ b/docs/architecture/herdr-socket-api.md
@@ -116,7 +116,6 @@ or does not get said.
 workspace only, never by tab. None of them is needed while the snapshot is one
 call.
 
-
 ## Why the event stream is not used
 
 Herdr does expose an event stream, and Auto Title deliberately ignores it.

--- a/docs/architecture/herdr-socket-api.md
+++ b/docs/architecture/herdr-socket-api.md
@@ -80,7 +80,7 @@ leaves when it changes.
 
 ## The methods Auto Title uses
 
-Three, and no others (`internal/herdr/session.go`):
+Four, and no others (`internal/herdr/session.go`):
 
 - **`session.snapshot`** returns the whole session — every tab with its label,
   every pane with its directory, terminal title, agent and agent status.
@@ -100,6 +100,12 @@ Three, and no others (`internal/herdr/session.go`):
 - **`tab.rename`** takes `{tab_id, label}`. Measured at 0.16 ms median and
   0.21 ms at p95 over forty calls, against 0.99 ms for the `session.snapshot`
   preceding them. Renaming is not what limits anything.
+- **`pane.rename`** takes `{pane_id, label}` and answers with the pane. It is
+  what Herdr's goto panel lists a pane by: that panel falls back through the
+  pane's label, the agent's name, its display name, its title and finally
+  `pane N`, so a session of Claude Code panes reads as a column of `claude`
+  until something sets a label. Auto Title uses it only when asked to — see
+  [configuration](./configuration.md).
 
 A label is **one line**. `tab.rename` accepts a newline and stores it verbatim,
 with no error and no stripping, but the tab bar renders a single line and Herdr
@@ -109,6 +115,7 @@ or does not get said.
 `tab.get` and `pane.get` read one object each, and `pane.list` filters by
 workspace only, never by tab. None of them is needed while the snapshot is one
 call.
+
 
 ## Why the event stream is not used
 
@@ -240,3 +247,14 @@ reads, so this section describes Herdr rather than those types.
   was given: `herdr tab rename wG:tS ""` answered `label: ""`, and the snapshot
   reported the same. The tab bar shows the position for both. Anything reading
   the label to mean "unnamed" has to accept the empty string as well.
+- **A pane's label is absent from the wire until the pane has one.** Across a
+  seven-pane session no pane object carried `label` in `session.snapshot`,
+  `pane.get` or `pane.list`; renaming one made the key appear in all three, and
+  clearing it made the key vanish again. It decodes to `""`, which is the one
+  thing an absent label can mean — and reading it back is what makes protecting
+  a manual pane rename possible at all.
+- **A pane has one unnamed shape where a tab has two.** `pane.rename` *clears*
+  an empty label rather than storing it: both `{"pane_id": p}` with no label and
+  `{"pane_id": p, "label": ""}` answered with the `label` key gone. So clearing
+  a pane's name is the whole of the gesture that hands it back, and there is no
+  position spelling to accept beside it.

--- a/docs/architecture/herdr-socket-api.md
+++ b/docs/architecture/herdr-socket-api.md
@@ -104,8 +104,8 @@ Four, and no others (`internal/herdr/session.go`):
   what Herdr's goto panel lists a pane by: that panel falls back through the
   pane's label, the agent's name, its display name, its title and finally
   `pane N`, so a session of Claude Code panes reads as a column of `claude`
-  until something sets a label. Auto Title uses it only when asked to — see
-  [configuration](./configuration.md).
+  until something sets a label. Auto Title uses it unless pane naming is turned
+  off — see [configuration](./configuration.md).
 
 A label is **one line**. `tab.rename` accepts a newline and stores it verbatim,
 with no error and no stripping, but the tab bar renders a single line and Herdr

--- a/docs/architecture/manual-rename-protection.md
+++ b/docs/architecture/manual-rename-protection.md
@@ -9,7 +9,8 @@ generated: { by: claude-code/opus-5, at: 2026-08-25T12:46:22+03:00 }
 
 # Manual Rename Protection
 
-Rename a tab yourself and Auto Title leaves it alone from then on.
+Rename a tab yourself and Auto Title leaves it alone from then on. The same
+holds for a pane, once pane naming is turned on.
 
 There is nothing to correlate a rename with. The plugin polls rather than
 subscribing, so a rename is not an event that arrives but **a label that has
@@ -119,6 +120,33 @@ in memory and the file is rewritten from them.
 
 A `reset` subcommand talking to the running process over a control channel of
 its own is specified and not built.
+
+## Panes are protected the same way, and separately
+
+Auto Title can name panes as well as tabs
+([configuration](./configuration.md)), and a pane it names is a pane the user
+can rename back. The rule above is the same rule: `Manual` holds a set of
+claims per kind, and `ObservePane`, `AppliedPane`, `LockedPane` and
+`RetainPanes` are the tab methods over the pane set. Locks for both live in the
+same file, panes under `locked_panes`, so a store written by an older version
+reads back unchanged.
+
+Two things differ, both because Herdr labels a pane differently from a tab.
+
+**A pane has one unnamed spelling, not two.** `pane.rename` *clears* an empty
+label rather than storing it, and Herdr omits the field entirely until a pane
+has a label, so an unnamed pane is `""` and nothing else. There is no position
+to compare against and no `TabInfo.number` trap to walk into — the whole of
+`PaneSightingFrom` is the pane's id, its label and what the resolver wants.
+
+**Claiming a tab does not claim its panes.** The two are separate locks on
+purpose: naming a tab by hand says what the tab bar should read, and says
+nothing about how the panes inside it should be listed in the goto panel. A tab
+the user has taken still has its panes named, and a pane the user has taken sits
+inside a tab Auto Title goes on naming.
+
+Handing a pane back is the same gesture with one spelling: clear its label
+(`herdr pane rename <PANE_ID>`) and the next poll takes it again.
 
 ## Nothing expires
 

--- a/docs/architecture/manual-rename-protection.md
+++ b/docs/architecture/manual-rename-protection.md
@@ -21,7 +21,7 @@ changed between two polls**. The whole design follows from that, and it lives in
 
 A tab is the user's work when its label moved to something Auto Title neither
 set nor would have set. Three things are compared on every poll
-(`Manual.Observe`):
+(`Claims.Observe`):
 
 - **Current** — the label the snapshot reports.
 - **Desired** — what the resolver would name the tab right now.
@@ -32,7 +32,7 @@ Title's own work, and it is harmless either way. A label equal to *Seen* has not
 moved, so nobody did anything. Anything else moved, and whoever moved it was not
 the plugin.
 
-`Manual.Applied` records each successful rename, so the plugin's own work never
+`Claims.Applied` records each successful rename, so the plugin's own work never
 reads as the user's on the next poll.
 
 ## Two traps this design walked into
@@ -92,7 +92,7 @@ a worse surprise than the plugin briefly stopping. Locks are therefore persisted
 
 But Herdr's tab ids belong to a session, so a stored `wE:t2` may be an unrelated
 tab by the time it is read back. **A lock records the label it was taken with**
-and is released if the tab no longer carries it (`Manual.Retain`, which also
+and is released if the tab no longer carries it (`Claims.Retain`, which also
 drops everything about tabs the session no longer holds).
 
 The cost of that guard is stated plainly: **a rename made while the plugin is
@@ -125,11 +125,10 @@ its own is specified and not built.
 
 Auto Title can name panes as well as tabs
 ([configuration](./configuration.md)), and a pane it names is a pane the user
-can rename back. The rule above is the same rule: `Manual` holds a set of
-claims per kind, and `ObservePane`, `AppliedPane`, `LockedPane` and
-`RetainPanes` are the tab methods over the pane set. Locks for both live in the
-same file, panes under `locked_panes`, so a store written by an older version
-reads back unchanged.
+can rename back. The rule above is the same rule: `Manual` holds one `Claims`
+per kind, `Manual.Tabs` and `Manual.Panes`, and each runs it over ids of its own.
+Locks for both live in the same file, panes under `locked_panes`, so a store
+written by an older version reads back unchanged.
 
 Two things differ, both because Herdr labels a pane differently from a tab.
 

--- a/docs/architecture/manual-rename-protection.md
+++ b/docs/architecture/manual-rename-protection.md
@@ -10,7 +10,7 @@ generated: { by: claude-code/opus-5, at: 2026-08-25T12:46:22+03:00 }
 # Manual Rename Protection
 
 Rename a tab yourself and Auto Title leaves it alone from then on. The same
-holds for a pane, once pane naming is turned on.
+holds for a pane, which Auto Title names too unless that is turned off.
 
 There is nothing to correlate a rename with. The plugin polls rather than
 subscribing, so a rename is not an event that arrives but **a label that has

--- a/docs/architecture/poll-loop.md
+++ b/docs/architecture/poll-loop.md
@@ -157,8 +157,8 @@ requests instead of one, and a tab the user has claimed is read as well, because
 its panes are still named against it. The reads a poll has already spent are not
 spent again — the pane that named the tab is filled once, the git checkouts are
 memoized by directory, and a pane holding still keeps its last process answer —
-but the floor is one read per pane, and that is the whole reason the setting
-exists and defaults to off ([configuration](./configuration.md)).
+but the floor is one read per pane, which is why it can be turned off
+([configuration](./configuration.md)).
 
 The whole poll is bounded by `pollTimeout` (5 s). A tab that closed between the
 snapshot and its rename answers `tab_not_found`, which is expected rather than an

--- a/docs/architecture/poll-loop.md
+++ b/docs/architecture/poll-loop.md
@@ -110,21 +110,23 @@ changes name at most once per poll however fast its pane is churning, so
 
 1. `session.snapshot` — the whole session in one request.
 2. `Changes.Observe` — note which panes' revisions advanced.
-3. `Manual.Retain` — drop bookkeeping for tabs the session no longer holds,
-   and release a lock whose tab has moved on. This runs off the snapshot's own
-   labels, because it is what decides which tabs the next step can skip.
+3. `Claims.Retain`, for tabs and for panes — drop bookkeeping for what the
+   session no longer holds, and release a lock whose owner has moved on. This
+   runs off the snapshot's own labels, because it is what decides which tabs and
+   panes the next steps can skip.
 4. `tabsIn` — assemble tabs with their panes from the snapshot alone. Nothing
    is read here: assembly is what says which pane will be asked about.
 5. Per tab (`nameTab`): skip it if locked, otherwise read the one pane the tab
-   is named from (`paneReads.fill`), resolve a title, check whether the label
-   moved under us, and rename when the result differs from the label the tab
-   already carries.
-6. Per tab again (`namePanes`), and only when pane naming is on: the same five
-   steps over every pane of it, against the pane's own label. A pane with
-   nothing its tab does not already say is left unnamed.
+   is named from (`paneReads.fill`), resolve a title, then check whether the
+   label moved under us and rename when the result differs from the label the
+   tab already carries (`apply`).
+6. Per tab again (`namePanes`), and only when pane naming is on: read the tab's
+   own pane even if the tab is locked, and every pane nobody has claimed; name
+   all of them at once against the tab (`ResolvePanes`); then `apply` each name
+   against the pane's own label, exactly as step 5 does for the tab.
 
-**Only the pane that names its tab is read**, and only while its tab is
-nobody's. `pane.process_info` is asked about the panes that moved since they
+**Without pane naming, only the pane that names its tab is read**, and only
+while its tab is nobody's. `pane.process_info` is asked about the panes that moved since they
 were last read, reusing the last answer for the rest; a pane whose processes
 cannot be read simply has none, and a failed read is not remembered as an
 answer. That pane's directory is read for the branch it has checked out, every
@@ -151,11 +153,12 @@ still, issues nothing beyond the snapshot itself.
 **Naming panes turns the per-tab read into a per-pane one.** With
 `HERDR_AUTO_TITLE_PANES` on, step 6 reads every pane of every tab rather than
 the one its tab speaks through, so the four-pane tab above costs four process
-requests instead of one. The reads a poll has already spent are not spent again
-— the pane that named the tab is filled once, the git checkouts are memoized by
-directory, and a pane holding still keeps its last process answer — but the
-floor is one read per pane, and that is the whole reason the setting exists and
-defaults to off ([configuration](./configuration.md)).
+requests instead of one, and a tab the user has claimed is read as well, because
+its panes are still named against it. The reads a poll has already spent are not
+spent again — the pane that named the tab is filled once, the git checkouts are
+memoized by directory, and a pane holding still keeps its last process answer —
+but the floor is one read per pane, and that is the whole reason the setting
+exists and defaults to off ([configuration](./configuration.md)).
 
 The whole poll is bounded by `pollTimeout` (5 s). A tab that closed between the
 snapshot and its rename answers `tab_not_found`, which is expected rather than an

--- a/docs/architecture/poll-loop.md
+++ b/docs/architecture/poll-loop.md
@@ -115,10 +115,13 @@ changes name at most once per poll however fast its pane is churning, so
    labels, because it is what decides which tabs the next step can skip.
 4. `tabsIn` — assemble tabs with their panes from the snapshot alone. Nothing
    is read here: assembly is what says which pane will be asked about.
-5. Per tab: skip it if locked, otherwise read the one pane the tab is named
-   from (`paneReads.fill`), resolve a title, check whether the label moved
-   under us, and rename when the result differs from the label the tab already
-   carries.
+5. Per tab (`nameTab`): skip it if locked, otherwise read the one pane the tab
+   is named from (`paneReads.fill`), resolve a title, check whether the label
+   moved under us, and rename when the result differs from the label the tab
+   already carries.
+6. Per tab again (`namePanes`), and only when pane naming is on: the same five
+   steps over every pane of it, against the pane's own label. A pane with
+   nothing its tab does not already say is left unnamed.
 
 **Only the pane that names its tab is read**, and only while its tab is
 nobody's. `pane.process_info` is asked about the panes that moved since they
@@ -145,9 +148,18 @@ it — which is also what stops a rename from provoking the next one. A session
 where every tab already carries the right name, and whose panes are sitting
 still, issues nothing beyond the snapshot itself.
 
+**Naming panes turns the per-tab read into a per-pane one.** With
+`HERDR_AUTO_TITLE_PANES` on, step 6 reads every pane of every tab rather than
+the one its tab speaks through, so the four-pane tab above costs four process
+requests instead of one. The reads a poll has already spent are not spent again
+— the pane that named the tab is filled once, the git checkouts are memoized by
+directory, and a pane holding still keeps its last process answer — but the
+floor is one read per pane, and that is the whole reason the setting exists and
+defaults to off ([configuration](./configuration.md)).
+
 The whole poll is bounded by `pollTimeout` (5 s). A tab that closed between the
 snapshot and its rename answers `tab_not_found`, which is expected rather than an
-error.
+error; a pane that closed answers `pane_not_found` and is treated the same way.
 
 ## When Herdr is not there
 

--- a/docs/architecture/title-resolution.md
+++ b/docs/architecture/title-resolution.md
@@ -307,6 +307,41 @@ nvim`: the half that repeats goes, the half that distinguishes stays. An agent's
 name counts too, but only while it is going to be shown — which is why it is
 dropped before this runs rather than after.
 
+## A pane is named for what tells it from its tab
+
+Naming panes is off by default ([configuration](./configuration.md)). When it
+is on, the same chain names a pane, from that pane's own state rather than from
+the pane its tab speaks through — which is the point, because a tab speaks
+through one pane and the goto panel lists them all.
+
+The panel puts a pane's row **under** its tab's, so the rule of the section
+above applies again with the tab in the workspace's place: a part the tab's
+title was built from is worth less on the pane's row than a part that tells the
+two apart. A split of two agents in one repository reads
+
+```
+pane-rename › herdr-auto-title pane      the tab, truncated
+  herdr-auto-title pane 重命名            the pane the tab speaks through
+  herdr-reviewr                          the pane doing something else
+```
+
+The comparison is against what the tab was built from, **not** against the tab's
+finished title. Those differ whenever the tab dropped a part for repeating the
+workspace: the workspace is still on screen above them both, so a pane that
+picked it back up would put it there a third time.
+
+**The activity is never dropped, whatever the tab says.** Where a pane is has a
+row of its own above it; what it is doing is the whole of what a pane's row is
+for. That is why the first row above keeps its activity and loses the directory
+— and why it ends up carrying more than the tab, which had to truncate the same
+words to fit the directory in front of them.
+
+**A pane whose only fact is its directory keeps it**, and then does repeat its
+tab. There is nothing else known about such a pane, and the alternative is what
+Herdr shows for a pane with no label at all: the name of the agent in it, which
+is the same word on every row of the session and the reason this setting
+exists.
+
 ## The agent's name is optional
 
 `HERDR_AUTO_TITLE_AGENT_NAME=false` leaves the agent's name out of every title.

--- a/docs/architecture/title-resolution.md
+++ b/docs/architecture/title-resolution.md
@@ -317,7 +317,10 @@ through one pane and the goto panel lists them all.
 The panel puts a pane's row **under** its tab's, so the rule of the section
 above applies again with the tab in the workspace's place: a part the tab's
 title was built from is worth less on the pane's row than a part that tells the
-two apart. A split of two agents in one repository reads
+two apart. It is the same rule in the code too (`withoutAbove`): a title drops
+what each row shown above it carries, the workspace for a tab and then the tab
+for a pane, and keeps everything when that would leave nothing. A split of two
+agents in one repository reads
 
 ```
 pane-rename › herdr-auto-title pane      the tab, truncated
@@ -328,7 +331,10 @@ pane-rename › herdr-auto-title pane      the tab, truncated
 The comparison is against what the tab was built from, **not** against the tab's
 finished title. Those differ whenever the tab dropped a part for repeating the
 workspace: the workspace is still on screen above them both, so a pane that
-picked it back up would put it there a third time.
+picked it back up would put it there a third time. What the tab is built from is
+read from the tab's own pane, so that pane is read even when the user has claimed
+the tab — unread, it would have no branch, and whether a pane kept the branch
+would depend on the order the panes happened to be named in.
 
 **The activity is never dropped, whatever the tab says.** Where a pane is has a
 row of its own above it; what it is doing is the whole of what a pane's row is

--- a/docs/architecture/title-resolution.md
+++ b/docs/architecture/title-resolution.md
@@ -309,8 +309,8 @@ dropped before this runs rather than after.
 
 ## A pane is named for what tells it from its tab
 
-Naming panes is off by default ([configuration](./configuration.md)). When it
-is on, the same chain names a pane, from that pane's own state rather than from
+Pane naming is on unless it is turned off ([configuration](./configuration.md)).
+The same chain names a pane, from that pane's own state rather than from
 the pane its tab speaks through — which is the point, because a tab speaks
 through one pane and the goto panel lists them all.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,6 +1,6 @@
 // Package app polls the Herdr session and keeps every tab's title in step with
-// what that tab is doing, and each pane's label too where the configuration
-// asks for it.
+// what that tab is doing, and each pane's label too unless the configuration
+// turns that off.
 package app
 
 import (
@@ -24,7 +24,7 @@ type App struct {
 	log       *slog.Logger
 	titles    resolver.TitleResolver
 	// panes names each pane of a tab as well as the tab itself, and is nil
-	// unless the user asked for it.
+	// when the user turned that off.
 	panes   resolver.PaneResolver
 	changes *state.Changes
 	manual  *state.Manual
@@ -61,8 +61,8 @@ func New(
 }
 
 // Resolvers builds what the configuration asks titles to be resolved by: the
-// shipped chain, its position in front when asked, and panes named only when
-// asked.
+// shipped chain, its position in front when asked, and panes named unless that
+// is turned off.
 func Resolvers(cfg Config) (resolver.TitleResolver, resolver.PaneResolver) {
 	chain := resolver.Default(resolver.Options{
 		MaxLength:     cfg.MaxLength,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,5 +1,6 @@
 // Package app polls the Herdr session and keeps every tab's title in step with
-// what that tab is doing.
+// what that tab is doing, and each pane's label too where the configuration
+// asks for it.
 package app
 
 import (
@@ -22,9 +23,12 @@ type App struct {
 	pollEvery time.Duration
 	log       *slog.Logger
 	titles    resolver.TitleResolver
-	changes   *state.Changes
-	manual    *state.Manual
-	reads     *paneReader
+	// panes names each pane of a tab as well as the tab itself, and is nil
+	// unless the user asked for it.
+	panes   resolver.PaneResolver
+	changes *state.Changes
+	manual  *state.Manual
+	reads   *paneReader
 	// failures is the run of polls that have failed in a row, which decides
 	// how loudly the next one is reported.
 	failures failureLog
@@ -35,11 +39,17 @@ type App struct {
 }
 
 // New builds the application. The client belongs to Run rather than to the
-// App, so one App can be driven by any connection.
-func New(cfg Config, log *slog.Logger, titles resolver.TitleResolver) *App {
+// App, so one App can be driven by any connection. panes may be nil, and is
+// ignored unless the configuration asks for pane names.
+func New(
+	cfg Config,
+	log *slog.Logger,
+	titles resolver.TitleResolver,
+	panes resolver.PaneResolver,
+) *App {
 	changes := state.NewChanges()
 
-	return &App{
+	app := &App{
 		pollEvery: cfg.Poll,
 		log:       log,
 		titles:    titles,
@@ -47,6 +57,12 @@ func New(cfg Config, log *slog.Logger, titles resolver.TitleResolver) *App {
 		manual:    state.LoadManual(cfg.ManualPath),
 		reads:     newPaneReader(cfg, log, changes),
 	}
+
+	if cfg.RenamePanes {
+		app.panes = panes
+	}
+
+	return app
 }
 
 // Run polls the session until the context is cancelled. Herdr's event stream is
@@ -134,6 +150,10 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 	// what decides which of them are locked, and a locked tab is never read.
 	a.manual.Retain(labelsIn(snapshot.Tabs))
 
+	if a.panes != nil {
+		a.manual.RetainPanes(paneLabelsIn(snapshot.Panes))
+	}
+
 	tabs := a.tabsIn(snapshot)
 	reads := a.reads.forPoll(snapshot.Panes)
 
@@ -142,26 +162,8 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 			return ctx.Err()
 		}
 
-		if a.manual.Locked(tab.ID) {
-			continue
-		}
-
-		// Read here rather than during assembly: the reads are what a poll
-		// spends, and only a tab that will be renamed is worth them. The
-		// resolver picks the same pane, because the choice is made from state.
-		reads.fill(ctx, client, state.SelectContextPane(tab))
-
-		decision := a.titles.Resolve(tab)
-		if a.manual.Observe(state.SightingFrom(tab, decision.Name)) {
-			a.log.Info("leaving a tab the user renamed", "tab_id", tab.ID, "name", tab.CurrentName)
-			continue
-		}
-
-		if decision.Name == "" || decision.Name == tab.CurrentName {
-			continue
-		}
-
-		a.rename(ctx, client, tab, decision)
+		a.nameTab(ctx, client, reads, tab)
+		a.namePanes(ctx, client, reads, tab)
 	}
 
 	// Reached only when every tab was seen. Deferring this would settle after a
@@ -169,6 +171,80 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 	a.manual.Settled()
 
 	return nil
+}
+
+// nameTab keeps one tab's label in step with what the tab is doing.
+func (a *App) nameTab(
+	ctx context.Context,
+	client herdr.Client,
+	reads *paneReads,
+	tab state.TabState,
+) {
+	if a.manual.Locked(tab.ID) {
+		return
+	}
+
+	// Read here rather than during assembly: the reads are what a poll
+	// spends, and only a tab that will be renamed is worth them. The
+	// resolver picks the same pane, because the choice is made from state.
+	reads.fill(ctx, client, state.SelectContextPane(tab))
+
+	decision := a.titles.Resolve(tab)
+	if a.manual.Observe(state.SightingFrom(tab, decision.Name)) {
+		a.log.Info("leaving a tab the user renamed", "tab_id", tab.ID, "name", tab.CurrentName)
+		return
+	}
+
+	if decision.Name == "" || decision.Name == tab.CurrentName {
+		return
+	}
+
+	a.rename(ctx, client, tab, decision)
+}
+
+// namePanes labels every pane of a tab, which is what Herdr's goto panel lists
+// a pane by. It reads each pane rather than the one its tab speaks through, so
+// it costs a read per pane — see docs/architecture/poll-loop.md.
+func (a *App) namePanes(
+	ctx context.Context,
+	client herdr.Client,
+	reads *paneReads,
+	tab state.TabState,
+) {
+	if a.panes == nil {
+		return
+	}
+
+	for _, pane := range tab.Panes {
+		if ctx.Err() != nil {
+			return
+		}
+
+		if a.manual.LockedPane(pane.ID) {
+			continue
+		}
+
+		// The context pane was filled by nameTab, and filling it again costs
+		// nothing: a poll remembers every read it has already spent.
+		reads.fill(ctx, client, pane)
+
+		decision := a.panes.ResolvePane(pane, tab)
+		if a.manual.ObservePane(state.PaneSightingFrom(pane, decision.Name)) {
+			a.log.Info(
+				"leaving a pane the user renamed",
+				"pane_id", pane.ID,
+				"name", pane.CurrentName,
+			)
+
+			continue
+		}
+
+		if decision.Name == "" || decision.Name == pane.CurrentName {
+			continue
+		}
+
+		a.renamePane(ctx, client, pane, decision)
+	}
 }
 
 // rename gives the tab the name the resolver chose. Nothing that goes wrong
@@ -205,12 +281,55 @@ func (a *App) rename(
 	)
 }
 
+// renamePane gives the pane the name the resolver chose. Like a tab's rename,
+// nothing that goes wrong here is worth cutting the poll short.
+func (a *App) renamePane(
+	ctx context.Context,
+	client herdr.Client,
+	pane *state.PaneState,
+	decision resolver.Decision,
+) {
+	if err := herdr.RenamePane(ctx, client, pane.ID, decision.Name); err != nil {
+		if herdr.ErrorCode(err) == herdr.CodePaneNotFound {
+			a.log.Debug("pane closed before it could be renamed", "pane_id", pane.ID)
+			return
+		}
+
+		a.log.Warn("pane rename failed", "pane_id", pane.ID, "name", decision.Name, "error", err)
+
+		return
+	}
+
+	// Recorded before the log line so the next poll cannot read this rename as
+	// the user's.
+	a.manual.AppliedPane(pane.ID, decision.Name)
+	a.log.Info("pane renamed",
+		"pane_id", pane.ID,
+		"old", pane.CurrentName,
+		"new", decision.Name,
+		"reason", decision.Reason,
+		"confidence", decision.Confidence,
+	)
+}
+
 // labelsIn indexes the session's tabs by id for the manual-name bookkeeping,
 // which needs both an id that is gone and a label that has moved on.
 func labelsIn(tabs []herdr.TabInfo) map[string]string {
 	labels := make(map[string]string, len(tabs))
 	for _, tab := range tabs {
 		labels[tab.TabID] = tab.Label
+	}
+
+	return labels
+}
+
+// paneLabelsIn indexes the session's panes by id, for the same bookkeeping
+// labelsIn feeds. A pane Herdr has never been asked to name carries no label
+// at all, which arrives here as the empty string.
+func paneLabelsIn(panes []herdr.PaneInfo) map[string]string {
+	labels := make(map[string]string, len(panes))
+	for _, pane := range panes {
+		labels[pane.PaneID] = pane.Label
 	}
 
 	return labels

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -39,8 +39,8 @@ type App struct {
 }
 
 // New builds the application. The client belongs to Run rather than to the
-// App, so one App can be driven by any connection. panes may be nil, and is
-// ignored unless the configuration asks for pane names.
+// App, so one App can be driven by any connection. A nil panes leaves every
+// pane's label alone.
 func New(
 	cfg Config,
 	log *slog.Logger,
@@ -49,20 +49,37 @@ func New(
 ) *App {
 	changes := state.NewChanges()
 
-	app := &App{
+	return &App{
 		pollEvery: cfg.Poll,
 		log:       log,
 		titles:    titles,
+		panes:     panes,
 		changes:   changes,
 		manual:    state.LoadManual(cfg.ManualPath),
 		reads:     newPaneReader(cfg, log, changes),
 	}
+}
 
-	if cfg.RenamePanes {
-		app.panes = panes
+// Resolvers builds what the configuration asks titles to be resolved by: the
+// shipped chain, its position in front when asked, and panes named only when
+// asked.
+func Resolvers(cfg Config) (resolver.TitleResolver, resolver.PaneResolver) {
+	chain := resolver.Default(resolver.Options{
+		MaxLength:     cfg.MaxLength,
+		BranchMax:     cfg.BranchMax,
+		HideAgentName: !cfg.ShowAgentName,
+	})
+
+	var titles resolver.TitleResolver = chain
+	if cfg.ShowPosition {
+		titles = resolver.NewNumbered(chain, cfg.MaxLength)
 	}
 
-	return app
+	if !cfg.RenamePanes {
+		return titles, nil
+	}
+
+	return titles, chain
 }
 
 // Run polls the session until the context is cancelled. Herdr's event stream is
@@ -148,11 +165,8 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 	a.changes.Observe(snapshot.Panes)
 	// Taken from the snapshot rather than from the tabs below, because this is
 	// what decides which of them are locked, and a locked tab is never read.
-	a.manual.Retain(labelsIn(snapshot.Tabs))
-
-	if a.panes != nil {
-		a.manual.RetainPanes(paneLabelsIn(snapshot.Panes))
-	}
+	a.manual.Tabs.Retain(labelsIn(snapshot.Tabs))
+	a.manual.Panes.Retain(paneLabelsIn(snapshot.Panes))
 
 	tabs := a.tabsIn(snapshot)
 	reads := a.reads.forPoll(snapshot.Panes)
@@ -163,7 +177,10 @@ func (a *App) readAndRename(ctx context.Context, client herdr.Client) error {
 		}
 
 		a.nameTab(ctx, client, reads, tab)
-		a.namePanes(ctx, client, reads, tab)
+
+		if a.panes != nil {
+			a.namePanes(ctx, client, reads, tab)
+		}
 	}
 
 	// Reached only when every tab was seen. Deferring this would settle after a
@@ -180,7 +197,7 @@ func (a *App) nameTab(
 	reads *paneReads,
 	tab state.TabState,
 ) {
-	if a.manual.Locked(tab.ID) {
+	if a.manual.Tabs.Locked(tab.ID) {
 		return
 	}
 
@@ -190,16 +207,14 @@ func (a *App) nameTab(
 	reads.fill(ctx, client, state.SelectContextPane(tab))
 
 	decision := a.titles.Resolve(tab)
-	if a.manual.Observe(state.SightingFrom(tab, decision.Name)) {
-		a.log.Info("leaving a tab the user renamed", "tab_id", tab.ID, "name", tab.CurrentName)
-		return
-	}
-
-	if decision.Name == "" || decision.Name == tab.CurrentName {
-		return
-	}
-
-	a.rename(ctx, client, tab, decision)
+	a.apply(
+		ctx,
+		client,
+		tabLabels,
+		a.manual.Tabs,
+		state.SightingFrom(tab, decision.Name),
+		decision,
+	)
 }
 
 // namePanes labels every pane of a tab, which is what Herdr's goto panel lists
@@ -211,101 +226,98 @@ func (a *App) namePanes(
 	reads *paneReads,
 	tab state.TabState,
 ) {
-	if a.panes == nil {
-		return
-	}
+	// Every pane is named against the tab's own pane, which is read even when
+	// the tab is claimed; a poll never spends the same read twice.
+	reads.fill(ctx, client, state.SelectContextPane(tab))
 
 	for _, pane := range tab.Panes {
+		if !a.manual.Panes.Locked(pane.ID) {
+			reads.fill(ctx, client, pane)
+		}
+	}
+
+	for i, decision := range a.panes.ResolvePanes(tab) {
 		if ctx.Err() != nil {
 			return
 		}
 
-		if a.manual.LockedPane(pane.ID) {
+		pane := tab.Panes[i]
+		if a.manual.Panes.Locked(pane.ID) {
 			continue
 		}
 
-		// The context pane was filled by nameTab, and filling it again costs
-		// nothing: a poll remembers every read it has already spent.
-		reads.fill(ctx, client, pane)
-
-		decision := a.panes.ResolvePane(pane, tab)
-		if a.manual.ObservePane(state.PaneSightingFrom(pane, decision.Name)) {
-			a.log.Info(
-				"leaving a pane the user renamed",
-				"pane_id", pane.ID,
-				"name", pane.CurrentName,
-			)
-
-			continue
-		}
-
-		if decision.Name == "" || decision.Name == pane.CurrentName {
-			continue
-		}
-
-		a.renamePane(ctx, client, pane, decision)
+		a.apply(
+			ctx,
+			client,
+			paneLabels,
+			a.manual.Panes,
+			state.PaneSightingFrom(pane, decision.Name),
+			decision,
+		)
 	}
 }
 
-// rename gives the tab the name the resolver chose. Nothing that goes wrong
-// here is worth cutting the poll short: the next one decides again from state
-// it has read again.
-func (a *App) rename(
+// labelKind is what differs between the two things Auto Title names.
+type labelKind struct {
+	noun   string
+	rename func(ctx context.Context, c herdr.Client, id, label string) error
+	// gone is the error Herdr answers when the thing closed between the
+	// snapshot and the rename. The next poll will not see it at all.
+	gone string
+}
+
+var (
+	tabLabels = labelKind{
+		noun:   "tab",
+		rename: herdr.RenameTab,
+		gone:   herdr.CodeTabNotFound,
+	}
+	paneLabels = labelKind{
+		noun:   "pane",
+		rename: herdr.RenamePane,
+		gone:   herdr.CodePaneNotFound,
+	}
+)
+
+// apply gives a tab or a pane the name the resolver chose, unless the user put
+// the label it carries there. Nothing that goes wrong here is worth cutting the
+// poll short: the next one decides again from state it has read again.
+func (a *App) apply(
 	ctx context.Context,
 	client herdr.Client,
-	tab state.TabState,
+	kind labelKind,
+	claims *state.Claims,
+	seen state.Sighting,
 	decision resolver.Decision,
 ) {
-	if err := herdr.RenameTab(ctx, client, tab.ID, decision.Name); err != nil {
-		if herdr.ErrorCode(err) == herdr.CodeTabNotFound {
-			// The tab closed between the snapshot and the rename. The next
-			// poll will not see it at all.
-			a.log.Debug("tab closed before it could be renamed", "tab_id", tab.ID)
+	idKey := kind.noun + "_id"
+
+	if claims.Observe(seen) {
+		a.log.Info("leaving a "+kind.noun+" the user renamed", idKey, seen.ID, "name", seen.Current)
+		return
+	}
+
+	if decision.Name == "" || decision.Name == seen.Current {
+		return
+	}
+
+	if err := kind.rename(ctx, client, seen.ID, decision.Name); err != nil {
+		if herdr.ErrorCode(err) == kind.gone {
+			a.log.Debug(kind.noun+" closed before it could be renamed", idKey, seen.ID)
 			return
 		}
 
-		a.log.Warn("rename failed", "tab_id", tab.ID, "name", decision.Name, "error", err)
+		a.log.Warn(kind.noun+" rename failed", idKey, seen.ID, "name", decision.Name, "error", err)
 
 		return
 	}
 
 	// Recorded before the log line so the next poll cannot read this rename as
 	// the user's.
-	a.manual.Applied(tab.ID, decision.Name)
-	a.log.Info("tab renamed",
-		"tab_id", tab.ID,
-		"old", tab.CurrentName,
-		"new", decision.Name,
-		"reason", decision.Reason,
-		"confidence", decision.Confidence,
-	)
-}
-
-// renamePane gives the pane the name the resolver chose. Like a tab's rename,
-// nothing that goes wrong here is worth cutting the poll short.
-func (a *App) renamePane(
-	ctx context.Context,
-	client herdr.Client,
-	pane *state.PaneState,
-	decision resolver.Decision,
-) {
-	if err := herdr.RenamePane(ctx, client, pane.ID, decision.Name); err != nil {
-		if herdr.ErrorCode(err) == herdr.CodePaneNotFound {
-			a.log.Debug("pane closed before it could be renamed", "pane_id", pane.ID)
-			return
-		}
-
-		a.log.Warn("pane rename failed", "pane_id", pane.ID, "name", decision.Name, "error", err)
-
-		return
-	}
-
-	// Recorded before the log line so the next poll cannot read this rename as
-	// the user's.
-	a.manual.AppliedPane(pane.ID, decision.Name)
-	a.log.Info("pane renamed",
-		"pane_id", pane.ID,
-		"old", pane.CurrentName,
+	claims.Applied(seen.ID, decision.Name)
+	a.log.Info(kind.noun+" renamed",
+		idKey, seen.ID,
+		"old", seen.Current,
 		"new", decision.Name,
 		"reason", decision.Reason,
 		"confidence", decision.Confidence,

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -60,14 +60,19 @@ func testResolver(t *testing.T) *resolver.Deterministic {
 	})
 }
 
-// newTestApp builds an App on the shipped chain, which names a pane as well as
-// a tab. Whether it does is the configuration's to say, not the chain's.
+// newTestApp builds an App on the shipped chain, naming panes only when the
+// configuration asks for it.
 func newTestApp(t *testing.T, cfg Config) *App {
 	t.Helper()
 
 	chain := testResolver(t)
 
-	return New(cfg, discardLogger(), chain, chain)
+	var panes resolver.PaneResolver
+	if cfg.RenamePanes {
+		panes = chain
+	}
+
+	return New(cfg, discardLogger(), chain, panes)
 }
 
 // harness drives an App against a stubbed Herdr session one poll at a time, so

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -50,7 +50,7 @@ func setHome(t *testing.T, dir string) {
 // testResolver builds the shipped chain against a home directory of the test's
 // own, because CWD declines a pane sitting in the user's and the fixtures below
 // must not depend on whose machine they run on.
-func testResolver(t *testing.T) resolver.TitleResolver {
+func testResolver(t *testing.T) *resolver.Deterministic {
 	t.Helper()
 	setHome(t, filepath.Join(t.TempDir(), "home"))
 
@@ -58,6 +58,16 @@ func testResolver(t *testing.T) resolver.TitleResolver {
 		MaxLength: resolver.DefaultMaxLength,
 		BranchMax: resolver.DefaultBranchMaxLength,
 	})
+}
+
+// newTestApp builds an App on the shipped chain, which names a pane as well as
+// a tab. Whether it does is the configuration's to say, not the chain's.
+func newTestApp(t *testing.T, cfg Config) *App {
+	t.Helper()
+
+	chain := testResolver(t)
+
+	return New(cfg, discardLogger(), chain, chain)
 }
 
 // harness drives an App against a stubbed Herdr session one poll at a time, so
@@ -77,7 +87,7 @@ func start(t *testing.T, tabs []herdr.TabInfo, panes []herdr.PaneInfo) *harness 
 func startConfigured(t *testing.T, client *herdrtest.Client, cfg Config) *harness {
 	t.Helper()
 
-	return &harness{t: t, app: New(cfg, discardLogger(), testResolver(t)), client: client}
+	return &harness{t: t, app: newTestApp(t, cfg), client: client}
 }
 
 // poll runs the step the ticker runs, its failure handling included, so a test
@@ -358,7 +368,7 @@ func TestRunReturnsWhenAnotherServerTakesTheSocket(t *testing.T) {
 
 	cfg := testConfig()
 	cfg.Poll = time.Millisecond
-	app := New(cfg, discardLogger(), testResolver(t))
+	app := newTestApp(t, cfg)
 
 	done := make(chan struct{})
 
@@ -412,7 +422,7 @@ func TestRunStopsCleanlyOnCancellation(t *testing.T) {
 			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
 		},
 	)
-	app := New(testConfig(), discardLogger(), testResolver(t))
+	app := newTestApp(t, testConfig())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -947,7 +957,7 @@ func TestARepositoryIsWalkedOncePerPoll(t *testing.T) {
 	// the read. Rewriting HEAD between two panes of one poll is how the test
 	// sees that the second one never reached the disk.
 	repo := repoAt(t, "feat/oauth")
-	app := New(testConfig(), discardLogger(), testResolver(t))
+	app := newTestApp(t, testConfig())
 	ctx, client := context.Background(), herdrtest.New(nil, nil)
 
 	reads := app.reads.forPoll(nil)
@@ -983,7 +993,7 @@ func TestADirectoryHoldingNoRepositoryIsRememberedToo(t *testing.T) {
 	// Finding out that there is no repository costs the same walk to the root
 	// as finding one, so a pane outside a checkout must not repeat it per tab.
 	dir := t.TempDir()
-	app := New(testConfig(), discardLogger(), testResolver(t))
+	app := newTestApp(t, testConfig())
 	ctx, client := context.Background(), herdrtest.New(nil, nil)
 
 	reads := app.reads.forPoll(nil)
@@ -1014,7 +1024,7 @@ func TestBranchesSwitchedOffAreNotRead(t *testing.T) {
 
 	cfg := testConfig()
 	cfg.BranchMax = 0
-	app := New(cfg, discardLogger(), testResolver(t))
+	app := newTestApp(t, cfg)
 
 	pane := paneAt("wE:p1", repo)
 	app.reads.forPoll(nil).fill(context.Background(), herdrtest.New(nil, nil), pane)
@@ -1101,7 +1111,7 @@ func TestAPollPastItsDeadlineStopsReadingTheFilesystem(t *testing.T) {
 	// and a pane sitting on a hung mount blocks the whole loop for as long as
 	// the mount does. A poll the tab loop will throw away makes none of them.
 	repo := repoAt(t, "feat/oauth")
-	app := New(testConfig(), discardLogger(), testResolver(t))
+	app := newTestApp(t, testConfig())
 	client := herdrtest.New(nil, nil)
 
 	snapshot := herdr.Snapshot{
@@ -1140,7 +1150,7 @@ func TestAPaneIsReadFromItsForegroundProcessesDirectory(t *testing.T) {
 		CWD: elsewhere, ForegroundCWD: elsewhere,
 	}
 
-	app := New(testConfig(), discardLogger(), testResolver(t))
+	app := newTestApp(t, testConfig())
 	client := herdrtest.New([]herdr.TabInfo{{TabID: "wE:t1", Label: "1"}}, []herdr.PaneInfo{pane})
 	client.SetProcesses(
 		"wE:p1",
@@ -1178,7 +1188,7 @@ func TestRunNamesWhatExistsBeforeTheFirstTick(t *testing.T) {
 
 	cfg := testConfig()
 	cfg.Poll = time.Minute
-	app := New(cfg, discardLogger(), testResolver(t))
+	app := newTestApp(t, cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -63,8 +63,8 @@ type Config struct {
 	// is named like any other pane in that directory.
 	ShowAgentName bool
 	// RenamePanes names each pane as well as its tab, which is what Herdr's
-	// goto panel lists a pane by. Off by default: it costs a read per pane
-	// rather than per tab — see docs/architecture/poll-loop.md.
+	// goto panel lists a pane by. It costs a read per pane rather than per
+	// tab — see docs/architecture/poll-loop.md.
 	RenamePanes bool
 }
 
@@ -85,6 +85,7 @@ func LoadConfig() (Config, []string) {
 		ManualPath:      state.DefaultManualPath(),
 		ReadTranscripts: true,
 		ShowAgentName:   true,
+		RenamePanes:     true,
 	}
 
 	cfg.Debug = fromEnv(&warnings, EnvDebug, cfg.Debug, boolean)

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -26,6 +26,7 @@ const (
 	EnvManual     = "HERDR_AUTO_TITLE_MANUAL_FILE"
 	EnvTranscript = "HERDR_AUTO_TITLE_TRANSCRIPT"
 	EnvAgentName  = "HERDR_AUTO_TITLE_AGENT_NAME"
+	EnvPanes      = "HERDR_AUTO_TITLE_PANES"
 )
 
 // ConfigFile is the configuration file, read from the same directory the
@@ -61,6 +62,10 @@ type Config struct {
 	// what it is working on. Turned off, a pane whose agent has said nothing
 	// is named like any other pane in that directory.
 	ShowAgentName bool
+	// RenamePanes names each pane as well as its tab, which is what Herdr's
+	// goto panel lists a pane by. Off by default: it costs a read per pane
+	// rather than per tab — see docs/architecture/poll-loop.md.
+	RenamePanes bool
 }
 
 // LoadConfig reads configuration from the configuration file and the
@@ -90,6 +95,7 @@ func LoadConfig() (Config, []string) {
 	cfg.ShowPosition = fromEnv(&warnings, EnvPosition, cfg.ShowPosition, boolean)
 	cfg.ReadTranscripts = fromEnv(&warnings, EnvTranscript, cfg.ReadTranscripts, boolean)
 	cfg.ShowAgentName = fromEnv(&warnings, EnvAgentName, cfg.ShowAgentName, boolean)
+	cfg.RenamePanes = fromEnv(&warnings, EnvPanes, cfg.RenamePanes, boolean)
 	// A path needs neither parsing nor checking, so it does not go through
 	// fromEnv: any string the user set is the path they meant, and an empty
 	// one asks for locks that do not outlive the process.

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -87,10 +87,9 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if !cfg.ShowAgentName {
 		t.Error("agent names are off by default")
 	}
-	// Naming panes changes what an existing user sees and costs a read per
-	// pane, so it is the one setting that has to be asked for.
-	if cfg.RenamePanes {
-		t.Error("panes are named without being asked for")
+
+	if !cfg.RenamePanes {
+		t.Error("panes are not named by default")
 	}
 }
 
@@ -122,17 +121,19 @@ func TestLoadConfigTurnsTheAgentNameOff(t *testing.T) {
 	}
 }
 
-func TestLoadConfigTurnsPaneNamingOn(t *testing.T) {
+func TestLoadConfigTurnsPaneNamingOff(t *testing.T) {
+	// The way back to the goto panel Herdr draws on its own, for a user who
+	// read the column of agent names as what it was for.
 	isolate(t)
-	t.Setenv(EnvPanes, "true")
+	t.Setenv(EnvPanes, "false")
 
 	cfg, warnings := LoadConfig()
 	if len(warnings) != 0 {
 		t.Errorf("warnings = %v, want none", warnings)
 	}
 
-	if !cfg.RenamePanes {
-		t.Error("panes are not named despite being enabled")
+	if cfg.RenamePanes {
+		t.Error("panes are named despite being turned off")
 	}
 }
 

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -27,7 +27,7 @@ func isolate(t *testing.T) {
 
 	names := []string{
 		EnvDebug, EnvPoll, EnvMaxLength, EnvBranchMax,
-		EnvPosition, EnvManual, EnvTranscript, EnvAgentName,
+		EnvPosition, EnvManual, EnvTranscript, EnvAgentName, EnvPanes,
 	}
 
 	for _, name := range names {
@@ -87,6 +87,11 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if !cfg.ShowAgentName {
 		t.Error("agent names are off by default")
 	}
+	// Naming panes changes what an existing user sees and costs a read per
+	// pane, so it is the one setting that has to be asked for.
+	if cfg.RenamePanes {
+		t.Error("panes are named without being asked for")
+	}
 }
 
 func TestLoadConfigTurnsPositionsOff(t *testing.T) {
@@ -114,6 +119,20 @@ func TestLoadConfigTurnsTheAgentNameOff(t *testing.T) {
 
 	if cfg.ShowAgentName {
 		t.Error("agent names are shown despite being disabled")
+	}
+}
+
+func TestLoadConfigTurnsPaneNamingOn(t *testing.T) {
+	isolate(t)
+	t.Setenv(EnvPanes, "true")
+
+	cfg, warnings := LoadConfig()
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want none", warnings)
+	}
+
+	if !cfg.RenamePanes {
+		t.Error("panes are not named despite being enabled")
 	}
 }
 

--- a/internal/app/panes_test.go
+++ b/internal/app/panes_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/kryptamine/herdr-auto-title/internal/herdr/herdrtest"
 )
 
-// paneConfig is the configuration with pane naming asked for, which nothing
-// else in these tests turns on.
+// paneConfig is the configuration with pane naming on, as it ships. The rest of
+// this package's tests leave it off, so what they count is a tab's reads alone.
 func paneConfig() Config {
 	cfg := testConfig()
 	cfg.RenamePanes = true
@@ -18,8 +18,7 @@ func paneConfig() Config {
 }
 
 // split is a tab of two panes in different directories. The focused one names
-// the tab, so `wE:p2` is the pane with something of its own left to say — which
-// is the only kind of pane that gets a label at all.
+// the tab, so `wE:p2` is the pane with something of its own left to say.
 func split() []herdr.PaneInfo {
 	return []herdr.PaneInfo{
 		{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
@@ -51,9 +50,9 @@ func labelsOf(h *harness, paneID string) []string {
 	return labels
 }
 
-func TestPanesAreLeftAloneUnlessAskedFor(t *testing.T) {
-	// The setting exists because naming panes costs a read per pane rather
-	// than per tab, and because it changes what an existing user sees.
+func TestPanesAreLeftAloneWhenTurnedOff(t *testing.T) {
+	// Turning pane naming off gives the user back the goto panel Herdr draws
+	// on its own, and a poll that reads one pane per tab.
 	h := start(t, oneTab(), split())
 	h.poll()
 

--- a/internal/app/panes_test.go
+++ b/internal/app/panes_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/kryptamine/herdr-auto-title/internal/herdr"
 	"github.com/kryptamine/herdr-auto-title/internal/herdr/herdrtest"
-	"github.com/kryptamine/herdr-auto-title/internal/resolver"
 )
 
 // paneConfig is the configuration with pane naming asked for, which nothing
@@ -222,24 +221,15 @@ func TestNamingPanesCostsOneProcessReadPerPane(t *testing.T) {
 	}
 }
 
-// appFromConfig builds the App the way main.run does, which is the only place
-// that decides what reaches the pane path and what does not.
+// appFromConfig builds the App from the resolvers the configuration asks for,
+// which is what decides what reaches the pane path and what does not.
 func appFromConfig(t *testing.T, cfg Config) *App {
 	t.Helper()
 	setHome(t, filepath.Join(t.TempDir(), "home"))
 
-	chain := resolver.Default(resolver.Options{
-		MaxLength:     cfg.MaxLength,
-		BranchMax:     cfg.BranchMax,
-		HideAgentName: !cfg.ShowAgentName,
-	})
+	titles, panes := Resolvers(cfg)
 
-	var titles resolver.TitleResolver = chain
-	if cfg.ShowPosition {
-		titles = resolver.NewNumbered(chain, cfg.MaxLength)
-	}
-
-	return New(cfg, discardLogger(), titles, chain)
+	return New(cfg, discardLogger(), titles, panes)
 }
 
 func TestTheSettingsThatShapeATitleShapeAPaneLabel(t *testing.T) {
@@ -306,5 +296,24 @@ func TestTheSettingsThatShapeATitleShapeAPaneLabel(t *testing.T) {
 				t.Errorf("tab = %v, want %q", tabs, tc.wantTab)
 			}
 		})
+	}
+}
+
+func TestAPaneKeepsItsNameWhenItsTabIsClaimed(t *testing.T) {
+	// A pane is named against its tab's own pane, which a claimed tab does not
+	// read for itself. Unread, it has no branch, so a pane ordered before it
+	// would take the branch back the moment the user named the tab.
+	repo := repoAt(t, "feat/oauth")
+	h := startPanes(t, oneTab(), []herdr.PaneInfo{
+		{PaneID: "wE:p1", TabID: "wE:t1", CWD: repo, Agent: "claude"},
+		{PaneID: "wE:p2", TabID: "wE:t1", CWD: repo, Focused: true},
+	})
+	h.poll()
+
+	h.client.SetTab(herdr.TabInfo{TabID: "wE:t1", Label: "Important work"})
+	h.polls(2)
+
+	if got := labelsOf(h, "wE:p1"); len(got) != 1 || got[0] != "claude" {
+		t.Errorf("pane = %v, want it named once and kept when its tab was claimed", got)
 	}
 }

--- a/internal/app/panes_test.go
+++ b/internal/app/panes_test.go
@@ -1,0 +1,310 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/kryptamine/herdr-auto-title/internal/herdr"
+	"github.com/kryptamine/herdr-auto-title/internal/herdr/herdrtest"
+	"github.com/kryptamine/herdr-auto-title/internal/resolver"
+)
+
+// paneConfig is the configuration with pane naming asked for, which nothing
+// else in these tests turns on.
+func paneConfig() Config {
+	cfg := testConfig()
+	cfg.RenamePanes = true
+
+	return cfg
+}
+
+// split is a tab of two panes in different directories. The focused one names
+// the tab, so `wE:p2` is the pane with something of its own left to say — which
+// is the only kind of pane that gets a label at all.
+func split() []herdr.PaneInfo {
+	return []herdr.PaneInfo{
+		{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
+		{PaneID: "wE:p2", TabID: "wE:t1", CWD: api},
+	}
+}
+
+func oneTab() []herdr.TabInfo {
+	return []herdr.TabInfo{{TabID: "wE:t1", Label: "1"}}
+}
+
+func startPanes(t *testing.T, tabs []herdr.TabInfo, panes []herdr.PaneInfo) *harness {
+	t.Helper()
+
+	return startConfigured(t, herdrtest.New(tabs, panes), paneConfig())
+}
+
+// labelsOf is the labels one pane was given, in order, so a test says what
+// happened to the pane it is about rather than to the whole split.
+func labelsOf(h *harness, paneID string) []string {
+	var labels []string
+
+	for _, call := range h.client.PaneRenames() {
+		if call.PaneID == paneID {
+			labels = append(labels, call.Label)
+		}
+	}
+
+	return labels
+}
+
+func TestPanesAreLeftAloneUnlessAskedFor(t *testing.T) {
+	// The setting exists because naming panes costs a read per pane rather
+	// than per tab, and because it changes what an existing user sees.
+	h := start(t, oneTab(), split())
+	h.poll()
+
+	if renames := h.client.PaneRenames(); len(renames) != 0 {
+		t.Errorf("issued %v, want no pane renamed while the setting is off", renames)
+	}
+
+	if len(h.client.Renames()) != 1 {
+		t.Error("the tab was not named")
+	}
+}
+
+func TestAPaneIsNamedForWhatTellsItFromItsTab(t *testing.T) {
+	// The goto panel lists a pane under its tab, so the pane that differs is
+	// named by the difference alone rather than by the whole of its context.
+	h := startPanes(t, oneTab(), split())
+	h.poll()
+
+	if tabs := h.client.Renames(); len(tabs) != 1 || tabs[0].Label != "dashboard" {
+		t.Fatalf("tab = %v, want the focused pane's directory", tabs)
+	}
+
+	if got := labelsOf(h, "wE:p2"); len(got) != 1 || got[0] != "api" {
+		t.Errorf("pane = %v, want the directory its tab does not carry", got)
+	}
+}
+
+func TestEveryPaneIsNamedEvenWhenItEchoesItsTab(t *testing.T) {
+	// The whole point of the feature: Herdr lists an unlabelled pane by its
+	// agent, so every pane of a session reads `claude`. A label that repeats
+	// the tab is redundant; `claude` on every row says nothing at all.
+	h := startPanes(
+		t,
+		oneTab(),
+		[]herdr.PaneInfo{
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true, Agent: "claude"},
+		},
+	)
+	h.poll()
+
+	if got := labelsOf(h, "wE:p1"); len(got) != 1 || got[0] != "dashboard › claude" {
+		t.Errorf("pane = %v, want the lone pane named for what it is about", got)
+	}
+}
+
+func TestAPaneIsNotRenamedToWhatItAlreadyCarries(t *testing.T) {
+	h := startPanes(t, oneTab(), split())
+	h.polls(3)
+
+	if got := labelsOf(h, "wE:p2"); len(got) != 1 {
+		t.Errorf("pane = %v, want it named once and then left alone", got)
+	}
+}
+
+func TestAPaneTheUserRenamedIsLeftAlone(t *testing.T) {
+	// The reason this feature cannot ship without the protection: a name the
+	// user set by hand is theirs, and overwriting it twice a second is data
+	// loss rather than a cosmetic bug.
+	h := startPanes(t, oneTab(), split())
+	h.poll()
+
+	h.client.SetPane(herdr.PaneInfo{
+		PaneID: "wE:p2", TabID: "wE:t1", Revision: 2, CWD: api,
+		Label: "Important work",
+	})
+	h.poll()
+
+	// The context moves on; the pane does not.
+	h.client.SetPane(herdr.PaneInfo{
+		PaneID: "wE:p2", TabID: "wE:t1", Revision: 3, CWD: billing,
+		Label: "Important work",
+	})
+	h.poll()
+
+	if got := labelsOf(h, "wE:p2"); len(got) != 1 {
+		t.Errorf("pane = %v, want only the one before the user took the pane", got)
+	}
+}
+
+func TestClearingAPaneLabelHandsThePaneBack(t *testing.T) {
+	// The way out of a pane lock. Herdr has one spelling for it: pane.rename
+	// clears an empty label rather than storing it, so a released pane carries
+	// no label at all.
+	h := startPanes(t, oneTab(), split())
+	h.poll()
+
+	h.client.SetPane(herdr.PaneInfo{
+		PaneID: "wE:p2", TabID: "wE:t1", CWD: api, Label: "Important work",
+	})
+	h.poll()
+
+	h.client.SetPane(herdr.PaneInfo{PaneID: "wE:p2", TabID: "wE:t1", CWD: api})
+	h.poll()
+
+	if got := labelsOf(h, "wE:p2"); len(got) != 2 || got[1] != "api" {
+		t.Errorf("pane = %v, want it named again once it was handed back", got)
+	}
+}
+
+func TestThePluginsOwnPaneRenamesDoNotLockThePane(t *testing.T) {
+	// Every rename changes a label the plugin then sees again. Reading its own
+	// work as the user's would stop it naming anything after the first time.
+	h := startPanes(t, oneTab(), split())
+	h.poll()
+
+	awaitClock()
+	h.client.SetPane(herdr.PaneInfo{
+		PaneID: "wE:p2", TabID: "wE:t1", Revision: 2, CWD: billing, Label: "api",
+	})
+	h.poll()
+
+	if got := labelsOf(h, "wE:p2"); len(got) != 2 || got[1] != "billing" {
+		t.Errorf("pane = %v, want it renamed as its context moved", got)
+	}
+}
+
+func TestATabTheUserClaimedStillHasItsPanesNamed(t *testing.T) {
+	// The two locks are independent. A tab named by hand says nothing about
+	// what the panes inside it should be listed as.
+	h := startPanes(t, oneTab(), split())
+	h.poll()
+
+	h.client.SetTab(herdr.TabInfo{TabID: "wE:t1", Label: "Important work"})
+	h.client.SetPane(herdr.PaneInfo{
+		PaneID: "wE:p2", TabID: "wE:t1", Revision: 2, CWD: billing,
+	})
+	h.poll()
+
+	if renames := h.client.Renames(); len(renames) != 1 {
+		t.Errorf("issued %v, want the claimed tab left alone", renames)
+	}
+
+	if got := labelsOf(h, "wE:p2"); len(got) != 2 || got[1] != "billing" {
+		t.Errorf("pane = %v, want the pane inside it still named", got)
+	}
+}
+
+func TestAPaneClosingBeforeItsRenameIsNotFatal(t *testing.T) {
+	// A pane can close between the snapshot that listed it and the rename that
+	// follows, and the poll it happens in must still finish.
+	h := startPanes(t, oneTab(), split())
+	h.client.ClosePane("wE:p2")
+
+	if !h.poll() {
+		t.Fatal("the loop stopped over a pane that closed")
+	}
+}
+
+func TestNamingPanesCostsOneProcessReadPerPane(t *testing.T) {
+	// The measured cost the setting exists for, stated as a number a change
+	// would move: each pane is read once, and the tab's is not read twice.
+	h := startPanes(
+		t,
+		oneTab(),
+		[]herdr.PaneInfo{
+			{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
+			{PaneID: "wE:p2", TabID: "wE:t1", CWD: api},
+			{PaneID: "wE:p3", TabID: "wE:t1", CWD: billing},
+		},
+	)
+	h.poll()
+
+	if got := h.client.ProcessReads(); got != 3 {
+		t.Errorf("process reads = %d, want one per pane and no second for the tab's", got)
+	}
+}
+
+// appFromConfig builds the App the way main.run does, which is the only place
+// that decides what reaches the pane path and what does not.
+func appFromConfig(t *testing.T, cfg Config) *App {
+	t.Helper()
+	setHome(t, filepath.Join(t.TempDir(), "home"))
+
+	chain := resolver.Default(resolver.Options{
+		MaxLength:     cfg.MaxLength,
+		BranchMax:     cfg.BranchMax,
+		HideAgentName: !cfg.ShowAgentName,
+	})
+
+	var titles resolver.TitleResolver = chain
+	if cfg.ShowPosition {
+		titles = resolver.NewNumbered(chain, cfg.MaxLength)
+	}
+
+	return New(cfg, discardLogger(), titles, chain)
+}
+
+func TestTheSettingsThatShapeATitleShapeAPaneLabel(t *testing.T) {
+	// A pane is named by the chain that names tabs, so everything the user has
+	// tuned about a title holds for a pane too. The position is the exception,
+	// and the last case states which way round that goes.
+	tests := []struct {
+		name     string
+		tune     func(*Config)
+		wantPane string
+		wantTab  string
+	}{
+		{
+			"a pane carries the agent its tab does not",
+			func(*Config) {},
+			"billing › claude",
+			"dashboard",
+		},
+		{
+			"the agent name can be left out",
+			func(c *Config) { c.ShowAgentName = false },
+			"billing",
+			"dashboard",
+		},
+		{
+			"the length limit binds a pane too",
+			func(c *Config) { c.MaxLength = 6 },
+			"billin",
+			"dashbo",
+		},
+		{
+			"the position leads the tab and not the pane",
+			func(c *Config) { c.ShowPosition = true },
+			"billing › claude",
+			"1 · dashboard",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := paneConfig()
+			cfg.ShowAgentName = true
+			tc.tune(&cfg)
+
+			client := herdrtest.New(oneTab(), []herdr.PaneInfo{
+				{PaneID: "wE:p1", TabID: "wE:t1", CWD: dashboard, Focused: true},
+				{PaneID: "wE:p2", TabID: "wE:t1", CWD: billing, Agent: "claude"},
+			})
+			appFromConfig(t, cfg).poll(t.Context(), client)
+
+			var got string
+
+			for _, call := range client.PaneRenames() {
+				if call.PaneID == "wE:p2" {
+					got = call.Label
+				}
+			}
+
+			if got != tc.wantPane {
+				t.Errorf("pane = %q, want %q", got, tc.wantPane)
+			}
+
+			if tabs := client.Renames(); len(tabs) != 1 || tabs[0].Label != tc.wantTab {
+				t.Errorf("tab = %v, want %q", tabs, tc.wantTab)
+			}
+		})
+	}
+}

--- a/internal/app/reads.go
+++ b/internal/app/reads.go
@@ -90,9 +90,8 @@ type paneReads struct {
 	checkouts checkoutMemo
 }
 
-// fill supplies what the snapshot could not say about the one pane a tab is
-// named from. The other panes of that tab keep what the snapshot said, because
-// nothing reads any more of them.
+// fill supplies what the snapshot could not say about a pane. A pane nobody
+// fills keeps what the snapshot said, which is most of them.
 func (p *paneReads) fill(ctx context.Context, client herdr.Client, pane *state.PaneState) {
 	if pane == nil {
 		return

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -149,3 +149,9 @@ func PaneProcesses(ctx context.Context, c Client, paneID string) ([]PaneProcessI
 func RenameTab(ctx context.Context, c Client, tabID, label string) error {
 	return c.Call(ctx, MethodTabRename, TabRenameParams{TabID: tabID, Label: label}, nil)
 }
+
+// RenamePane names a pane, which is what the goto panel lists a pane by. An
+// empty label clears the name rather than storing it, so nothing here sends one.
+func RenamePane(ctx context.Context, c Client, paneID, label string) error {
+	return c.Call(ctx, MethodPaneRename, PaneRenameParams{PaneID: paneID, Label: label}, nil)
+}

--- a/internal/herdr/herdrtest/stub.go
+++ b/internal/herdr/herdrtest/stub.go
@@ -32,20 +32,26 @@ type RenameCall struct {
 	Label string
 }
 
+type PaneRenameCall struct {
+	PaneID string
+	Label  string
+}
+
 // Client is an in-memory herdr.Client. Tests change the session it describes
 // and inspect the renames it received.
 type Client struct {
-	mu         sync.Mutex
-	workspaces []herdr.WorkspaceInfo
-	tabs       map[string]herdr.TabInfo
-	panes      map[string]herdr.PaneInfo
-	processes  map[string][]herdr.PaneProcessInfoProcess
-	renames    []RenameCall
-	renameErr  error
-	processErr error
-	callErr    error
-	reads      int
-	server     string
+	mu          sync.Mutex
+	workspaces  []herdr.WorkspaceInfo
+	tabs        map[string]herdr.TabInfo
+	panes       map[string]herdr.PaneInfo
+	processes   map[string][]herdr.PaneProcessInfoProcess
+	renames     []RenameCall
+	paneRenames []PaneRenameCall
+	renameErr   error
+	processErr  error
+	callErr     error
+	reads       int
+	server      string
 }
 
 var _ herdr.Client = (*Client)(nil)
@@ -155,6 +161,13 @@ func (s *Client) Renames() []RenameCall {
 	return slices.Clone(s.renames)
 }
 
+func (s *Client) PaneRenames() []PaneRenameCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return slices.Clone(s.paneRenames)
+}
+
 // ProcessReads counts the pane.process_info calls received so far, which is how
 // a test sees that a pane was not asked about twice.
 func (s *Client) ProcessReads() int {
@@ -189,6 +202,9 @@ func (s *Client) Call(ctx context.Context, method string, params any, result any
 
 	case herdr.MethodTabRename:
 		return s.rename(params)
+
+	case herdr.MethodPaneRename:
+		return s.renamePane(params)
 
 	default:
 		return fmt.Errorf("stub client: unsupported method %s", method)
@@ -240,6 +256,27 @@ func (s *Client) rename(params any) error {
 	tab.Label = call.Label
 	s.tabs[call.TabID] = tab
 	s.renames = append(s.renames, RenameCall(call))
+
+	return nil
+}
+
+func (s *Client) renamePane(params any) error {
+	var call herdr.PaneRenameParams
+	if err := decode(params, &call); err != nil {
+		return err
+	}
+
+	pane, live := s.panes[call.PaneID]
+	if !live {
+		return &herdr.APIError{
+			Code:    herdr.CodePaneNotFound,
+			Message: "pane " + call.PaneID + " not found",
+		}
+	}
+	// Herdr's label really does change, so the next poll must agree.
+	pane.Label = call.Label
+	s.panes[call.PaneID] = pane
+	s.paneRenames = append(s.paneRenames, PaneRenameCall(call))
 
 	return nil
 }

--- a/internal/herdr/protocol.go
+++ b/internal/herdr/protocol.go
@@ -53,11 +53,12 @@ func ErrorCode(err error) string {
 	return ""
 }
 
-// Method names used by Auto Title: two to read the session and one to act on it.
+// Method names used by Auto Title: two to read the session and two to act on it.
 const (
 	MethodSessionSnapshot = "session.snapshot"
 	MethodPaneProcessInfo = "pane.process_info"
 	MethodTabRename       = "tab.rename"
+	MethodPaneRename      = "pane.rename"
 )
 
 type PaneTarget struct {
@@ -67,6 +68,11 @@ type PaneTarget struct {
 type TabRenameParams struct {
 	TabID string `json:"tab_id"`
 	Label string `json:"label"`
+}
+
+type PaneRenameParams struct {
+	PaneID string `json:"pane_id"`
+	Label  string `json:"label"`
 }
 
 type emptyParams struct{}

--- a/internal/herdr/session.go
+++ b/internal/herdr/session.go
@@ -31,6 +31,11 @@ type PaneInfo struct {
 	Focused  bool   `json:"focused"`
 	Revision uint64 `json:"revision"`
 
+	// Label is the name the pane carries, which Herdr omits entirely while it
+	// has none. Unlike a tab, a pane has one spelling for unnamed: the empty
+	// string, because pane.rename clears rather than stores one.
+	Label string `json:"label"`
+
 	CWD                   string `json:"cwd"`
 	ForegroundCWD         string `json:"foreground_cwd"`
 	TerminalTitle         string `json:"terminal_title"`

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -104,12 +104,12 @@ type TitleResolver interface {
 	Resolve(tab state.TabState) Decision
 }
 
-// PaneResolver names one pane rather than a tab. Herdr's goto panel lists a
-// pane under its tab, so a pane is named for what tells it from that tab.
+// PaneResolver names the panes of a tab rather than the tab. Herdr's goto panel
+// lists a pane under its tab, so a pane is named for what tells it from that tab.
 type PaneResolver interface {
-	// ResolvePane names one pane of tab, or returns an empty decision when the
-	// pane has nothing to say that its tab does not. The pane is never nil.
-	ResolvePane(pane *state.PaneState, tab state.TabState) Decision
+	// ResolvePanes names every pane of tab, in the order tab.Panes holds them.
+	// The tab's own pane is read from too, so it must be filled first.
+	ResolvePanes(tab state.TabState) []Decision
 }
 
 // Options are the settings a title is assembled under, as opposed to the ones
@@ -171,86 +171,31 @@ func Default(opts Options) *Deterministic {
 // Resolve names a tab in three steps: ask the sources what they see, drop the
 // parts that only repeat something already on screen, and assemble the rest.
 func (d *Deterministic) Resolve(tab state.TabState) Decision {
-	return d.name(state.SelectContextPane(tab), tab.WorkspaceName)
+	return d.name(d.collect(state.SelectContextPane(tab)), Parts{Context: tab.WorkspaceName})
 }
 
-// ResolvePane names one pane of a tab by what tells it from that tab: the
-// panes of a tab share a directory and an agent, and the goto panel puts the
-// pane's row under the tab's, so repeating either says nothing twice over.
-func (d *Deterministic) ResolvePane(pane *state.PaneState, tab state.TabState) Decision {
-	found := d.collect(pane)
+// ResolvePanes names each pane of a tab by what tells it from that tab. The row
+// above a pane is the tab's parts, not its finished title, for the reason in
+// docs/architecture/title-resolution.md.
+func (d *Deterministic) ResolvePanes(tab state.TabState) []Decision {
+	workspace := Parts{Context: tab.WorkspaceName}
+	above := d.collect(state.SelectContextPane(tab)).parts
 
-	parts := found.parts
-	if d.hideAgentName {
-		parts.Agent = ""
+	decisions := make([]Decision, len(tab.Panes))
+	for i, pane := range tab.Panes {
+		decisions[i] = d.name(d.collect(pane), workspace, above)
 	}
 
-	parts = withoutRepetition(parts, tab.WorkspaceName)
-
-	// What tells this pane from its tab is the best name it can have. A pane
-	// left with nothing still gets one — Herdr would list it as the agent in
-	// it, which is the same word on every row and the reason this exists.
-	if name := Format(withoutTheTabs(parts, d.tabParts(tab)), d.maxLength); name != "" {
-		return Decision{Name: name, Confidence: found.confidence, Reason: found.reason}
-	}
-
-	name := Format(parts, d.maxLength)
-	if name == "" {
-		return Decision{
-			Name:       GenericFallback,
-			Confidence: ConfidenceFallback,
-			Reason:     "generic_fallback",
-		}
-	}
-
-	return Decision{Name: name, Confidence: found.confidence, Reason: found.reason}
+	return decisions
 }
 
-// tabParts is what the tab was built from, before the parts that only repeat
-// the workspace were dropped: a pane must not say again what the tab dropped
-// for want of width, because the workspace above them both still says it.
-func (d *Deterministic) tabParts(tab state.TabState) Parts {
-	parts := d.collect(state.SelectContextPane(tab)).parts
-	if d.hideAgentName {
-		parts.Agent = ""
+// name assembles what the chain found into a title, dropping in turn what each
+// row shown above it already carries.
+func (d *Deterministic) name(found collected, rows ...Parts) Decision {
+	parts := withoutRepetition(found.parts)
+	for _, row := range rows {
+		parts = withoutAbove(parts, row)
 	}
-
-	return parts
-}
-
-// withoutTheTabs drops the parts of a pane's title that its tab already carries.
-// Where the pane is stays on the tab's row above; what it is doing is the whole
-// of what a pane row is for, so the activity is kept whatever the tab says.
-func withoutTheTabs(parts, tab Parts) Parts {
-	if strings.EqualFold(parts.Context, tab.Context) {
-		parts.Context = ""
-	}
-
-	if strings.EqualFold(parts.Branch, tab.Branch) {
-		parts.Branch = ""
-	}
-
-	if strings.EqualFold(parts.Agent, tab.Agent) {
-		parts.Agent = ""
-	}
-
-	return parts
-}
-
-// name is the resolution both entry points share, given the pane to read and
-// the surrounding label a title must not merely repeat.
-func (d *Deterministic) name(pane *state.PaneState, context string) Decision {
-	found := d.collect(pane)
-
-	parts := found.parts
-	if d.hideAgentName {
-		// Dropped before the repetition check, so a tab left with nothing but
-		// its directory keeps it rather than losing it to a name it will not
-		// show.
-		parts.Agent = ""
-	}
-
-	parts = withoutRepetition(parts, context)
 
 	name := Format(parts, d.maxLength)
 	if name == "" {
@@ -295,6 +240,12 @@ func (d *Deterministic) collect(pane *state.PaneState) collected {
 		if found.complete() {
 			break
 		}
+	}
+
+	// Dropped before any repetition check, so a title left with nothing but its
+	// directory keeps it rather than losing it to a name it will not show.
+	if d.hideAgentName {
+		found.parts.Agent = ""
 	}
 
 	return found
@@ -344,9 +295,9 @@ func (c *collected) complete() bool {
 	return c.parts.Context != "" && (c.parts.Activity != "" || c.parts.Agent != "")
 }
 
-// withoutRepetition drops the parts of a title that only say again what the
-// reader can already see.
-func withoutRepetition(parts Parts, workspace string) Parts {
+// withoutRepetition drops the parts of a title that only say again what another
+// part of it says.
+func withoutRepetition(parts Parts) Parts {
 	// A shell that titles its window after its directory would otherwise
 	// produce `dashboard › dashboard`.
 	if strings.EqualFold(parts.Activity, parts.Context) {
@@ -366,13 +317,30 @@ func withoutRepetition(parts Parts, workspace string) Parts {
 		parts.Branch = ""
 	}
 
-	// Herdr shows the workspace above its tabs, so repeating it wastes half the
-	// width. Dropped only when something else remains: a branch counts, and so
-	// does an agent's name, which by here is gone if it is not to be shown.
-	if (parts.Activity != "" || parts.Branch != "" || parts.Agent != "") &&
-		strings.EqualFold(parts.Context, workspace) {
-		parts.Context = ""
+	return parts
+}
+
+// withoutAbove drops the parts a row shown above the title already carries: the
+// workspace above a tab, the tab above a pane. The activity is what a row is
+// for and always stays, and a title left with nothing keeps what it had.
+func withoutAbove(parts, above Parts) Parts {
+	kept := parts
+
+	if strings.EqualFold(kept.Context, above.Context) {
+		kept.Context = ""
 	}
 
-	return parts
+	if strings.EqualFold(kept.Branch, above.Branch) {
+		kept.Branch = ""
+	}
+
+	if strings.EqualFold(kept.Agent, above.Agent) {
+		kept.Agent = ""
+	}
+
+	if kept == (Parts{}) {
+		return parts
+	}
+
+	return kept
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1,6 +1,6 @@
-// Package resolver turns a tab's read state into a tab title. Resolution is
-// deterministic: identical state always yields an identical decision. No
-// network call and no LLM: every source names a tab from state already read.
+// Package resolver turns a pane's read state into a title, for the tab that
+// pane speaks for or for the pane itself. Resolution is deterministic: no
+// network call and no LLM, and identical state yields an identical decision.
 package resolver
 
 import (
@@ -104,6 +104,14 @@ type TitleResolver interface {
 	Resolve(tab state.TabState) Decision
 }
 
+// PaneResolver names one pane rather than a tab. Herdr's goto panel lists a
+// pane under its tab, so a pane is named for what tells it from that tab.
+type PaneResolver interface {
+	// ResolvePane names one pane of tab, or returns an empty decision when the
+	// pane has nothing to say that its tab does not. The pane is never nil.
+	ResolvePane(pane *state.PaneState, tab state.TabState) Decision
+}
+
 // Options are the settings a title is assembled under, as opposed to the ones
 // a single source reads.
 type Options struct {
@@ -122,7 +130,10 @@ type Deterministic struct {
 	hideAgentName bool
 }
 
-var _ TitleResolver = (*Deterministic)(nil)
+var (
+	_ TitleResolver = (*Deterministic)(nil)
+	_ PaneResolver  = (*Deterministic)(nil)
+)
 
 // New builds a resolver from sources, ordering them by confidence rather than
 // by the order they are listed in. Equal confidences keep the order given.
@@ -160,7 +171,76 @@ func Default(opts Options) *Deterministic {
 // Resolve names a tab in three steps: ask the sources what they see, drop the
 // parts that only repeat something already on screen, and assemble the rest.
 func (d *Deterministic) Resolve(tab state.TabState) Decision {
-	found := d.collect(state.SelectContextPane(tab))
+	return d.name(state.SelectContextPane(tab), tab.WorkspaceName)
+}
+
+// ResolvePane names one pane of a tab by what tells it from that tab: the
+// panes of a tab share a directory and an agent, and the goto panel puts the
+// pane's row under the tab's, so repeating either says nothing twice over.
+func (d *Deterministic) ResolvePane(pane *state.PaneState, tab state.TabState) Decision {
+	found := d.collect(pane)
+
+	parts := found.parts
+	if d.hideAgentName {
+		parts.Agent = ""
+	}
+
+	parts = withoutRepetition(parts, tab.WorkspaceName)
+
+	// What tells this pane from its tab is the best name it can have. A pane
+	// left with nothing still gets one — Herdr would list it as the agent in
+	// it, which is the same word on every row and the reason this exists.
+	if name := Format(withoutTheTabs(parts, d.tabParts(tab)), d.maxLength); name != "" {
+		return Decision{Name: name, Confidence: found.confidence, Reason: found.reason}
+	}
+
+	name := Format(parts, d.maxLength)
+	if name == "" {
+		return Decision{
+			Name:       GenericFallback,
+			Confidence: ConfidenceFallback,
+			Reason:     "generic_fallback",
+		}
+	}
+
+	return Decision{Name: name, Confidence: found.confidence, Reason: found.reason}
+}
+
+// tabParts is what the tab was built from, before the parts that only repeat
+// the workspace were dropped: a pane must not say again what the tab dropped
+// for want of width, because the workspace above them both still says it.
+func (d *Deterministic) tabParts(tab state.TabState) Parts {
+	parts := d.collect(state.SelectContextPane(tab)).parts
+	if d.hideAgentName {
+		parts.Agent = ""
+	}
+
+	return parts
+}
+
+// withoutTheTabs drops the parts of a pane's title that its tab already carries.
+// Where the pane is stays on the tab's row above; what it is doing is the whole
+// of what a pane row is for, so the activity is kept whatever the tab says.
+func withoutTheTabs(parts, tab Parts) Parts {
+	if strings.EqualFold(parts.Context, tab.Context) {
+		parts.Context = ""
+	}
+
+	if strings.EqualFold(parts.Branch, tab.Branch) {
+		parts.Branch = ""
+	}
+
+	if strings.EqualFold(parts.Agent, tab.Agent) {
+		parts.Agent = ""
+	}
+
+	return parts
+}
+
+// name is the resolution both entry points share, given the pane to read and
+// the surrounding label a title must not merely repeat.
+func (d *Deterministic) name(pane *state.PaneState, context string) Decision {
+	found := d.collect(pane)
 
 	parts := found.parts
 	if d.hideAgentName {
@@ -170,7 +250,7 @@ func (d *Deterministic) Resolve(tab state.TabState) Decision {
 		parts.Agent = ""
 	}
 
-	parts = withoutRepetition(parts, tab.WorkspaceName)
+	parts = withoutRepetition(parts, context)
 
 	name := Format(parts, d.maxLength)
 	if name == "" {

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -322,3 +322,75 @@ func TestTheHomeDirectoryIsMatchedTheWayWindowsSpellsIt(t *testing.T) {
 		t.Errorf("name = %q, want %q", got.Name, GenericFallback)
 	}
 }
+
+func TestResolvePaneNamesThePaneItIsGiven(t *testing.T) {
+	// The point of naming panes: a tab speaks through one pane, and the goto
+	// panel lists them all. Each must be named from itself or the split reads
+	// as one row repeated.
+	chain := defaultChain()
+	tab := state.TabState{
+		ID: "wE:t1",
+		Panes: []*state.PaneState{
+			{ID: "wE:p1", Dir: dashboard, Focused: true},
+			{ID: "wE:p2", Dir: api},
+		},
+	}
+
+	if got := chain.Resolve(tab).Name; got != "dashboard" {
+		t.Errorf("tab = %q, want the focused pane's directory", got)
+	}
+
+	if got := chain.ResolvePane(tab.Panes[1], tab).Name; got != "api" {
+		t.Errorf("pane = %q, want the unfocused pane's own directory", got)
+	}
+}
+
+func TestResolvePaneDropsWhatItsTabAlreadySays(t *testing.T) {
+	// The goto panel puts a pane's row under its tab's, so the directory both
+	// share is on screen once already and only the agent tells them apart.
+	chain := defaultChain()
+	speaker := &state.PaneState{ID: "wE:p1", Dir: dashboard, Focused: true}
+	pane := &state.PaneState{ID: "wE:p2", Dir: dashboard, Agent: "claude"}
+	tab := state.TabState{ID: "wE:t1", Panes: []*state.PaneState{speaker, pane}}
+
+	if got := chain.Resolve(tab).Name; got != "dashboard" {
+		t.Fatalf("tab = %q, want the directory", got)
+	}
+
+	if got := chain.ResolvePane(pane, tab).Name; got != "claude" {
+		t.Errorf("pane = %q, want the directory its tab carries dropped", got)
+	}
+}
+
+func TestAPaneKeepsItsActivityAndDropsTheSharedContext(t *testing.T) {
+	// The pane a tab speaks through says the same thing the tab does. Where it
+	// is belongs to the tab's row; the width the pane's row has is worth more
+	// spent on what it is doing, which here is what the tab had to truncate.
+	chain := defaultChain()
+	pane := &state.PaneState{
+		ID: "wE:p1", Dir: dashboard, Focused: true,
+		TerminalTitle: "rewriting the pane label rules",
+	}
+	tab := state.TabState{ID: "wE:t1", Panes: []*state.PaneState{pane}}
+
+	if got := chain.Resolve(tab).Name; got != "dashboard › rewriting the pane label rules" {
+		t.Fatalf("tab = %q, want where and what", got)
+	}
+
+	if got := chain.ResolvePane(pane, tab).Name; got != "rewriting the pane label rules" {
+		t.Errorf("pane = %q, want the what alone", got)
+	}
+}
+
+func TestAPaneWithOnlyAContextStillGetsIt(t *testing.T) {
+	// The floor: a pane whose only known fact is its directory has nothing but
+	// its tab's words to be named by, and Herdr's own fallback — the agent's
+	// name, the same on every row — is the worse of the two.
+	chain := defaultChain()
+	pane := &state.PaneState{ID: "wE:p1", Dir: dashboard, Focused: true}
+	tab := state.TabState{ID: "wE:t1", Panes: []*state.PaneState{pane}}
+
+	if got := chain.ResolvePane(pane, tab).Name; got != "dashboard" {
+		t.Errorf("pane = %q, want the directory it has and nothing else", got)
+	}
+}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -323,7 +323,7 @@ func TestTheHomeDirectoryIsMatchedTheWayWindowsSpellsIt(t *testing.T) {
 	}
 }
 
-func TestResolvePaneNamesThePaneItIsGiven(t *testing.T) {
+func TestResolvePanesNamesThePaneItIsGiven(t *testing.T) {
 	// The point of naming panes: a tab speaks through one pane, and the goto
 	// panel lists them all. Each must be named from itself or the split reads
 	// as one row repeated.
@@ -340,12 +340,12 @@ func TestResolvePaneNamesThePaneItIsGiven(t *testing.T) {
 		t.Errorf("tab = %q, want the focused pane's directory", got)
 	}
 
-	if got := chain.ResolvePane(tab.Panes[1], tab).Name; got != "api" {
+	if got := chain.ResolvePanes(tab)[1].Name; got != "api" {
 		t.Errorf("pane = %q, want the unfocused pane's own directory", got)
 	}
 }
 
-func TestResolvePaneDropsWhatItsTabAlreadySays(t *testing.T) {
+func TestResolvePanesDropsWhatItsTabAlreadySays(t *testing.T) {
 	// The goto panel puts a pane's row under its tab's, so the directory both
 	// share is on screen once already and only the agent tells them apart.
 	chain := defaultChain()
@@ -357,7 +357,7 @@ func TestResolvePaneDropsWhatItsTabAlreadySays(t *testing.T) {
 		t.Fatalf("tab = %q, want the directory", got)
 	}
 
-	if got := chain.ResolvePane(pane, tab).Name; got != "claude" {
+	if got := chain.ResolvePanes(tab)[1].Name; got != "claude" {
 		t.Errorf("pane = %q, want the directory its tab carries dropped", got)
 	}
 }
@@ -377,7 +377,7 @@ func TestAPaneKeepsItsActivityAndDropsTheSharedContext(t *testing.T) {
 		t.Fatalf("tab = %q, want where and what", got)
 	}
 
-	if got := chain.ResolvePane(pane, tab).Name; got != "rewriting the pane label rules" {
+	if got := chain.ResolvePanes(tab)[0].Name; got != "rewriting the pane label rules" {
 		t.Errorf("pane = %q, want the what alone", got)
 	}
 }
@@ -390,7 +390,7 @@ func TestAPaneWithOnlyAContextStillGetsIt(t *testing.T) {
 	pane := &state.PaneState{ID: "wE:p1", Dir: dashboard, Focused: true}
 	tab := state.TabState{ID: "wE:t1", Panes: []*state.PaneState{pane}}
 
-	if got := chain.ResolvePane(pane, tab).Name; got != "dashboard" {
+	if got := chain.ResolvePanes(tab)[0].Name; got != "dashboard" {
 		t.Errorf("pane = %q, want the directory it has and nothing else", got)
 	}
 }

--- a/internal/state/manual.go
+++ b/internal/state/manual.go
@@ -9,35 +9,46 @@ import (
 	"sync"
 )
 
-// Manual remembers which tabs the user renamed by hand, so Auto Title stops
-// naming them. A rename is not an event but a label that moved between two
-// polls; see docs/architecture/manual-rename-protection.md.
+// Manual remembers which tabs and panes the user renamed by hand, so Auto
+// Title stops naming them. A rename is not an event but a label that moved
+// between two polls; see docs/architecture/manual-rename-protection.md.
 type Manual struct {
 	mu   sync.Mutex
 	path string
-	// settled is false until the first poll has finished, while no tab can yet
-	// be judged.
+	// settled is false until the first poll has finished, while nothing can yet
+	// be judged. One poll looks at tabs and panes together, so they share it.
 	settled bool
-	// seen is the label each tab carried when it was last looked at.
+	tabs    claims
+	panes   claims
+}
+
+// claims is what is remembered about one kind of thing Herdr labels.
+type claims struct {
+	// seen is the label each thing carried when it was last looked at.
 	seen map[string]string
-	// locked is the label a tab carried when the user claimed it. The label,
-	// not the id, is what makes a reloaded lock safe: Herdr reuses tab ids.
+	// locked is the label a thing carried when the user claimed it. The label,
+	// not the id, is what makes a reloaded lock safe: Herdr reuses ids.
 	locked map[string]string
+}
+
+func newClaims() claims {
+	return claims{seen: make(map[string]string), locked: make(map[string]string)}
 }
 
 // manualFile is the on-disk form: locks outlive the process because Herdr can
 // restart a plugin mid-session.
 type manualFile struct {
-	Locked map[string]string `json:"locked_tabs"`
+	Locked      map[string]string `json:"locked_tabs"`
+	LockedPanes map[string]string `json:"locked_panes"`
 }
 
 // LoadManual reads persisted locks from path. Anything unreadable yields an
 // empty set: this is a convenience, not a reason to refuse to start.
 func LoadManual(path string) *Manual {
 	m := &Manual{
-		path:   path,
-		seen:   make(map[string]string),
-		locked: make(map[string]string),
+		path:  path,
+		tabs:  newClaims(),
+		panes: newClaims(),
 	}
 
 	raw, err := os.ReadFile(path) //nolint:gosec // the path is configured, never terminal-derived
@@ -50,7 +61,8 @@ func LoadManual(path string) *Manual {
 		return m
 	}
 
-	maps.Copy(m.locked, stored.Locked)
+	maps.Copy(m.tabs.locked, stored.Locked)
+	maps.Copy(m.panes.locked, stored.LockedPanes)
 
 	return m
 }
@@ -67,18 +79,27 @@ func DefaultManualPath() string {
 
 // Locked reports whether the user has claimed this tab.
 func (m *Manual) Locked(tabID string) bool {
+	return m.lockedIn(&m.tabs, tabID)
+}
+
+// LockedPane reports whether the user has claimed this pane.
+func (m *Manual) LockedPane(paneID string) bool {
+	return m.lockedIn(&m.panes, paneID)
+}
+
+func (m *Manual) lockedIn(c *claims, id string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	_, locked := m.locked[tabID]
+	_, locked := c.locked[id]
 
 	return locked
 }
 
-// Sighting is what one poll saw of a tab: the label it carries, what the
-// resolver would name it, and what Herdr names a tab nobody has claimed.
+// Sighting is what one poll saw of a tab or a pane: the label it carries, what
+// the resolver would name it, and what Herdr names one nobody has claimed.
 type Sighting struct {
-	TabID   string
+	ID      string
 	Current string
 	Desired string
 	Default string
@@ -89,29 +110,49 @@ type Sighting struct {
 // package's to know.
 func SightingFrom(tab TabState, desired string) Sighting {
 	return Sighting{
-		TabID:   tab.ID,
+		ID:      tab.ID,
 		Current: tab.CurrentName,
 		Desired: desired,
 		Default: strconv.Itoa(tab.Position),
 	}
 }
 
-// Observe records what a poll saw and reports whether the user put that label
-// there.
+// PaneSightingFrom is what a poll saw of a pane. A pane has one spelling for
+// unnamed and no second default: pane.rename clears an empty label rather than
+// storing it, so Default stays empty.
+func PaneSightingFrom(pane *PaneState, desired string) Sighting {
+	return Sighting{
+		ID:      pane.ID,
+		Current: pane.CurrentName,
+		Desired: desired,
+	}
+}
+
+// Observe records what a poll saw of a tab and reports whether the user put
+// that label there.
 func (m *Manual) Observe(s Sighting) bool {
+	return m.observeIn(&m.tabs, s)
+}
+
+// ObservePane is Observe for a pane, and judges it by the same three labels.
+func (m *Manual) ObservePane(s Sighting) bool {
+	return m.observeIn(&m.panes, s)
+}
+
+func (m *Manual) observeIn(c *claims, s Sighting) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	previous, known := m.seen[s.TabID]
-	m.seen[s.TabID] = s.Current
+	previous, known := c.seen[s.ID]
+	c.seen[s.ID] = s.Current
 
 	switch {
 	case s.Current == s.Desired:
 		return false
 	case s.Current == "", s.Current == s.Default:
-		// Nobody has named it. A known tab can wear either: clearing a name
-		// empties the label rather than putting the position back, and the
-		// position itself slides down when a tab to the left closes.
+		// Nobody has named it. A tab can wear either spelling — clearing a name
+		// empties the label rather than restoring the position, and a position
+		// slides down when a tab to its left closes. A pane has only the empty.
 		return false
 	case known:
 		if s.Current == previous {
@@ -122,14 +163,15 @@ func (m *Manual) Observe(s Sighting) bool {
 		return false
 	}
 
-	m.locked[s.TabID] = s.Current
+	c.locked[s.ID] = s.Current
+
 	m.saveLocked()
 
 	return true
 }
 
-// Settled marks the end of a poll. Only the first matters: after it, an unseen
-// tab is one that did not exist before.
+// Settled marks the end of a poll. Only the first matters: after it, something
+// unseen is something that did not exist before.
 func (m *Manual) Settled() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -137,35 +179,53 @@ func (m *Manual) Settled() {
 	m.settled = true
 }
 
-// Applied records a label Auto Title has just set, so the next poll does not
-// read its own work as the user's.
+// Applied records a label Auto Title has just set on a tab, so the next poll
+// does not read its own work as the user's.
 func (m *Manual) Applied(tabID, label string) {
+	m.appliedIn(&m.tabs, tabID, label)
+}
+
+// AppliedPane is Applied for a pane.
+func (m *Manual) AppliedPane(paneID, label string) {
+	m.appliedIn(&m.panes, paneID, label)
+}
+
+func (m *Manual) appliedIn(c *claims, id, label string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.seen[tabID] = label
+	c.seen[id] = label
 }
 
 // Retain drops everything about tabs the session no longer holds, and releases
 // a lock whose tab now carries a different label — which is what stops a
 // reloaded lock from claiming an unrelated tab that inherited its id.
 func (m *Manual) Retain(live map[string]string) {
+	m.retainIn(&m.tabs, live)
+}
+
+// RetainPanes is Retain for panes, and guards a reloaded lock the same way.
+func (m *Manual) RetainPanes(live map[string]string) {
+	m.retainIn(&m.panes, live)
+}
+
+func (m *Manual) retainIn(c *claims, live map[string]string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	changed := false
 
-	for tabID, label := range m.locked {
-		if current, alive := live[tabID]; !alive || current != label {
-			delete(m.locked, tabID)
+	for id, label := range c.locked {
+		if current, alive := live[id]; !alive || current != label {
+			delete(c.locked, id)
 
 			changed = true
 		}
 	}
 
-	for tabID := range m.seen {
-		if _, alive := live[tabID]; !alive {
-			delete(m.seen, tabID)
+	for id := range c.seen {
+		if _, alive := live[id]; !alive {
+			delete(c.seen, id)
 		}
 	}
 
@@ -186,7 +246,11 @@ func (m *Manual) saveLocked() {
 	}
 
 	// encoding/json sorts map keys itself, so the file is diffable already.
-	raw, err := json.MarshalIndent(manualFile{Locked: m.locked}, "", "  ")
+	raw, err := json.MarshalIndent(
+		manualFile{Locked: m.tabs.locked, LockedPanes: m.panes.locked},
+		"",
+		"  ",
+	)
 	if err != nil {
 		return
 	}

--- a/internal/state/manual.go
+++ b/internal/state/manual.go
@@ -13,17 +13,20 @@ import (
 // Title stops naming them. A rename is not an event but a label that moved
 // between two polls; see docs/architecture/manual-rename-protection.md.
 type Manual struct {
+	Tabs  *Claims
+	Panes *Claims
+
 	mu   sync.Mutex
 	path string
 	// settled is false until the first poll has finished, while nothing can yet
 	// be judged. One poll looks at tabs and panes together, so they share it.
 	settled bool
-	tabs    claims
-	panes   claims
 }
 
-// claims is what is remembered about one kind of thing Herdr labels.
-type claims struct {
+// Claims is what is remembered about one kind of thing Herdr labels. Herdr
+// numbers tabs and panes apart, so each kind keeps claims of its own.
+type Claims struct {
+	manual *Manual
 	// seen is the label each thing carried when it was last looked at.
 	seen map[string]string
 	// locked is the label a thing carried when the user claimed it. The label,
@@ -31,8 +34,8 @@ type claims struct {
 	locked map[string]string
 }
 
-func newClaims() claims {
-	return claims{seen: make(map[string]string), locked: make(map[string]string)}
+func newClaims(m *Manual) *Claims {
+	return &Claims{manual: m, seen: make(map[string]string), locked: make(map[string]string)}
 }
 
 // manualFile is the on-disk form: locks outlive the process because Herdr can
@@ -45,11 +48,9 @@ type manualFile struct {
 // LoadManual reads persisted locks from path. Anything unreadable yields an
 // empty set: this is a convenience, not a reason to refuse to start.
 func LoadManual(path string) *Manual {
-	m := &Manual{
-		path:  path,
-		tabs:  newClaims(),
-		panes: newClaims(),
-	}
+	m := &Manual{path: path}
+	m.Tabs = newClaims(m)
+	m.Panes = newClaims(m)
 
 	raw, err := os.ReadFile(path) //nolint:gosec // the path is configured, never terminal-derived
 	if err != nil {
@@ -61,8 +62,8 @@ func LoadManual(path string) *Manual {
 		return m
 	}
 
-	maps.Copy(m.tabs.locked, stored.Locked)
-	maps.Copy(m.panes.locked, stored.LockedPanes)
+	maps.Copy(m.Tabs.locked, stored.Locked)
+	maps.Copy(m.Panes.locked, stored.LockedPanes)
 
 	return m
 }
@@ -77,19 +78,10 @@ func DefaultManualPath() string {
 	return filepath.Join(dir, "herdr-auto-title", "manual-names.json")
 }
 
-// Locked reports whether the user has claimed this tab.
-func (m *Manual) Locked(tabID string) bool {
-	return m.lockedIn(&m.tabs, tabID)
-}
-
-// LockedPane reports whether the user has claimed this pane.
-func (m *Manual) LockedPane(paneID string) bool {
-	return m.lockedIn(&m.panes, paneID)
-}
-
-func (m *Manual) lockedIn(c *claims, id string) bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+// Locked reports whether the user has claimed this one.
+func (c *Claims) Locked(id string) bool {
+	c.manual.mu.Lock()
+	defer c.manual.mu.Unlock()
 
 	_, locked := c.locked[id]
 
@@ -128,18 +120,11 @@ func PaneSightingFrom(pane *PaneState, desired string) Sighting {
 	}
 }
 
-// Observe records what a poll saw of a tab and reports whether the user put
-// that label there.
-func (m *Manual) Observe(s Sighting) bool {
-	return m.observeIn(&m.tabs, s)
-}
+// Observe records what a poll saw and reports whether the user put that label
+// there.
+func (c *Claims) Observe(s Sighting) bool {
+	m := c.manual
 
-// ObservePane is Observe for a pane, and judges it by the same three labels.
-func (m *Manual) ObservePane(s Sighting) bool {
-	return m.observeIn(&m.panes, s)
-}
-
-func (m *Manual) observeIn(c *claims, s Sighting) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -179,37 +164,21 @@ func (m *Manual) Settled() {
 	m.settled = true
 }
 
-// Applied records a label Auto Title has just set on a tab, so the next poll
-// does not read its own work as the user's.
-func (m *Manual) Applied(tabID, label string) {
-	m.appliedIn(&m.tabs, tabID, label)
-}
-
-// AppliedPane is Applied for a pane.
-func (m *Manual) AppliedPane(paneID, label string) {
-	m.appliedIn(&m.panes, paneID, label)
-}
-
-func (m *Manual) appliedIn(c *claims, id, label string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+// Applied records a label Auto Title has just set, so the next poll does not
+// read its own work as the user's.
+func (c *Claims) Applied(id, label string) {
+	c.manual.mu.Lock()
+	defer c.manual.mu.Unlock()
 
 	c.seen[id] = label
 }
 
-// Retain drops everything about tabs the session no longer holds, and releases
-// a lock whose tab now carries a different label — which is what stops a
-// reloaded lock from claiming an unrelated tab that inherited its id.
-func (m *Manual) Retain(live map[string]string) {
-	m.retainIn(&m.tabs, live)
-}
+// Retain drops everything about what the session no longer holds, and releases
+// a lock whose owner now carries a different label — which is what stops a
+// reloaded lock from claiming an unrelated tab or pane that inherited its id.
+func (c *Claims) Retain(live map[string]string) {
+	m := c.manual
 
-// RetainPanes is Retain for panes, and guards a reloaded lock the same way.
-func (m *Manual) RetainPanes(live map[string]string) {
-	m.retainIn(&m.panes, live)
-}
-
-func (m *Manual) retainIn(c *claims, live map[string]string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -247,7 +216,7 @@ func (m *Manual) saveLocked() {
 
 	// encoding/json sorts map keys itself, so the file is diffable already.
 	raw, err := json.MarshalIndent(
-		manualFile{Locked: m.tabs.locked, LockedPanes: m.panes.locked},
+		manualFile{Locked: m.Tabs.locked, LockedPanes: m.Panes.locked},
 		"",
 		"  ",
 	)

--- a/internal/state/manual_test.go
+++ b/internal/state/manual_test.go
@@ -20,7 +20,7 @@ func newManual(t *testing.T) *Manual {
 // sighting is the common case: the first tab in a workspace, which the
 // resolver would name `dashboard`.
 func sighting(current string) Sighting {
-	return Sighting{TabID: "wE:t1", Current: current, Desired: "dashboard", Default: "1"}
+	return Sighting{ID: "wE:t1", Current: current, Desired: "dashboard", Default: "1"}
 }
 
 func TestSightingFromDerivesTheDefaultLabel(t *testing.T) {
@@ -30,7 +30,7 @@ func TestSightingFromDerivesTheDefaultLabel(t *testing.T) {
 
 	got := SightingFrom(tab, "dashboard")
 	want := Sighting{
-		TabID:   "wE:t9",
+		ID:      "wE:t9",
 		Current: "Important work",
 		Desired: "dashboard",
 		Default: "3",
@@ -48,12 +48,12 @@ func TestTheFirstPollNeverLocks(t *testing.T) {
 	m := LoadManual("")
 
 	for _, s := range []Sighting{
-		{TabID: "wE:t1", Current: "1", Desired: "dashboard", Default: "1"},
-		{TabID: "wE:t2", Current: "Important work", Desired: "api", Default: "2"},
-		{TabID: "wE:t3", Current: "nvim › stale.go", Desired: "nvim › fresh.go", Default: "3"},
+		{ID: "wE:t1", Current: "1", Desired: "dashboard", Default: "1"},
+		{ID: "wE:t2", Current: "Important work", Desired: "api", Default: "2"},
+		{ID: "wE:t3", Current: "nvim › stale.go", Desired: "nvim › fresh.go", Default: "3"},
 	} {
 		if m.Observe(s) {
-			t.Errorf("tab %s was locked on the first poll", s.TabID)
+			t.Errorf("tab %s was locked on the first poll", s.ID)
 		}
 	}
 }
@@ -65,7 +65,7 @@ func TestATabTurningUpAlreadyNamedIsTheUsers(t *testing.T) {
 	m := newManual(t)
 
 	if !m.Observe(
-		Sighting{TabID: "wE:t9", Current: "My thing", Desired: "dashboard", Default: "9"},
+		Sighting{ID: "wE:t9", Current: "My thing", Desired: "dashboard", Default: "9"},
 	) {
 		t.Fatal("a tab that appeared already named was not read as the user's")
 	}
@@ -79,7 +79,7 @@ func TestATabTurningUpUnnamedIsNotTheUsers(t *testing.T) {
 	// Herdr names a new tab after its position. Nobody has claimed this one.
 	m := newManual(t)
 
-	if m.Observe(Sighting{TabID: "wE:t9", Current: "9", Desired: "dashboard", Default: "9"}) {
+	if m.Observe(Sighting{ID: "wE:t9", Current: "9", Desired: "dashboard", Default: "9"}) {
 		t.Error("an unnamed new tab was locked")
 	}
 }
@@ -212,7 +212,7 @@ func TestRetainDropsTabsTheSessionNoLongerHolds(t *testing.T) {
 
 	// Its baseline went too, so a tab reusing the id starts clean and is
 	// judged on what it carries rather than on what the old tab did.
-	if m.Observe(Sighting{TabID: "wE:t1", Current: "1", Desired: "dashboard", Default: "1"}) {
+	if m.Observe(Sighting{ID: "wE:t1", Current: "1", Desired: "dashboard", Default: "1"}) {
 		t.Error("an unnamed tab reusing the id was locked")
 	}
 }
@@ -247,5 +247,85 @@ func TestWithoutAPathLocksStayInMemory(t *testing.T) {
 
 	if !m.Locked("wE:t1") {
 		t.Error("the lock was not kept")
+	}
+}
+
+// paneSighting is the pane counterpart of sighting: a pane the resolver would
+// name `dashboard`, and which carries no label until somebody sets one.
+func paneSighting(current string) Sighting {
+	return Sighting{ID: "wE:p1", Current: current, Desired: "dashboard"}
+}
+
+func TestPaneSightingFromHasNoDefaultLabel(t *testing.T) {
+	// A pane has one spelling for unnamed and no second one. pane.rename clears
+	// an empty label rather than storing it, and Herdr omits the field entirely
+	// until a pane is named, so there is no position to compare against.
+	got := PaneSightingFrom(&PaneState{ID: "wE:p1", CurrentName: "Important work"}, "dashboard")
+	want := Sighting{ID: "wE:p1", Current: "Important work", Desired: "dashboard"}
+
+	if got != want {
+		t.Errorf("sighting = %+v, want %+v", got, want)
+	}
+}
+
+func TestAPaneTheUserRenamedIsLocked(t *testing.T) {
+	m := LoadManual("")
+	m.Settled()
+
+	if !m.ObservePane(paneSighting("Important work")) {
+		t.Fatal("a pane carrying a name nobody set was not claimed")
+	}
+
+	if !m.LockedPane("wE:p1") {
+		t.Error("the pane was not locked")
+	}
+	// The tab of the same poll is a claim of its own: locking one must not
+	// lock the other, and the two id spaces are Herdr's, not this package's.
+	if m.Locked("wE:p1") {
+		t.Error("claiming a pane claimed a tab of the same id")
+	}
+}
+
+func TestAPaneAutoTitleNamedIsNotTheUsers(t *testing.T) {
+	m := LoadManual("")
+	m.Settled()
+	m.AppliedPane("wE:p1", "dashboard")
+
+	if m.ObservePane(paneSighting("dashboard")) {
+		t.Error("the plugin's own pane rename read as the user's")
+	}
+}
+
+func TestClearingAPaneLabelHandsItBack(t *testing.T) {
+	m := LoadManual("")
+	m.Settled()
+	m.ObservePane(paneSighting("Important work"))
+
+	// Herdr reports a cleared pane as carrying no label at all.
+	m.RetainPanes(map[string]string{"wE:p1": ""})
+
+	if m.LockedPane("wE:p1") {
+		t.Error("clearing the label did not hand the pane back")
+	}
+}
+
+func TestPaneLocksSurviveAReload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "manual-names.json")
+
+	m := LoadManual(path)
+	m.Settled()
+	m.ObservePane(paneSighting("Important work"))
+
+	if !LoadManual(path).LockedPane("wE:p1") {
+		t.Error("the pane lock was not persisted")
+	}
+	// Tab locks are written under a key of their own, so a store holding one
+	// kind still reads back the other.
+	m.Observe(sighting("1"))
+	m.Observe(sighting("My tab"))
+
+	reloaded := LoadManual(path)
+	if !reloaded.Locked("wE:t1") || !reloaded.LockedPane("wE:p1") {
+		t.Error("the two kinds of lock did not survive the same store")
 	}
 }

--- a/internal/state/manual_test.go
+++ b/internal/state/manual_test.go
@@ -52,7 +52,7 @@ func TestTheFirstPollNeverLocks(t *testing.T) {
 		{ID: "wE:t2", Current: "Important work", Desired: "api", Default: "2"},
 		{ID: "wE:t3", Current: "nvim › stale.go", Desired: "nvim › fresh.go", Default: "3"},
 	} {
-		if m.Observe(s) {
+		if m.Tabs.Observe(s) {
 			t.Errorf("tab %s was locked on the first poll", s.ID)
 		}
 	}
@@ -64,13 +64,13 @@ func TestATabTurningUpAlreadyNamedIsTheUsers(t *testing.T) {
 	// the name it carries is not Auto Title's.
 	m := newManual(t)
 
-	if !m.Observe(
+	if !m.Tabs.Observe(
 		Sighting{ID: "wE:t9", Current: "My thing", Desired: "dashboard", Default: "9"},
 	) {
 		t.Fatal("a tab that appeared already named was not read as the user's")
 	}
 
-	if !m.Locked("wE:t9") {
+	if !m.Tabs.Locked("wE:t9") {
 		t.Error("the tab is not locked")
 	}
 }
@@ -79,7 +79,7 @@ func TestATabTurningUpUnnamedIsNotTheUsers(t *testing.T) {
 	// Herdr names a new tab after its position. Nobody has claimed this one.
 	m := newManual(t)
 
-	if m.Observe(Sighting{ID: "wE:t9", Current: "9", Desired: "dashboard", Default: "9"}) {
+	if m.Tabs.Observe(Sighting{ID: "wE:t9", Current: "9", Desired: "dashboard", Default: "9"}) {
 		t.Error("an unnamed new tab was locked")
 	}
 }
@@ -89,14 +89,14 @@ func TestATabFallingBackToItsDefaultLabelIsNotTheUsers(t *testing.T) {
 	// slides down for every tab that closes to the left. Locking there would
 	// freeze the tab at a number for the rest of the session.
 	m := newManual(t)
-	m.Observe(sighting("1"))
-	m.Applied("wE:t1", "dashboard")
+	m.Tabs.Observe(sighting("1"))
+	m.Tabs.Applied("wE:t1", "dashboard")
 
-	if m.Observe(sighting("1")) {
+	if m.Tabs.Observe(sighting("1")) {
 		t.Fatal("a tab back on its default label was read as the user's")
 	}
 
-	if m.Locked("wE:t1") {
+	if m.Tabs.Locked("wE:t1") {
 		t.Error("the tab is locked")
 	}
 }
@@ -106,48 +106,48 @@ func TestATabWhoseNameWasClearedIsNotTheUsers(t *testing.T) {
 	// back, so an empty label is Herdr's other way of saying nobody named it —
 	// see docs/architecture/herdr-socket-api.md.
 	m := newManual(t)
-	m.Observe(sighting("1"))
-	m.Applied("wE:t1", "dashboard")
+	m.Tabs.Observe(sighting("1"))
+	m.Tabs.Applied("wE:t1", "dashboard")
 
-	if m.Observe(sighting("")) {
+	if m.Tabs.Observe(sighting("")) {
 		t.Fatal("a tab whose name was cleared was read as the user's")
 	}
 
-	if m.Locked("wE:t1") {
+	if m.Tabs.Locked("wE:t1") {
 		t.Error("the tab is locked")
 	}
 }
 
 func TestARenameByTheUserLocksTheTab(t *testing.T) {
 	m := newManual(t)
-	m.Observe(sighting("1"))
-	m.Applied("wE:t1", "dashboard")
+	m.Tabs.Observe(sighting("1"))
+	m.Tabs.Applied("wE:t1", "dashboard")
 
-	if !m.Observe(sighting("Important work")) {
+	if !m.Tabs.Observe(sighting("Important work")) {
 		t.Fatal("a label the plugin neither set nor wanted was not read as the user's")
 	}
 
-	if !m.Locked("wE:t1") {
+	if !m.Tabs.Locked("wE:t1") {
 		t.Error("the tab is not locked")
 	}
 }
 
 func TestARenameByThePluginDoesNotLock(t *testing.T) {
 	m := newManual(t)
-	m.Observe(sighting("1"))
-	m.Applied("wE:t1", "dashboard")
+	m.Tabs.Observe(sighting("1"))
+	m.Tabs.Applied("wE:t1", "dashboard")
 
-	if m.Observe(sighting("dashboard")) {
+	if m.Tabs.Observe(sighting("dashboard")) {
 		t.Error("the plugin's own rename was read as the user's")
 	}
 }
 
 func TestALabelThatHasNotMovedIsNobodysDoing(t *testing.T) {
 	m := newManual(t)
-	m.Observe(sighting("Important work"))
+	m.Tabs.Observe(sighting("Important work"))
 
 	// Same label on the next poll: nothing happened, whatever it says.
-	if m.Observe(sighting("Important work")) {
+	if m.Tabs.Observe(sighting("Important work")) {
 		t.Error("an unchanged label was read as a rename")
 	}
 }
@@ -155,9 +155,9 @@ func TestALabelThatHasNotMovedIsNobodysDoing(t *testing.T) {
 func TestALabelMatchingWhatWeWouldSetDoesNotLock(t *testing.T) {
 	// Indistinguishable from the plugin's own work, and harmless either way.
 	m := newManual(t)
-	m.Observe(sighting("1"))
+	m.Tabs.Observe(sighting("1"))
 
-	if m.Observe(sighting("dashboard")) {
+	if m.Tabs.Observe(sighting("dashboard")) {
 		t.Error("a label matching the resolved one locked the tab")
 	}
 }
@@ -166,13 +166,13 @@ func TestLocksSurviveAReload(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "manual-names.json")
 
 	m := LoadManual(path)
-	m.Observe(sighting("1"))
+	m.Tabs.Observe(sighting("1"))
 
-	if !m.Observe(sighting("Important work")) {
+	if !m.Tabs.Observe(sighting("Important work")) {
 		t.Fatal("the tab was not locked")
 	}
 
-	if !LoadManual(path).Locked("wE:t1") {
+	if !LoadManual(path).Tabs.Locked("wE:t1") {
 		t.Error("the lock did not survive a restart")
 	}
 }
@@ -184,35 +184,35 @@ func TestAReloadedLockIsReleasedWhenTheLabelMovedOn(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "manual-names.json")
 
 	m := LoadManual(path)
-	m.Observe(sighting("1"))
-	m.Observe(sighting("Important work"))
+	m.Tabs.Observe(sighting("1"))
+	m.Tabs.Observe(sighting("Important work"))
 
 	reloaded := LoadManual(path)
-	reloaded.Retain(map[string]string{"wE:t1": "2"})
+	reloaded.Tabs.Retain(map[string]string{"wE:t1": "2"})
 
-	if reloaded.Locked("wE:t1") {
+	if reloaded.Tabs.Locked("wE:t1") {
 		t.Error("a lock was kept for a tab that no longer carries its name")
 	}
 
-	if LoadManual(path).Locked("wE:t1") {
+	if LoadManual(path).Tabs.Locked("wE:t1") {
 		t.Error("the released lock was not written out")
 	}
 }
 
 func TestRetainDropsTabsTheSessionNoLongerHolds(t *testing.T) {
 	m := newManual(t)
-	m.Observe(sighting("1"))
-	m.Observe(sighting("Important work"))
+	m.Tabs.Observe(sighting("1"))
+	m.Tabs.Observe(sighting("Important work"))
 
-	m.Retain(map[string]string{})
+	m.Tabs.Retain(map[string]string{})
 
-	if m.Locked("wE:t1") {
+	if m.Tabs.Locked("wE:t1") {
 		t.Error("a closed tab is still locked")
 	}
 
 	// Its baseline went too, so a tab reusing the id starts clean and is
 	// judged on what it carries rather than on what the old tab did.
-	if m.Observe(Sighting{ID: "wE:t1", Current: "1", Desired: "dashboard", Default: "1"}) {
+	if m.Tabs.Observe(Sighting{ID: "wE:t1", Current: "1", Desired: "dashboard", Default: "1"}) {
 		t.Error("an unnamed tab reusing the id was locked")
 	}
 }
@@ -226,26 +226,26 @@ func TestAnUnreadableStoreIsNotFatal(t *testing.T) {
 	}
 
 	m := LoadManual(path)
-	if m.Locked("wE:t1") {
+	if m.Tabs.Locked("wE:t1") {
 		t.Error("a corrupt store produced a lock")
 	}
 	// And it still works from there.
-	m.Observe(sighting("1"))
+	m.Tabs.Observe(sighting("1"))
 
-	if !m.Observe(sighting("Important work")) {
+	if !m.Tabs.Observe(sighting("Important work")) {
 		t.Error("locking stopped working after a corrupt store")
 	}
 }
 
 func TestWithoutAPathLocksStayInMemory(t *testing.T) {
 	m := LoadManual("")
-	m.Observe(sighting("1"))
+	m.Tabs.Observe(sighting("1"))
 
-	if !m.Observe(sighting("Important work")) {
+	if !m.Tabs.Observe(sighting("Important work")) {
 		t.Error("locking needs a file")
 	}
 
-	if !m.Locked("wE:t1") {
+	if !m.Tabs.Locked("wE:t1") {
 		t.Error("the lock was not kept")
 	}
 }
@@ -272,16 +272,16 @@ func TestAPaneTheUserRenamedIsLocked(t *testing.T) {
 	m := LoadManual("")
 	m.Settled()
 
-	if !m.ObservePane(paneSighting("Important work")) {
+	if !m.Panes.Observe(paneSighting("Important work")) {
 		t.Fatal("a pane carrying a name nobody set was not claimed")
 	}
 
-	if !m.LockedPane("wE:p1") {
+	if !m.Panes.Locked("wE:p1") {
 		t.Error("the pane was not locked")
 	}
 	// The tab of the same poll is a claim of its own: locking one must not
 	// lock the other, and the two id spaces are Herdr's, not this package's.
-	if m.Locked("wE:p1") {
+	if m.Tabs.Locked("wE:p1") {
 		t.Error("claiming a pane claimed a tab of the same id")
 	}
 }
@@ -289,9 +289,9 @@ func TestAPaneTheUserRenamedIsLocked(t *testing.T) {
 func TestAPaneAutoTitleNamedIsNotTheUsers(t *testing.T) {
 	m := LoadManual("")
 	m.Settled()
-	m.AppliedPane("wE:p1", "dashboard")
+	m.Panes.Applied("wE:p1", "dashboard")
 
-	if m.ObservePane(paneSighting("dashboard")) {
+	if m.Panes.Observe(paneSighting("dashboard")) {
 		t.Error("the plugin's own pane rename read as the user's")
 	}
 }
@@ -299,12 +299,12 @@ func TestAPaneAutoTitleNamedIsNotTheUsers(t *testing.T) {
 func TestClearingAPaneLabelHandsItBack(t *testing.T) {
 	m := LoadManual("")
 	m.Settled()
-	m.ObservePane(paneSighting("Important work"))
+	m.Panes.Observe(paneSighting("Important work"))
 
 	// Herdr reports a cleared pane as carrying no label at all.
-	m.RetainPanes(map[string]string{"wE:p1": ""})
+	m.Panes.Retain(map[string]string{"wE:p1": ""})
 
-	if m.LockedPane("wE:p1") {
+	if m.Panes.Locked("wE:p1") {
 		t.Error("clearing the label did not hand the pane back")
 	}
 }
@@ -314,18 +314,18 @@ func TestPaneLocksSurviveAReload(t *testing.T) {
 
 	m := LoadManual(path)
 	m.Settled()
-	m.ObservePane(paneSighting("Important work"))
+	m.Panes.Observe(paneSighting("Important work"))
 
-	if !LoadManual(path).LockedPane("wE:p1") {
+	if !LoadManual(path).Panes.Locked("wE:p1") {
 		t.Error("the pane lock was not persisted")
 	}
 	// Tab locks are written under a key of their own, so a store holding one
 	// kind still reads back the other.
-	m.Observe(sighting("1"))
-	m.Observe(sighting("My tab"))
+	m.Tabs.Observe(sighting("1"))
+	m.Tabs.Observe(sighting("My tab"))
 
 	reloaded := LoadManual(path)
-	if !reloaded.Locked("wE:t1") || !reloaded.LockedPane("wE:p1") {
+	if !reloaded.Tabs.Locked("wE:t1") || !reloaded.Panes.Locked("wE:p1") {
 		t.Error("the two kinds of lock did not survive the same store")
 	}
 }

--- a/internal/state/tab.go
+++ b/internal/state/tab.go
@@ -15,6 +15,9 @@ import (
 // PaneState is one pane's context as Herdr reported it when it was last read.
 type PaneState struct {
 	ID string
+	// CurrentName is the label the pane carries, empty while nobody has named
+	// it. Herdr falls back to the agent's name for display and stores nothing.
+	CurrentName string
 
 	// Dir is the directory this pane speaks for: its foreground process's own
 	// once a poll has read it, and the snapshot's guess until then.
@@ -99,6 +102,7 @@ func cleanDir(dir string) string {
 func PaneFrom(info herdr.PaneInfo, changedAt time.Time) *PaneState {
 	return &PaneState{
 		ID:               info.PaneID,
+		CurrentName:      info.Label,
 		Dir:              snapshotDir(info),
 		TerminalTitle:    info.TerminalTitleStripped,
 		TerminalTitleRaw: info.TerminalTitle,


### PR DESCRIPTION
## Why

Herdr's goto panel (`prefix`+`g`) lists a pane by `pane.label`, falling back through the agent's name, its display name, its title and finally `pane N`. Auto Title only ever called `tab.rename`, so a session of Claude Code panes reads as a column of `claude` with nothing to pick between them.

## What it does

`HERDR_AUTO_TITLE_PANES=true` names each pane with the chain that names tabs, from that pane's own state rather than from the pane its tab speaks through.

A pane's row sits **under** its tab's, so the parts the tab already carries are dropped and the activity is kept — where a pane is has a row of its own above it, and what it is doing is the whole of what a pane row is for:

```
pane-rename › herdr-auto-title pane      the tab, truncated
  herdr-auto-title pane 重命名            the pane the tab speaks through
  herdr-reviewr                          the pane doing something else
```

The first row ends up carrying **more** than its tab, which had to truncate the same words to fit the directory in front of them.

A pane whose only fact is its directory does repeat its tab. There is nothing else known about such a pane, and the alternative is the `claude` this setting exists to replace.

## Manual rename protection

Extended to panes, and this is the part that matters most: without it a name you typed would be overwritten twice a second.

`Manual` now holds a set of claims per kind. Locks for both live in the same file, panes under `locked_panes`, so a store written by an older version reads back unchanged. **The two locks are independent** — a tab named by hand says what the tab bar should read and says nothing about how the panes inside it should be listed.

## Probed, not assumed

Two facts about `pane.rename` differ from `tab.rename` and both are recorded in `docs/architecture/herdr-socket-api.md`:

- **A pane's label is absent from the wire until the pane has one.** Across a seven-pane session no pane object carried `label` in `session.snapshot`, `pane.get` or `pane.list`; renaming one made the key appear in all three, and clearing it made the key vanish again.
- **`pane.rename` clears an empty label rather than storing it.** Both `{"pane_id": p}` with no label and `{"pane_id": p, "label": ""}` answered with the key gone. So a pane has **one** unnamed spelling where a tab has two, and there is no position spelling to accept beside it.

## Why it is off by default

It changes what an existing user sees, and it costs a `pane.process_info` read per pane rather than per tab — a cost that scales with how the user splits. A test pins that number so a change would move it.

## Checks

`make check` is green — fmt, vet, golangci-lint (0 issues) and `go test -race`.

Verified against a live 21-pane session. The protection tests were checked by removing the protection: `TestAPaneTheUserRenamedIsLeftAlone` then fails with the pane's manual name overwritten, which is the failure it exists to catch.

Not verified: Windows. Only macOS hardware was available.
